### PR TITLE
fix: explorer shows wrong path on refresh

### DIFF
--- a/packages/client/src/queries/filesystem.ts
+++ b/packages/client/src/queries/filesystem.ts
@@ -1,40 +1,50 @@
 import { filesystemApi, filesystemQueryKeys } from '@stump/api'
 import type { DirectoryListing } from '@stump/types'
 import { AxiosError } from 'axios'
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { useQuery } from '../client'
 
 // TODO: use QueryOptions and usePageQuery instead of DirectoryListingQueryParams
 export interface DirectoryListingQueryParams {
 	enabled: boolean
-	startingPath?: string
-	// TODO: I kind of hate this name...
+	/**
+	 * The initial path to query for. If not provided, the root directory will be queried for.
+	 */
+	initialPath?: string
 	/**
 	 * The minimum path that can be queried for. This is useful for enforcing no access to parent
 	 * directories relative to the enforcedRoot.
 	 */
 	enforcedRoot?: string
 	page?: number
-	onGoForward?: (callback: (path: string) => void) => void
+	/**
+	 * A callback that will be called when navigating forward in the directory listing.
+	 */
+	onGoForward?: (path: string | null) => void
+	/**
+	 * A callback that will be called when navigating back in the directory listing.
+	 */
 	onGoBack?: (path: string | null) => void
 }
 
 export function useDirectoryListing({
 	enabled,
-	startingPath,
+	initialPath,
 	enforcedRoot,
 	page = 1,
 	onGoForward,
 	onGoBack,
 }: DirectoryListingQueryParams) {
-	const [path, setPath] = useState(startingPath || null)
+	const [currentPath, setCurrentPath] = useState(initialPath || null)
+	const [history, setHistory] = useState(currentPath ? [currentPath] : [])
+	const [currentIndex, setCurrentIndex] = useState(0)
 
 	const [directoryListing, setDirectoryListing] = useState<DirectoryListing>()
 
 	const { isLoading, error } = useQuery(
-		[filesystemQueryKeys.listDirectory, path, page],
-		() => filesystemApi.listDirectory({ page, path }),
+		[filesystemQueryKeys.listDirectory, currentPath, page],
+		() => filesystemApi.listDirectory({ page, path: currentPath }),
 		{
 			// Do not run query until `enabled` aka modal is opened.
 			enabled,
@@ -46,46 +56,67 @@ export function useDirectoryListing({
 		},
 	)
 
-	// Re-set path if startingPath changes.
 	useEffect(() => {
-		if (startingPath) {
-			setPath(startingPath)
-		}
-	}, [startingPath])
-
-	const actions = useMemo(
-		() => ({
-			// FIXME: does not work as expected. Need more complicated annoying solution.
-			goBack() {
-				const parent = directoryListing?.parent || ''
-				// If there is no parent, we are at the root directory, so we don't want to go back.
-				if (!parent) {
-					return
-				}
-
-				// if parent comes BEFORE enforcedRoot, then we are trying to go back to a parent
-				// directory that is not allowed. In this case, we don't want to go back.
-				if (enforcedRoot !== parent && enforcedRoot?.startsWith(parent)) {
-					return
-				}
-
-				if (directoryListing?.parent) {
-					onGoBack?.(path)
-					setPath(directoryListing.parent)
-				}
-			},
-			goForward() {
-				if (!onGoForward) {
-					console.warn('goForward was called without an onGoForward callback')
+		if (initialPath) {
+			setCurrentPath(initialPath)
+			setHistory((curr) => {
+				if (curr.length === 0) {
+					return [initialPath]
 				} else {
-					onGoForward((path) => setPath(path))
+					// TODO: I think this is right, but am lazy rn to add a ref lol
+					// return curr.slice(0, currentIndex + 1).concat(initialPath)
+					return [...curr, initialPath]
 				}
-			},
-			onSelect(directory: string) {
-				setPath(directory)
-			},
-		}),
-		[directoryListing, onGoBack, onGoForward, path, enforcedRoot],
+			})
+		}
+	}, [initialPath])
+
+	const canGoBack = useMemo(() => {
+		return currentIndex > 0
+	}, [currentIndex])
+
+	const goBack = useCallback(() => {
+		const parent = directoryListing?.parent || ''
+		// If there is no parent, we are at the root directory, so we don't want to go back.
+		if (!parent) {
+			return
+		}
+
+		// if parent comes BEFORE enforcedRoot, then we are trying to go back to a parent
+		// directory that is not allowed. In this case, we don't want to go back.
+		if (enforcedRoot !== parent && enforcedRoot?.startsWith(parent)) {
+			return
+		}
+
+		if (directoryListing?.parent) {
+			onGoBack?.(directoryListing.parent)
+			setCurrentPath(directoryListing.parent)
+			setCurrentIndex((prev) => prev - 1)
+		}
+	}, [enforcedRoot, directoryListing, onGoBack])
+
+	const canGoForward = useMemo(() => {
+		return history.length > currentIndex + 1
+	}, [history, currentIndex])
+
+	const goForward = useCallback(() => {
+		const nextPath = history[currentIndex + 1]
+		if (nextPath) {
+			onGoForward?.(nextPath)
+			setCurrentPath(nextPath)
+			setCurrentIndex((prev) => prev + 1)
+		}
+	}, [history, currentIndex, onGoForward])
+
+	const onSelect = useCallback(
+		(directory: string) => {
+			setCurrentPath(directory)
+			// we need to splice anything after the current index, because we are creating a new
+			// history branch.
+			setHistory((prev) => prev.slice(0, currentIndex + 1).concat(directory))
+			setCurrentIndex((prev) => prev + 1)
+		},
+		[currentIndex],
 	)
 
 	const errorMessage = useMemo(() => {
@@ -103,13 +134,17 @@ export function useDirectoryListing({
 	}, [error])
 
 	return {
+		canGoBack,
+		canGoForward,
+		currentPath,
 		directories: directoryListing?.files.filter((f) => f.is_directory) ?? [],
 		entries: directoryListing?.files ?? [],
 		error,
 		errorMessage,
+		goBack,
+		goForward,
 		isLoading,
+		onSelect,
 		parent: directoryListing?.parent,
-		path,
-		...actions,
 	}
 }

--- a/packages/client/src/queries/filesystem.ts
+++ b/packages/client/src/queries/filesystem.ts
@@ -1,10 +1,11 @@
 import { filesystemApi, filesystemQueryKeys } from '@stump/api'
 import type { DirectoryListing } from '@stump/types'
 import { AxiosError } from 'axios'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import { useQuery } from '../client'
 
+// TODO: use QueryOptions and usePageQuery instead of DirectoryListingQueryParams
 export interface DirectoryListingQueryParams {
 	enabled: boolean
 	startingPath?: string
@@ -36,6 +37,13 @@ export function useDirectoryListing({
 			suspense: false,
 		},
 	)
+
+	// Re-set path if startingPath changes.
+	useEffect(() => {
+		if (startingPath) {
+			setPath(startingPath)
+		}
+	}, [startingPath])
 
 	const actions = useMemo(
 		() => ({

--- a/packages/interface/src/components/DirectoryPickerModal.tsx
+++ b/packages/interface/src/components/DirectoryPickerModal.tsx
@@ -22,15 +22,15 @@ export default function DirectoryPickerModal({
 	// FIXME: This component needs to render a *virtual* list AND pass a page param as the user scrolls
 	// down the list. I recently tested a directory with 1000+ files and it took a while to load. So,
 	// I am paging the results to 100 per page. Might reduce to 50.
-	const { errorMessage, path, parent, directories, onSelect, goBack } = useDirectoryListing({
+	const { errorMessage, currentPath, parent, directories, onSelect, goBack } = useDirectoryListing({
 		enabled: isOpen,
-		startingPath,
+		initialPath: startingPath,
 		// TODO: page
 	})
 
 	function handleConfirm() {
 		if (!errorMessage) {
-			onPathChange(path)
+			onPathChange(currentPath)
 			onClose()
 		}
 	}
@@ -82,7 +82,7 @@ export default function DirectoryPickerModal({
 							className="line-clamp-1 h-[37px]"
 							containerClassName="max-w-full"
 							// isInvalid={!!errorMessage}
-							value={path ?? undefined}
+							value={currentPath ?? undefined}
 							readOnly
 							variant="primary"
 							// TODO: allow input to be editable

--- a/packages/interface/src/components/DirectoryPickerModal.tsx
+++ b/packages/interface/src/components/DirectoryPickerModal.tsx
@@ -22,7 +22,7 @@ export default function DirectoryPickerModal({
 	// FIXME: This component needs to render a *virtual* list AND pass a page param as the user scrolls
 	// down the list. I recently tested a directory with 1000+ files and it took a while to load. So,
 	// I am paging the results to 100 per page. Might reduce to 50.
-	const { errorMessage, currentPath, parent, directories, onSelect, goBack } = useDirectoryListing({
+	const { errorMessage, path, parent, directories, setPath, goBack } = useDirectoryListing({
 		enabled: isOpen,
 		initialPath: startingPath,
 		// TODO: page
@@ -30,7 +30,7 @@ export default function DirectoryPickerModal({
 
 	function handleConfirm() {
 		if (!errorMessage) {
-			onPathChange(currentPath)
+			onPathChange(path)
 			onClose()
 		}
 	}
@@ -82,13 +82,13 @@ export default function DirectoryPickerModal({
 							className="line-clamp-1 h-[37px]"
 							containerClassName="max-w-full"
 							// isInvalid={!!errorMessage}
-							value={currentPath ?? undefined}
+							value={path ?? undefined}
 							readOnly
 							variant="primary"
 							// TODO: allow input to be editable
 							// onInputStop={(newPath) => {
 							// 	if (newPath) {
-							// 		onSelect(newPath);
+							// 		setPath(newPath);
 							// 	}
 							// }}
 						/>
@@ -100,7 +100,7 @@ export default function DirectoryPickerModal({
 								className="justify-start px-1 py-2"
 								key={directory.path}
 								variant={i % 2 === 0 ? 'ghost' : 'subtle'}
-								onClick={() => onSelect(directory.path)}
+								onClick={() => setPath(directory.path)}
 							>
 								<div className="flex items-center gap-4">
 									<Folder size="1.25rem" />{' '}

--- a/packages/interface/src/scenes/library/explorer/FileExplorerNavigation.tsx
+++ b/packages/interface/src/scenes/library/explorer/FileExplorerNavigation.tsx
@@ -4,11 +4,11 @@ import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { useFileExplorerContext } from './context'
 
 export default function FileExplorerNavigation() {
-	const { goBack, goForward, canGoForward } = useFileExplorerContext()
+	const { goBack, goForward, canGoBack, canGoForward } = useFileExplorerContext()
 
 	return (
 		<div className="m-0 hidden items-center gap-1 md:flex">
-			<IconButton variant="ghost" size="sm" onClick={goBack}>
+			<IconButton variant="ghost" size="sm" onClick={goBack} disabled={!canGoBack}>
 				<ChevronLeft size="0.75rem" />
 			</IconButton>
 

--- a/packages/interface/src/scenes/library/explorer/LibraryExplorerScene.tsx
+++ b/packages/interface/src/scenes/library/explorer/LibraryExplorerScene.tsx
@@ -40,8 +40,9 @@ export default function LibraryExplorerScene() {
 
 	const { entries, onSelect, path, parent, goForward, goBack } = useDirectoryListing({
 		enabled: !!library?.path,
-		goBack: handleGoBack,
-		goForward: handleGoForward,
+		enforcedRoot: library?.path,
+		onGoBack: handleGoBack,
+		onGoForward: handleGoForward,
 		startingPath: state?.starting_path || library?.path,
 	})
 

--- a/packages/interface/src/scenes/library/explorer/LibraryExplorerScene.tsx
+++ b/packages/interface/src/scenes/library/explorer/LibraryExplorerScene.tsx
@@ -1,10 +1,9 @@
 import { mediaApi } from '@stump/api'
 import { useDirectoryListing, useLibraryByIdQuery } from '@stump/client'
 import { DirectoryListingFile } from '@stump/types'
-import { useMemo } from 'react'
 import { Helmet } from 'react-helmet'
 import toast from 'react-hot-toast'
-import { useLocation, useNavigate, useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 
 import paths from '../../../paths'
 import { LibraryExplorerContext } from './context'
@@ -15,43 +14,20 @@ import FileExplorer from './FileExplorer'
 // most of what would be needed on the backend is in place.
 export default function LibraryExplorerScene() {
 	const navigate = useNavigate()
-	const { state } = useLocation()
 
 	const { id } = useParams()
-
 	if (!id) {
 		throw new Error('Library id is required')
 	}
 
 	const { library, isLoading } = useLibraryByIdQuery(id)
 
-	const handleGoForward = (callback: (path: string) => void) => {
-		if (state?.starting_path) {
-			callback(state.starting_path)
-			navigate('.', { replace: true, state: { starting_path: path } })
-		}
-
-		console.debug('No starting path found: ', state)
-	}
-
-	const handleGoBack = (currentPath: string | null) => {
-		navigate('.', { replace: true, state: { starting_path: currentPath } })
-	}
-
-	const { entries, onSelect, path, parent, goForward, goBack } = useDirectoryListing({
-		enabled: !!library?.path,
-		enforcedRoot: library?.path,
-		onGoBack: handleGoBack,
-		onGoForward: handleGoForward,
-		startingPath: state?.starting_path || library?.path,
-	})
-
-	const canGoForward = useMemo(
-		() => !!state?.starting_path && state.starting_path !== path,
-		[state?.starting_path, path],
-	)
-
-	// console.log('canGoForward', canGoForward, { path, state })
+	const { entries, onSelect, currentPath, goForward, goBack, canGoBack, canGoForward } =
+		useDirectoryListing({
+			enabled: !!library?.path,
+			enforcedRoot: library?.path,
+			initialPath: library?.path,
+		})
 
 	const handleSelect = async (entry: DirectoryListingFile) => {
 		if (entry.is_directory) {
@@ -66,7 +42,7 @@ export default function LibraryExplorerScene() {
 				if (entity) {
 					navigate(paths.bookOverview(entity.id), {
 						state: {
-							starting_path: path,
+							forward_path: currentPath,
 						},
 					})
 				} else {
@@ -89,7 +65,9 @@ export default function LibraryExplorerScene() {
 	return (
 		<LibraryExplorerContext.Provider
 			value={{
-				canGoBack: !!parent,
+				// FIXME: this is not correct. When you exit the library explorer and then re-enter (e.g. back button)
+				// it needs to be able to go backwards to the previous path WITHOUT any history (i.e. using parent path).
+				canGoBack,
 				canGoForward,
 				files: entries,
 				goBack,


### PR DESCRIPTION
Fixes #142 

I don't want to spend much more time on the file explorer for now, since I'd rather dedicate time elsewhere, *but* I went ahead an made a few additional tweaks with small improvements to the backwards/forward navigation. I also added an optional prop to enforce a 'minimum directory' via `enforcedRoot` (but I kinda hate the name)