### PR TITLE
bug(core): fix alphanumeric sorting

### DIFF
--- a/.github/actions/setup-cargo/action.yml
+++ b/.github/actions/setup-cargo/action.yml
@@ -21,7 +21,7 @@ runs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.68.0
         profile: minimal
         override: true
         components: rustfmt, clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "alphanumeric-sort"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81149050d254e2b758c80dcf55949e5c45482e0c9cb3670b1c4b48eb51791f8e"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,7 +489,7 @@ dependencies = [
 [[package]]
 name = "builtin-psl-connectors"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.10#7e31dbeb1087c55a71c141c07d87bb39bc3a4e38"
 dependencies = [
  "connection-string",
  "either",
@@ -1078,7 +1084,7 @@ checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
 [[package]]
 name = "datamodel-renderer"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.10#7e31dbeb1087c55a71c141c07d87bb39bc3a4e38"
 dependencies = [
  "base64 0.13.1",
  "once_cell",
@@ -1113,7 +1119,7 @@ dependencies = [
 [[package]]
 name = "diagnostics"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.10#7e31dbeb1087c55a71c141c07d87bb39bc3a4e38"
 dependencies = [
  "colored",
  "indoc",
@@ -1211,7 +1217,7 @@ checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 [[package]]
 name = "dml"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.10#7e31dbeb1087c55a71c141c07d87bb39bc3a4e38"
 dependencies = [
  "chrono",
  "cuid",
@@ -1229,7 +1235,7 @@ dependencies = [
 [[package]]
 name = "dmmf"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.10#7e31dbeb1087c55a71c141c07d87bb39bc3a4e38"
 dependencies = [
  "bigdecimal",
  "indexmap",
@@ -2319,7 +2325,7 @@ dependencies = [
 [[package]]
 name = "introspection-connector"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.10#7e31dbeb1087c55a71c141c07d87bb39bc3a4e38"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2442,7 +2448,7 @@ dependencies = [
 [[package]]
 name = "json-rpc-api-build"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.10#7e31dbeb1087c55a71c141c07d87bb39bc3a4e38"
 dependencies = [
  "backtrace",
  "heck 0.3.3",
@@ -2827,7 +2833,7 @@ dependencies = [
 [[package]]
 name = "migration-connector"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.10#7e31dbeb1087c55a71c141c07d87bb39bc3a4e38"
 dependencies = [
  "chrono",
  "enumflags2",
@@ -2842,7 +2848,7 @@ dependencies = [
 [[package]]
 name = "migration-core"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.10#7e31dbeb1087c55a71c141c07d87bb39bc3a4e38"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3409,7 +3415,7 @@ dependencies = [
 [[package]]
 name = "parser-database"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.10#7e31dbeb1087c55a71c141c07d87bb39bc3a4e38"
 dependencies = [
  "diagnostics",
  "either",
@@ -3673,8 +3679,8 @@ dependencies = [
 
 [[package]]
 name = "prisma-client-rust"
-version = "0.6.8"
-source = "git+https://github.com/stumpapp/prisma-client-rust?rev=4e9c79c8355dcbb098169ccbc85a9349f8c7882d#4e9c79c8355dcbb098169ccbc85a9349f8c7882d"
+version = "0.6.10"
+source = "git+https://github.com/Brendonovich/prisma-client-rust.git?tag=0.6.10#948642d876c342f5925695bc3e487df6a02af9b2"
 dependencies = [
  "base64 0.13.1",
  "bigdecimal",
@@ -3707,8 +3713,8 @@ dependencies = [
 
 [[package]]
 name = "prisma-client-rust-cli"
-version = "0.6.8"
-source = "git+https://github.com/stumpapp/prisma-client-rust?rev=4e9c79c8355dcbb098169ccbc85a9349f8c7882d#4e9c79c8355dcbb098169ccbc85a9349f8c7882d"
+version = "0.6.10"
+source = "git+https://github.com/Brendonovich/prisma-client-rust.git?tag=0.6.10#948642d876c342f5925695bc3e487df6a02af9b2"
 dependencies = [
  "directories",
  "flate2",
@@ -3727,8 +3733,8 @@ dependencies = [
 
 [[package]]
 name = "prisma-client-rust-macros"
-version = "0.6.8"
-source = "git+https://github.com/stumpapp/prisma-client-rust?rev=4e9c79c8355dcbb098169ccbc85a9349f8c7882d#4e9c79c8355dcbb098169ccbc85a9349f8c7882d"
+version = "0.6.10"
+source = "git+https://github.com/Brendonovich/prisma-client-rust.git?tag=0.6.10#948642d876c342f5925695bc3e487df6a02af9b2"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -3738,8 +3744,8 @@ dependencies = [
 
 [[package]]
 name = "prisma-client-rust-sdk"
-version = "0.6.8"
-source = "git+https://github.com/stumpapp/prisma-client-rust?rev=4e9c79c8355dcbb098169ccbc85a9349f8c7882d#4e9c79c8355dcbb098169ccbc85a9349f8c7882d"
+version = "0.6.10"
+source = "git+https://github.com/Brendonovich/prisma-client-rust.git?tag=0.6.10#948642d876c342f5925695bc3e487df6a02af9b2"
 dependencies = [
  "convert_case 0.5.0",
  "dml",
@@ -3760,7 +3766,7 @@ dependencies = [
 [[package]]
 name = "prisma-models"
 version = "0.0.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.10#7e31dbeb1087c55a71c141c07d87bb39bc3a4e38"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -3776,7 +3782,7 @@ dependencies = [
 [[package]]
 name = "prisma-value"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.10#7e31dbeb1087c55a71c141c07d87bb39bc3a4e38"
 dependencies = [
  "base64 0.12.3",
  "bigdecimal",
@@ -3841,7 +3847,7 @@ dependencies = [
 [[package]]
 name = "psl"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.10#7e31dbeb1087c55a71c141c07d87bb39bc3a4e38"
 dependencies = [
  "builtin-psl-connectors",
  "dml",
@@ -3851,7 +3857,7 @@ dependencies = [
 [[package]]
 name = "psl-core"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.10#7e31dbeb1087c55a71c141c07d87bb39bc3a4e38"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -3917,7 +3923,7 @@ dependencies = [
 [[package]]
 name = "query-connector"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.10#7e31dbeb1087c55a71c141c07d87bb39bc3a4e38"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3937,7 +3943,7 @@ dependencies = [
 [[package]]
 name = "query-core"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.10#7e31dbeb1087c55a71c141c07d87bb39bc3a4e38"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -3981,7 +3987,7 @@ dependencies = [
 [[package]]
 name = "query-engine-metrics"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.10#7e31dbeb1087c55a71c141c07d87bb39bc3a4e38"
 dependencies = [
  "metrics 0.18.1",
  "metrics-exporter-prometheus",
@@ -4245,7 +4251,7 @@ dependencies = [
 [[package]]
 name = "request-handlers"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.10#7e31dbeb1087c55a71c141c07d87bb39bc3a4e38"
 dependencies = [
  "bigdecimal",
  "connection-string",
@@ -4454,7 +4460,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.10#7e31dbeb1087c55a71c141c07d87bb39bc3a4e38"
 dependencies = [
  "once_cell",
  "prisma-models",
@@ -4464,7 +4470,7 @@ dependencies = [
 [[package]]
 name = "schema-ast"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.10#7e31dbeb1087c55a71c141c07d87bb39bc3a4e38"
 dependencies = [
  "diagnostics",
  "pest",
@@ -4474,7 +4480,7 @@ dependencies = [
 [[package]]
 name = "schema-builder"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.10#7e31dbeb1087c55a71c141c07d87bb39bc3a4e38"
 dependencies = [
  "itertools",
  "lazy_static",
@@ -4929,12 +4935,12 @@ dependencies = [
 [[package]]
 name = "sql-ddl"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.10#7e31dbeb1087c55a71c141c07d87bb39bc3a4e38"
 
 [[package]]
 name = "sql-introspection-connector"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.10#7e31dbeb1087c55a71c141c07d87bb39bc3a4e38"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4958,7 +4964,7 @@ dependencies = [
 [[package]]
 name = "sql-migration-connector"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.10#7e31dbeb1087c55a71c141c07d87bb39bc3a4e38"
 dependencies = [
  "chrono",
  "connection-string",
@@ -4985,7 +4991,7 @@ dependencies = [
 [[package]]
 name = "sql-query-connector"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.10#7e31dbeb1087c55a71c141c07d87bb39bc3a4e38"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5016,7 +5022,7 @@ dependencies = [
 [[package]]
 name = "sql-schema-describer"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.10#7e31dbeb1087c55a71c141c07d87bb39bc3a4e38"
 dependencies = [
  "async-trait",
  "bigdecimal",
@@ -5116,6 +5122,7 @@ dependencies = [
 name = "stump_core"
 version = "0.0.0"
 dependencies = [
+ "alphanumeric-sort",
  "async-trait",
  "cuid",
  "data-encoding",
@@ -6074,7 +6081,7 @@ checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
 [[package]]
 name = "user-facing-error-macros"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.10#7e31dbeb1087c55a71c141c07d87bb39bc3a4e38"
 dependencies = [
  "proc-macro2",
  "quote 1.0.23",
@@ -6084,7 +6091,7 @@ dependencies = [
 [[package]]
 name = "user-facing-errors"
 version = "0.1.0"
-source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.5#7cc20cc54a7ab0b5e38c81901826939a91a17ba0"
+source = "git+https://github.com/Brendonovich/prisma-engines?tag=pcr-0.6.10#7e31dbeb1087c55a71c141c07d87bb39bc3a4e38"
 dependencies = [
  "backtrace",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,14 +15,14 @@ rust-version = "1.68.0"
 # TODO: replace my fork with next official pcr release when it comes out, I just don't
 # have the time for undocumented breaking changes right now
 [workspace.dependencies]
-# prisma-client-rust = { git = "https://github.com/Brendonovich/prisma-client-rust.git", rev = "37ffd66291e4da8104f88251157881993112acd6", features = [
-prisma-client-rust = { git = "https://github.com/stumpapp/prisma-client-rust", rev = "4e9c79c8355dcbb098169ccbc85a9349f8c7882d", features = [
+prisma-client-rust = { git = "https://github.com/Brendonovich/prisma-client-rust.git", tag = "0.6.10", features = [
+# prisma-client-rust = { git = "https://github.com/stumpapp/prisma-client-rust", rev = "4e9c79c8355dcbb098169ccbc85a9349f8c7882d", features = [
   'sqlite-create-many',
   "migrations",
   "sqlite",
 ], default-features = false }
-# prisma-client-rust-cli = { git = "https://github.com/Brendonovich/prisma-client-rust.git", rev = "37ffd66291e4da8104f88251157881993112acd6", features = [
-prisma-client-rust-cli = { git = "https://github.com/stumpapp/prisma-client-rust", rev = "4e9c79c8355dcbb098169ccbc85a9349f8c7882d", features = [
+prisma-client-rust-cli = { git = "https://github.com/Brendonovich/prisma-client-rust.git", tag = "0.6.10", features = [
+# prisma-client-rust-cli = { git = "https://github.com/stumpapp/prisma-client-rust", rev = "4e9c79c8355dcbb098169ccbc85a9349f8c7882d", features = [
   "sqlite-create-many",
   "migrations",
   "sqlite",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -23,6 +23,7 @@ itertools = "0.10.5"
 optional_struct = "0.2.0"
 utoipa = { version = "3.0.3" }
 uuid = "1.4.0"
+alphanumeric-sort = "1.5.1"
 
 ### FILESYSTEM UTILS ###
 walkdir = "2.3.2"

--- a/core/src/filesystem/media/common.rs
+++ b/core/src/filesystem/media/common.rs
@@ -25,3 +25,45 @@ pub(crate) fn metadata_from_buf(contents: String) -> Option<MediaMetadata> {
 		},
 	}
 }
+
+pub(crate) fn sort_file_names<S>(file_names: &mut [S])
+where
+	S: AsRef<str>,
+{
+	alphanumeric_sort::sort_str_slice(file_names);
+}
+
+#[cfg(test)]
+mod tests {
+	#[test]
+	fn test_is_accepted_cover_name() {
+		let cover_file_names = vec!["cover", "thumbnail", "folder"];
+		for cover_name in cover_file_names {
+			assert!(super::is_accepted_cover_name(cover_name));
+		}
+	}
+
+	#[test]
+	fn test_is_not_accepted_cover_name() {
+		let cover_file_names = vec!["cover1", "thumbnail1", "folder1"];
+		for cover_name in cover_file_names {
+			assert!(!super::is_accepted_cover_name(cover_name));
+		}
+	}
+
+	#[test]
+	fn test_sort_numeric_file_names() {
+		let mut names = ["3.jpg", "1.jpg", "5.jpg", "2.jpg", "4.jpg"];
+		super::sort_file_names(&mut names);
+		let expected = ["1.jpg", "2.jpg", "3.jpg", "4.jpg", "5.jpg"];
+		assert_eq!(names, expected);
+	}
+
+	#[test]
+	fn test_sort_alphanumeric_file_names() {
+		let mut names = ["shot-2", "shot-1", "shot-11", "shot-10", "shot-3"];
+		super::sort_file_names(&mut names);
+		let expected = ["shot-1", "shot-2", "shot-3", "shot-10", "shot-11"];
+		assert_eq!(names, expected);
+	}
+}

--- a/core/src/filesystem/media/common.rs
+++ b/core/src/filesystem/media/common.rs
@@ -3,7 +3,7 @@ use tracing::error;
 use crate::db::entity::metadata::MediaMetadata;
 
 pub fn is_accepted_cover_name(name: &str) -> bool {
-	let cover_file_names = vec!["cover", "thumbnail", "folder"];
+	let cover_file_names = ["cover", "thumbnail", "folder"];
 	cover_file_names
 		.iter()
 		.any(|&cover_name| name.eq_ignore_ascii_case(cover_name))
@@ -37,7 +37,7 @@ where
 mod tests {
 	#[test]
 	fn test_is_accepted_cover_name() {
-		let cover_file_names = vec!["cover", "thumbnail", "folder"];
+		let cover_file_names = ["cover", "thumbnail", "folder"];
 		for cover_name in cover_file_names {
 			assert!(super::is_accepted_cover_name(cover_name));
 		}

--- a/core/src/filesystem/media/rar.rs
+++ b/core/src/filesystem/media/rar.rs
@@ -145,7 +145,8 @@ impl FileProcessor for RarProcessor {
 				}
 			})
 			.collect::<Vec<_>>();
-		valid_entries.sort_by(|a, b| a.filename.cmp(&b.filename));
+		valid_entries
+			.sort_by(|a, b| alphanumeric_sort::compare_path(&a.filename, &b.filename));
 
 		let target_entry = valid_entries
 			.into_iter()
@@ -197,7 +198,7 @@ impl FileProcessor for RarProcessor {
 					false
 				}
 			})
-			.sorted_by(|a, b| a.filename.cmp(&b.filename))
+			.sorted_by(|a, b| alphanumeric_sort::compare_path(&a.filename, &b.filename))
 			.enumerate()
 			.map(|(idx, header)| (PathBuf::from(header.filename.as_os_str()), idx))
 			.collect::<HashMap<_, _>>();

--- a/core/src/filesystem/media/zip.rs
+++ b/core/src/filesystem/media/zip.rs
@@ -8,7 +8,10 @@ use tracing::{debug, error, trace};
 use zip::read::ZipFile;
 
 use crate::filesystem::{
-	content_type::ContentType, error::FileError, hash, media::common::metadata_from_buf,
+	content_type::ContentType,
+	error::FileError,
+	hash,
+	media::common::{metadata_from_buf, sort_file_names},
 };
 
 use super::{FileProcessor, FileProcessorOptions, ProcessedFile};
@@ -99,7 +102,7 @@ impl FileProcessor for ZipProcessor {
 		}
 
 		let mut file_names = file_names_archive.file_names().collect::<Vec<_>>();
-		file_names.sort();
+		sort_file_names(&mut file_names);
 
 		let mut images_seen = 0;
 		for name in file_names {
@@ -137,7 +140,7 @@ impl FileProcessor for ZipProcessor {
 
 		let file_names_archive = archive.clone();
 		let mut file_names = file_names_archive.file_names().collect::<Vec<_>>();
-		file_names.sort();
+		sort_file_names(&mut file_names);
 
 		let mut content_types = HashMap::new();
 

--- a/packages/client/src/hooks/useCoreEvent.ts
+++ b/packages/client/src/hooks/useCoreEvent.ts
@@ -45,6 +45,8 @@ export function useCoreEventHandler({
 			case 'CreatedMedia':
 			case 'CreatedMediaBatch':
 			case 'CreatedSeries':
+			case 'CreatedSeriesBatch':
+			case 'GeneratedThumbnailBatch':
 				// I set a timeout here to give the backend a little time to analyze at least
 				// one of the books in a new series before triggering a refetch. This is to
 				// prevent the series/media cards from being displayed before there is an image ready.

--- a/packages/client/src/invalidate.ts
+++ b/packages/client/src/invalidate.ts
@@ -56,6 +56,13 @@ export const core_event_triggers = {
 			seriesQueryKeys.getRecentlyAddedSeries,
 		],
 	},
+	GeneratedThumbnailBatch: {
+		keys: [
+			seriesQueryKeys.getSeriesById,
+			mediaQueryKeys.getRecentlyAddedMedia,
+			seriesQueryKeys.getRecentlyAddedSeries,
+		],
+	},
 	JobComplete: {
 		keys: [
 			libraryQueryKeys.getLibraryById,


### PR DESCRIPTION
Archives with alphanumeric filenames internally should now be sorted properly when served

- Added `alphanumeric-sort` and created simple wrapper function
- Upgrade `prisma-client-rust` and `prisma-client-rust-cli`. Hopefully no issues in CI relating to this, so I can move off of my fork