### PR TITLE
bug: fix recursion error during docker compilations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3673,8 +3673,8 @@ dependencies = [
 
 [[package]]
 name = "prisma-client-rust"
-version = "0.6.7"
-source = "git+https://github.com/Brendonovich/prisma-client-rust.git?tag=0.6.7#f71ad9122537c4ed29bf496a4a643947a5fe9aef"
+version = "0.6.8"
+source = "git+https://github.com/Brendonovich/prisma-client-rust.git?tag=0.6.8#51f0473b642b16bb78fe0f5f3235aeb56f89300d"
 dependencies = [
  "base64 0.13.1",
  "bigdecimal",
@@ -3707,8 +3707,8 @@ dependencies = [
 
 [[package]]
 name = "prisma-client-rust-cli"
-version = "0.6.7"
-source = "git+https://github.com/Brendonovich/prisma-client-rust.git?tag=0.6.7#f71ad9122537c4ed29bf496a4a643947a5fe9aef"
+version = "0.6.8"
+source = "git+https://github.com/Brendonovich/prisma-client-rust.git?tag=0.6.8#51f0473b642b16bb78fe0f5f3235aeb56f89300d"
 dependencies = [
  "directories",
  "flate2",
@@ -3727,8 +3727,8 @@ dependencies = [
 
 [[package]]
 name = "prisma-client-rust-macros"
-version = "0.6.7"
-source = "git+https://github.com/Brendonovich/prisma-client-rust.git?tag=0.6.7#f71ad9122537c4ed29bf496a4a643947a5fe9aef"
+version = "0.6.8"
+source = "git+https://github.com/Brendonovich/prisma-client-rust.git?tag=0.6.8#51f0473b642b16bb78fe0f5f3235aeb56f89300d"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -3738,8 +3738,8 @@ dependencies = [
 
 [[package]]
 name = "prisma-client-rust-sdk"
-version = "0.6.7"
-source = "git+https://github.com/Brendonovich/prisma-client-rust.git?tag=0.6.7#f71ad9122537c4ed29bf496a4a643947a5fe9aef"
+version = "0.6.8"
+source = "git+https://github.com/Brendonovich/prisma-client-rust.git?tag=0.6.8#51f0473b642b16bb78fe0f5f3235aeb56f89300d"
 dependencies = [
  "convert_case 0.5.0",
  "dml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,12 @@ version = "0.0.0"
 rust-version = "1.68.0"
 
 [workspace.dependencies]
-prisma-client-rust = { git = "https://github.com/Brendonovich/prisma-client-rust.git", tag = "0.6.7", features = [
-  # 'specta',
+prisma-client-rust = { git = "https://github.com/Brendonovich/prisma-client-rust.git", tag = "0.6.8", features = [
   'sqlite-create-many',
   "migrations",
   "sqlite",
 ], default-features = false }
-prisma-client-rust-cli = { git = "https://github.com/Brendonovich/prisma-client-rust.git", tag = "0.6.7", features = [
-  # "specta",
+prisma-client-rust-cli = { git = "https://github.com/Brendonovich/prisma-client-rust.git", tag = "0.6.8", features = [
   "sqlite-create-many",
   "migrations",
   "sqlite",

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,8 @@
+// This was added as a fix for https://github.com/stumpapp/stump/issues/146
+// I am not entirely sure why this issue cropped up all of the sudden, but
+// this seems to resolve it in a musl environment.
+#![recursion_limit = "256"]
+
 use std::sync::Arc;
 
 // TODO: for these crates, some should NOT hoist entire crate, I need to restrict it
@@ -12,6 +17,8 @@ pub mod opds;
 
 mod context;
 pub mod error;
+
+#[allow(warnings, unused)]
 pub mod prisma;
 
 use config::env::StumpEnvironment;


### PR DESCRIPTION
Fixes https://github.com/stumpapp/stump/issues/146, though to be honest I'm not sure why the issue randomly started cropping up to begin with. I tracked down the issue being a change introduced in https://github.com/stumpapp/stump/pull/141. I started with the `schema.prisma` changes and the problem presented immediately once I added those in. There have been multiple passing docker builds since this PR, which is why it is so puzzling that this fix is now all of the sudden needed. 

The musl version in the docker images I use did change a week ago from `1.1.24` to `1.2.3`, which seems to correspond to the last successful PR run, but I'll have to look into whether that is a potential cause another time.

I updated prisma while I was at it