### PR TITLE
:sparkles: basic PDF support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c3d816ce6f0e2909a96830d6911c2aff044370b1ef92d7f267b43bae5addedd"
 dependencies = [
  "atk-sys",
- "bitflags",
+ "bitflags 1.3.2",
  "glib",
  "libc",
 ]
@@ -259,7 +259,7 @@ dependencies = [
  "async-trait",
  "axum-core",
  "base64 0.20.0",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-util",
  "headers",
@@ -420,6 +420,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.68.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
+dependencies = [
+ "bitflags 2.4.0",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote 1.0.33",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.31",
+ "which",
+]
+
+[[package]]
 name = "bit_field"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,6 +453,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "blake3"
@@ -587,7 +616,7 @@ version = "0.15.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c76ee391b03d35510d9fa917357c7f1855bd9a6659c95a1b392e33f49b3369bc"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -638,6 +667,15 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "cfb"
@@ -715,12 +753,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.7.4",
+]
+
+[[package]]
 name = "cocoa"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f425db7937052c684daec3bd6375c8abe2d146dca4b8b143d6db777c39138f3a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "block",
  "cocoa-foundation",
  "core-foundation",
@@ -736,7 +785,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ade49b65d560ca58c403a479bb396592b155c0185eada742ee323d1d68d6318"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "block",
  "core-foundation",
  "core-graphics-types",
@@ -806,6 +855,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "console_log"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f"
+dependencies = [
+ "log",
+ "web-sys",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,7 +939,7 @@ version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-graphics-types",
  "foreign-types",
@@ -883,7 +952,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "foreign-types",
  "libc",
@@ -1522,7 +1591,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1740,7 +1809,7 @@ version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6e05c1f572ab0e1f15be94217f0dc29088c248b14f792a5ff0af0d84bcda9e8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cairo-rs",
  "gdk-pixbuf",
  "gdk-sys",
@@ -1756,7 +1825,7 @@ version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad38dd9cc8b099cceecdf41375bb6d481b1b5a7cd5cd603e10a69a9383f8619a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "gdk-pixbuf-sys",
  "gio",
  "glib",
@@ -1875,7 +1944,7 @@ version = "0.15.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68fdbc90312d462781a395f7a16d96a2b379bb6ef8cd6310a2df272771c4283b"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1905,7 +1974,7 @@ version = "0.15.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edb0306fbad0ab5428b0ca674a23893db909a98582969c9b537be4ced78c505d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -2000,7 +2069,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e3004a2d5d6d8b5057d2b57b3712c9529b62e82c77f25c1fecde1fd5c23bd0"
 dependencies = [
  "atk",
- "bitflags",
+ "bitflags 1.3.2",
  "cairo-rs",
  "field-offset",
  "futures-channel",
@@ -2110,7 +2179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
  "base64 0.13.1",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "headers-core",
  "http",
@@ -2441,7 +2510,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "inotify-sys",
  "libc",
 ]
@@ -2505,6 +2574,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "iter_tools"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531cafdc99b3b3252bb32f5620e61d56b19415efc19900b12d1b2e7483854897"
+dependencies = [
+ "itertools",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2531,7 +2609,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf053e7843f2812ff03ef5afe34bb9c06ffee120385caad4f6b9967fcd37d41c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "glib",
  "javascriptcore-rs-sys",
 ]
@@ -2648,7 +2726,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8367585489f01bc55dd27404dcf56b95e6da061a256a666ab23be9ba96a2e587"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
 ]
 
@@ -2671,6 +2749,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "lebe"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2689,6 +2773,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2264f9d90a9b4e60a2dc722ad899ea0374f03c2e96e755fe22a8f551d4d5fb3c"
 dependencies = [
  "pkg-config",
+]
+
+[[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "winapi",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d580318f95776505201b28cf98eb1fa5e4be3b689633ba6a3e6cd880ff22d8cb"
+dependencies = [
+ "cfg-if 1.0.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2743,7 +2847,7 @@ dependencies = [
  "libc",
  "neli",
  "thiserror",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2795,7 +2899,7 @@ version = "0.91.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2368312c59425dd133cb9a327afee65be0a633a8ce471d248e2202a48f8f68ae"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -2879,6 +2983,12 @@ name = "matchit"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "md5"
@@ -3075,7 +3185,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3129,7 +3239,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2032c77e030ddee34a6787a64166008da93f6a352b629261d0fee232b8742dd4"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "jni-sys",
  "ndk-sys",
  "num_enum",
@@ -3198,7 +3308,7 @@ version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58ea850aa68a06e48fdb069c0ec44d0d64c8dbffa49bf3b6f7f0a901fdea1ba9"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
@@ -3207,7 +3317,7 @@ dependencies = [
  "libc",
  "mio",
  "walkdir",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3370,7 +3480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2078c0039e6a54a0c42c28faa984e115fb4c2d5bf2208f77d1961002df8576f8"
 dependencies = [
  "pathdiff",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3379,7 +3489,7 @@ version = "0.10.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
@@ -3491,7 +3601,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6a252f1f8c11e84b3ab59d7a488e48e4478a93937e027076638c49536204639"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3506,7 +3616,7 @@ version = "0.15.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22e4045548659aee5313bde6c582b0d83a627b7904dd20dc2d9ef0895d414e4f"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "glib",
  "libc",
  "once_cell",
@@ -3576,7 +3686,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3610,7 +3720,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e375ec076445f61d4dbc4636e9e788f841d279c65d6fea8a3875caddd4f2dd82"
 dependencies = [
  "aes",
- "bitflags",
+ "bitflags 1.3.2",
  "cbc",
  "datasize",
  "deflate",
@@ -3640,6 +3750,39 @@ dependencies = [
  "quote 1.0.33",
  "syn 1.0.107",
 ]
+
+[[package]]
+name = "pdfium-render"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f78cb513747a3b3230ce38efd640eac6f2e6f26af47a063986f1bc0b07c4b17"
+dependencies = [
+ "bindgen",
+ "bitflags 2.4.0",
+ "bytemuck",
+ "bytes",
+ "chrono",
+ "console_error_panic_hook",
+ "console_log",
+ "image",
+ "iter_tools",
+ "js-sys",
+ "libloading 0.8.0",
+ "log",
+ "maybe-owned",
+ "once_cell",
+ "utf16string",
+ "vecmath",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
@@ -3832,6 +3975,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piston-float"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad78bf43dcf80e8f950c92b84f938a0fc7590b7f6866fbcbeca781609c115590"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3857,7 +4006,7 @@ version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d708eaf860a19b19ce538740d2b4bdeeb8337fa53f7738455e706623ad5c638"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crc32fast",
  "flate2",
  "miniz_oxide",
@@ -3874,6 +4023,16 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.31",
+]
 
 [[package]]
 name = "prisma-cli"
@@ -4355,7 +4514,7 @@ version = "10.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6823ea29436221176fe662da99998ad3b4db2c7f31e7b6f5fe43adccd6320bb"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -4404,7 +4563,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -4575,7 +4734,7 @@ version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c4b1eaf239b47034fb450ee9cdedd7d0226571689d8823030c4b6c2cb407152"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "chrono",
  "fallible-iterator",
  "fallible-streaming-iterator",
@@ -4625,6 +4784,12 @@ name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -4677,7 +4842,7 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -4743,7 +4908,7 @@ version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -4766,7 +4931,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df320f1889ac4ba6bc0cdc9c9af7af4bd64bb927bccdf32d81140dc1f9be12fe"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cssparser",
  "derive_more",
  "fxhash",
@@ -5047,6 +5212,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5120,7 +5291,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b4d76501d8ba387cf0fefbe055c3e0a59891d09f0f995ae4e4b16f6b60f3c0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "gio",
  "glib",
  "libc",
@@ -5134,7 +5305,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009ef427103fcb17f802871647a7fa6c60cbb654b4c4e4c0ac60a31c5f6dc9cf"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "gio-sys",
  "glib-sys",
  "gobject-sys",
@@ -5401,6 +5572,7 @@ dependencies = [
  "itertools",
  "optional_struct",
  "pdf",
+ "pdfium-render",
  "prisma-client-rust",
  "rayon",
  "regex",
@@ -5559,7 +5731,7 @@ version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac8e6399427c8494f9849b58694754d7cc741293348a6836b6c8d2c5aa82d8e6"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cairo-rs",
  "cc",
  "cocoa",
@@ -5966,7 +6138,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -6047,7 +6219,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-core",
  "futures-util",
@@ -6308,7 +6480,7 @@ name = "unrar"
 version = "0.4.4"
 source = "git+https://github.com/stumpapp/unrar.rs?branch=feature/typestate#00b936a0f4850bcbd0c586de97b3e2b6f4073cc2"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "lazy_static",
  "regex",
  "unrar_sys",
@@ -6389,6 +6561,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf16string"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b62a1e85e12d5d712bf47a85f426b73d303e2d00a90de5f3004df3596e9d216"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "utoipa"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6458,6 +6639,15 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vecmath"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "956ae1e0d85bca567dee1dcf87fb1ca2e792792f66f87dced8381f99cd91156a"
+dependencies = [
+ "piston-float",
+]
 
 [[package]]
 name = "version-compare"
@@ -6610,7 +6800,7 @@ version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8f859735e4a452aeb28c6c56a852967a8a76c8eb1cc32dbf931ad28a13d6370"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cairo-rs",
  "gdk",
  "gdk-sys",
@@ -6635,7 +6825,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d76ca6ecc47aeba01ec61e480139dda143796abcae6f83bcddf50d6b5b1dcf3"
 dependencies = [
  "atk-sys",
- "bitflags",
+ "bitflags 1.3.2",
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
  "gdk-sys",
@@ -6704,6 +6894,17 @@ name = "weezl"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
+
+[[package]]
+name = "which"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
+]
 
 [[package]]
 name = "widestring"
@@ -6801,13 +7002,37 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
+ "windows_aarch64_gnullvm 0.42.1",
  "windows_aarch64_msvc 0.42.1",
  "windows_i686_gnu 0.42.1",
  "windows_i686_msvc 0.42.1",
  "windows_x86_64_gnu 0.42.1",
- "windows_x86_64_gnullvm",
+ "windows_x86_64_gnullvm 0.42.1",
  "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -6821,6 +7046,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -6841,6 +7072,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6857,6 +7094,12 @@ name = "windows_i686_gnu"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6877,6 +7120,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6895,10 +7144,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6917,6 +7178,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winreg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
+name = "aes"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cipher 0.4.4",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,13 +471,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "blowfish"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe3ff3fc1de48c1ac2e3341c4df38b0d1bfb8fdf04632a187c8b75aaa319a7ab"
 dependencies = [
  "byteorder",
- "cipher",
+ "cipher 0.3.0",
  "opaque-debug",
 ]
 
@@ -590,6 +616,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher 0.4.4",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -667,6 +702,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -1102,6 +1147,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "datasize"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c88ad90721dc8e2ebe1430ac2f59c5bdcd74478baa68da26f30f33b0fe997f11"
+dependencies = [
+ "datasize_derive",
+]
+
+[[package]]
+name = "datasize_derive"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b0415ec81945214410892a00d4b5dd4566f6263205184248e018a3fe384a61e"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.33",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "dbus"
 version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1110,6 +1175,15 @@ dependencies = [
  "libc",
  "libdbus-sys",
  "winapi",
+]
+
+[[package]]
+name = "deflate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86f7e25f518f4b81808a2cf1c50996a61f5c2eb394b2393bd87f2a4780a432f"
+dependencies = [
+ "adler32",
 ]
 
 [[package]]
@@ -1255,6 +1329,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "document-features"
@@ -1404,6 +1484,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "fax"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2cec1797683c06c2f3de5edb3fde4d99c70e96f3204f6aaff944078353e5c55"
+dependencies = [
+ "fax_derive",
+]
+
+[[package]]
+name = "fax_derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c1d7ffc9f2dc8316348c75281a99c8fdc60c1ddf4f82a366d117bf1b74d5a39"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.33",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "field-offset"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1424,6 +1524,12 @@ dependencies = [
  "redox_syscall",
  "windows-sys",
 ]
+
+[[package]]
+name = "finl_unicode"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
 
 [[package]]
 name = "fixedbitset"
@@ -1843,6 +1949,15 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "globalcache"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469dba5c15b33d67400508ff1f640e8906fa6c8d5ee80540203eb9029ce475df"
+dependencies = [
+ "async-trait",
+]
 
 [[package]]
 name = "globset"
@@ -2312,6 +2427,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inflate"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cdb29978cc5797bd8dcc8e5bf7de604891df2a8dc576973d71a281e916db2ff"
+dependencies = [
+ "adler32",
+]
+
+[[package]]
 name = "inotify"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2329,6 +2453,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "block-padding",
+ "generic-array",
 ]
 
 [[package]]
@@ -2360,6 +2494,15 @@ name = "ipnet"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
+
+[[package]]
+name = "istring"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875cc6fb9aecbc1a9bd736f2d18b12e0756b4c80c5e35e28262154abcb077a39"
+dependencies = [
+ "datasize",
+]
 
 [[package]]
 name = "itertools"
@@ -2736,6 +2879,12 @@ name = "matchit"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -3453,6 +3602,44 @@ name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
+name = "pdf"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e375ec076445f61d4dbc4636e9e788f841d279c65d6fea8a3875caddd4f2dd82"
+dependencies = [
+ "aes",
+ "bitflags",
+ "cbc",
+ "datasize",
+ "deflate",
+ "fax",
+ "globalcache",
+ "inflate",
+ "istring",
+ "itertools",
+ "jpeg-decoder",
+ "log",
+ "md5",
+ "once_cell",
+ "pdf_derive",
+ "sha2 0.10.6",
+ "snafu",
+ "stringprep",
+ "weezl",
+]
+
+[[package]]
+name = "pdf_derive"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4007262775d0798de87b15cbc64cf1aed5f7ee87eec847e297b69d8ed4b4f8"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.33",
+ "syn 1.0.107",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -4669,7 +4856,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -4894,6 +5081,28 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "snafu"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4de37ad025c587a29e8f3f5605c00f70b98715ef90b9061a815b9e59e9042d6"
+dependencies = [
+ "doc-comment",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990079665f075b699031e9c08fd3ab99be5029b96f3b78dc0709e8f77e4efebf"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro2",
+ "quote 1.0.33",
+ "syn 1.0.107",
+]
 
 [[package]]
 name = "socket2"
@@ -5138,6 +5347,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "stringprep"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb41d74e231a107a1b4ee36bd1214b11285b77768d2e3824aedafa988fd36ee6"
+dependencies = [
+ "finl_unicode",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5180,6 +5400,7 @@ dependencies = [
  "infer",
  "itertools",
  "optional_struct",
+ "pdf",
  "prisma-client-rust",
  "rayon",
  "regex",
@@ -5282,9 +5503,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.29"
+version = "2.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "718fa2415bcb8d8bd775917a1bf12a7931b6dfa890753378538118181e0cb398"
 dependencies = [
  "proc-macro2",
  "quote 1.0.33",
@@ -6085,7 +6306,7 @@ checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 [[package]]
 name = "unrar"
 version = "0.4.4"
-source = "git+https://github.com/stumpapp/unrar.rs?branch=feature/typestate#d8c1b2854feb443f284d51eb8b7e32618141292a"
+source = "git+https://github.com/stumpapp/unrar.rs?branch=feature/typestate#00b936a0f4850bcbd0c586de97b3e2b6f4073cc2"
 dependencies = [
  "bitflags",
  "lazy_static",
@@ -6097,7 +6318,7 @@ dependencies = [
 [[package]]
 name = "unrar_sys"
 version = "0.2.1"
-source = "git+https://github.com/stumpapp/unrar.rs?branch=feature/typestate#d8c1b2854feb443f284d51eb8b7e32618141292a"
+source = "git+https://github.com/stumpapp/unrar.rs?branch=feature/typestate#00b936a0f4850bcbd0c586de97b3e2b6f4073cc2"
 dependencies = [
  "cc",
  "libc",

--- a/README.md
+++ b/README.md
@@ -97,33 +97,33 @@ A quick summary of the steps required to get going:
 
 4. Start one of the apps:
 
-I use [moonrepo](https://moonrepo.dev/) for Stump's repository management. A few example commands are:
+   I use [moonrepo](https://moonrepo.dev/) for Stump's repository management. A few example commands are:
 
-```bash
-# run the webapp + server
-moon run server:dev web:dev
-# run the desktop app + server
-moon run server:start desktop:dev
-# run the docs website
-moon run docs:dev
-```
+   ```bash
+   # run the webapp + server
+   moon run server:dev web:dev
+   # run the desktop app + server
+   moon run server:start desktop:dev
+   # run the docs website
+   moon run docs:dev
+   ```
 
-This isn't a requirement though! You can also run the apps directly with `pnpm`:
+   This isn't a requirement though! You can also run the apps directly with `pnpm`:
 
-```bash
-# run the webapp + server
-pnpm dev:web
-# run the desktop app + server
-pnpm dev:desktop
-# run the docs website
-pnpm docs dev
-```
+   ```bash
+   # run the webapp + server
+   pnpm dev:web
+   # run the desktop app + server
+   pnpm dev:desktop
+   # run the docs website
+   pnpm docs dev
+   ```
 
-Or just `cargo` for the server:
+   Or just `cargo` for the server:
 
-```bash
-cargo run --package stump_server --bin stump_server
-```
+   ```bash
+   cargo run --package stump_server --bin stump_server
+   ```
 
 And that's it!
 
@@ -134,7 +134,7 @@ If you aren't sure where to start, I recommend taking a look at [open issues](ht
 In general, the following areas are good places to start:
 
 - Translation, so Stump is accessible to as many people as possible
-  - Stump uses Crowdin for translations. You can find the project [here](https://crowdin.com/project/stump)
+  - [Crowdin](https://crowdin.com/project/stump) is being used for translations
 - Writing comprehensive tests
 - Designing UI elements/sections or improving the existing UI/UX
 - Docker build optimizations, caching, etc

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Stump is a free and open source comics, manga and digital book server with OPDS 
 - [Project Structure 📦](#project-structure-)
   - [/apps](#apps)
   - [/core](#core)
+  - [/crates](#crates)
   - [/packages](#packages)
 - [Similar Projects 👯](#similar-projects-)
 - [Acknowledgements 🙏](#acknowledgements-)
@@ -159,13 +160,16 @@ Stump has a monorepo structure managed by [pnpm workspaces](https://pnpm.io/work
 
 - `core`: A Rust crate containing Stump's core functionalities.
 
+### /crates
+
+- `prisma-cli`: A small rust app to run the Prisma CLI.
+
 ### /packages
 
 - `api`: All of the API functions used by the `client` package.
 - `client`: React-query config, hooks, and other client-side utilities.
 - `components`: Shared React components for the web and desktop applications.
 - `interface`: A React component responsible for the main UI layout for the web and desktop applications.
-- `prisma-cli`: A small rust app to run the Prisma CLI.
 - `types`: Shared TypeScript types for interfacing with Stump's core and API
 
 ## Similar Projects 👯

--- a/apps/docs/pages/faq.md
+++ b/apps/docs/pages/faq.md
@@ -35,7 +35,7 @@ The hardware requirements vary and should serve **only as a guide**. Generally s
 
 ## When will Stump be released?
 
-Stump is currently under development. The primary developer is working on it in their free time, mostly on the weekends, and there aren't many active contributors, so it's hard to say when it will be ready for a first release. That said, ideally the first release candidate will be ready by the end of 2023. If you're interested in expediting the development of Stump, please consider contributing to the project. You can find more information on how to contribute in the [Contributing](/contributing) guide.
+Stump is currently under development. The primary developer is working on it in their free time, mostly on the weekends. There aren't many active contributors, so it's hard to say when it will be release ready. Ideally the first release candidate will be ready by the end of 2023. Please consider contributing to the project if you're interested in expediting the development. You can find more information on ways to contribute in the [contributing](/contributing) guide.
 
 ## What is on the roadmap?
 
@@ -57,15 +57,6 @@ The current `0.1.0` release roadmap can be found on [GitHub](https://github.com/
 - Multi-language support
 
 If you're interested in tracking the broader development of features, you can take a look at [GitHub issues](https://github.com/stumpapp/stump/issues).
-
-## Similar Projects
-
-There are a number of other projects that are similar to Stump, it certainly isn't the first or only digital book media server out there. If Stump isn't for you, or you want to check out similar projects in the rust and/or self hosting spaces, consider checking out these other open source projects:
-
-- [Komga](https://github.com/gotson/komga)
-- [Kavita](https://github.com/Kareadita/Kavita)
-- [audiobookshelf](https://github.com/advplyr/audiobookshelf) (_Audio books, Podcasts_)
-- [Dim](https://github.com/Dusk-Labs/dim) (_Video, Audio_) (✨*Rust*✨)
 
 ## More questions?
 

--- a/apps/docs/pages/guides/_meta.json
+++ b/apps/docs/pages/guides/_meta.json
@@ -1,6 +1,7 @@
 {
 	"overview": "Overview",
 	"configuration": "Configuration",
+	"books": "Books",
 	"libraries": "Libraries",
 	"library-explorer": "Library Explorer",
 	"series": "Series",

--- a/apps/docs/pages/guides/books.md
+++ b/apps/docs/pages/guides/books.md
@@ -15,7 +15,7 @@ The following table outlines the supported formats for books in Stump:
 | ZIP Archive | `.cbz` `.zip` | ✅    | ✅        | ✅   |                                                                                                                                        |
 | RAR Archive | `.cbr` `.rar` | ✅    | ✅        | ✅   |                                                                                                                                        |
 | EPUB        | `.epub`       | ✅    | ❌        | ❌   | Epub files aren't generally supported by ODPS. Chapter HTML can be streamed from the server, however the UI does not utilize this yet. |
-| PDF         | `.pdf`        | ✅    | ❌        | ❌   | PDF support is _very_ barebones                                                                                                        |
+| PDF         | `.pdf`        | ✅    | ✅        | ✅   |                                                                                                                                        |
 
 - **Basic**: Basic support encapsulates the minimally viable functionality for a given format. In general, this will include things like:
   - File discovery

--- a/apps/docs/pages/guides/books.md
+++ b/apps/docs/pages/guides/books.md
@@ -1,0 +1,58 @@
+# Books
+
+The backbone of Stump! There are a couple key concepts to go over regarding how Stump represents books:
+
+- Books (also internally referred to as `media`) primarily refer to files on disk
+- Books are grouped into [`series`](/guides/series), which are then grouped into [`libraries`](/guides/libraries)
+- [Metadata](#metadata) is an associated set of information _about_ a book, such as its title, author, etc.
+
+## Supported formats
+
+The following table outlines the supported formats for books in Stump:
+
+| Format      | Extension(s)  | Basic | Streaming | OPDS | Notes                                                                                                                                  |
+| ----------- | ------------- | ----- | --------- | ---- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| ZIP Archive | `.cbz` `.zip` | ✅    | ✅        | ✅   |                                                                                                                                        |
+| RAR Archive | `.cbr` `.rar` | ✅    | ✅        | ✅   |                                                                                                                                        |
+| EPUB        | `.epub`       | ✅    | ❌        | ❌   | Epub files aren't generally supported by ODPS. Chapter HTML can be streamed from the server, however the UI does not utilize this yet. |
+| PDF         | `.pdf`        | ✅    | ❌        | ❌   | PDF support is _very_ barebones                                                                                                        |
+
+- **Basic**: Basic support encapsulates the minimally viable functionality for a given format. In general, this will include things like:
+  - File discovery
+  - Metadata extraction
+  - File serving
+- **Streaming**: Streaming support refers to the ability to stream a book's pages _individually_ to a client. This is generally important, as it reduces overall network loads by only sending the pages that are being requested by the client. If a format does not support streaming, the entire book will be sent to the client at once when it is requested.
+  - Epub files are sort of an exception to this, as they are essentially an archive of HTML/CSS files. The HTML files for each chapter can currently be streamed individually, however the UI does not utilize this yet.
+- **OPDS**: OPDS support refers to the ability to serve a book according to OPDS. For more information, see the [OPDS](/guides/opds) guide.
+
+## Metadata
+
+Metadata is an associated set of information _about_ a book, such as its title, author, etc. Different formats have different ways of storing and representing metadata. Stump will attempt to extract as much metadata as possible from a given book, however it is not always possible. For example, PDF files do not generally have very good metadata support, and comic book files (e.g. CBZ/CBR) often times have very malformed metadata.
+
+### Sources per format
+
+The following outlines the sources of metadata for each format:
+
+#### CBZ/CBR/RAR/ZIP
+
+Archive formats, aside from EPUB files, are primarily assumed to be comic books. As such, metadata is extracted from a file named `ComicInfo.xml` if it exists. Currently, Stump follows the [v2.0 schema](https://anansi-project.github.io/docs/comicinfo/schemas/v2.0) for parsing. There is some leeway for malformed XML that Stump will try to catch, but it is not guaranteed to work. Please ensure your `ComicInfo.xml` is valid XML.
+
+#### EPUB
+
+EPUB files typically store their metadata in an `OPF` file, but it is more limited than what can be found in a typical `ComicInfo.xml` file.
+
+#### PDF
+
+PDF files do not generally have very good metadata support. In general, I have seen only a few fields that are consistently populated, such as the title and author. PDF files are somewhat smelly 💩
+
+### Additional sources
+
+Stump will also attempt to extract series metadata from a `series.json` file at the root of a series directory. This is not specific to any format or books in general, though, so refer to the [series](/guides/series) guide for more information.
+
+### Special metadata fields
+
+There are a few special metadata fields that Stump will use for additional functionality:
+
+#### Age rating
+
+The age rating field can be used in-conjunction with [access controls](/guides/access-control) to restrict access to books based on their age rating. There are a **LOT** of different age rating systems, and Stump does not currently support all of them, so be sure to review the [age restriction](/guides/access-control#age-restrictions) section for more information.

--- a/apps/docs/pages/guides/opds.md
+++ b/apps/docs/pages/guides/opds.md
@@ -1,6 +1,8 @@
-# Using other OPDS clients
+# OPDS
 
-Stump is compatible with any OPDS client that _properly_ implements the OPDS specification. The general structure of the URL to connect to your Stump server is:
+Open Publication Distribution System ([OPDS](https://opds.io/)) is a specification for generating and serving catalogs of digital content. It is used by many applications, such as [Panels](https://panels.app/) and [Chunky Reader](https://apps.apple.com/us/app/chunky-comic-reader/id663567628).
+
+So long as an OPDS client _properly_ implements the OPDS specification, you should be able to use it with Stump. The general structure of the URL to connect to your Stump server is:
 
 `http(s)://your-server(:10801)(/baseUrl)/opds/v1.2/catalog`
 
@@ -8,17 +10,17 @@ For example, if you are running Stump on your local machine, with the default po
 
 `http://localhost:10801/opds/v1.2/catalog`
 
-Each OPDS client might have a different way of collecting this information during their onboarding steps. If you have any trouble using your preferred client, please open an issue on [GitHub](https://github.com/stumpapp/stump/issues/new/choose) or feel free to pop into the Stump [Discord](https://discord.gg/63Ybb7J3as) server and ask for help.
+Each OPDS client might have a different way of collecting this information during their onboarding steps. If you have any trouble using your preferred client, please open an issue on [GitHub](https://github.com/stumpapp/stump/issues/new/choose) or feel free to pop into the [Discord](https://discord.gg/63Ybb7J3as) for help. This page can be updated with your findings to help others in the future.
 
 ## Tested OPDS clients
 
 The following clients have been tested with Stump:
 
-| OS      |                                      Application                                       | Page Streaming | Issues/Notes |
-| ------- | :------------------------------------------------------------------------------------: | -------------: | -----------: |
-| iOS     |                             [Panels](https://panels.app/)                              |             ✅ |              |
-| iOS     |     [Chunky Reader](https://apps.apple.com/us/app/chunky-comic-reader/id663567628)     |             ✅ |              |
-| Android | [Moon+ Reader](https://play.google.com/store/apps/details?id=com.flyersoft.moonreader) |             ❌ |              |
-| Android |                         [KyBook 3](http://kybook-reader.com/)                          |             ❌ |              |
+| OS      |                                      Application                                       | Page Streaming |            Issues/Notes |
+| ------- | :------------------------------------------------------------------------------------: | -------------: | ----------------------: |
+| iOS     |                             [Panels](https://panels.app/)                              |             ✅ |                         |
+| iOS     |     [Chunky Reader](https://apps.apple.com/us/app/chunky-comic-reader/id663567628)     |             ✅ |                         |
+| Android | [Moon+ Reader](https://play.google.com/store/apps/details?id=com.flyersoft.moonreader) |             ❌ | No testing at this time |
+| Android |                         [KyBook 3](http://kybook-reader.com/)                          |             ❌ | No testing at this time |
 
 If you have any experiences, good or bad, using any of these clients or another client not listed here, please consider updating this page with your findings.

--- a/apps/docs/pages/guides/overview.md
+++ b/apps/docs/pages/guides/overview.md
@@ -3,10 +3,11 @@
 This section of the documenation contains several guides for using and/or setting up Stump. An overview of the guides is provided below.
 
 - [Installation](/installation) - How to install Stump on your system
-- [Configuration](/guides/configuration) - How to configure Stump to suit your needs, including things like system variables, port configuration, and more
+- [Configuration](/guides/configuration) - How to configure Stump, including system variables and more
+- [Books](/guides/books) - How Stump represents books, what formats are supported, etc
 - [Libraries](/guides/libraries) - What are libraries, how they are created, and how to use them
 - [Library Explorer](/guides/library-explorer) - How to use the Library Explorer to browse and search for books as a secondary option for navigating your library
-- [Series](/guies/series) - What are series and how libraries organize their associated books
+- [Series](/guides/series) - What are series and how libraries organize their associated books
 - [Tagging](/guides/tagging) - How to use tags to organize your libraries, series, books and other groupable entities
 - [Background Jobs](/guides/jobs) - What are background jobs, which are available, and how to configure them
 - [Filesystem Scans](/guides/filesystem-scans) - The scan options available with Stump, how to configure them, and how to use them

--- a/apps/server/src/routers/api/v1/media.rs
+++ b/apps/server/src/routers/api/v1/media.rs
@@ -641,6 +641,8 @@ async fn get_media_file(
 		.await?
 		.ok_or(ApiError::NotFound(String::from("Media not found")))?;
 
+	trace!(?media, "Downloading media file");
+
 	Ok(NamedFile::open(media.path.clone()).await?)
 }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -39,6 +39,7 @@ epub = "1.2.4"
 unrar = { git = "https://github.com/stumpapp/unrar.rs", branch = "feature/typestate" }
 # unrar = { version = "0.5.1" }
 pdf = "0.8.1"
+pdfium-render = "0.8.9"
 data-encoding = "2.3.2"
 ring = "0.16.20"
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -38,6 +38,7 @@ zip = "0.5.13"
 epub = "1.2.4"
 unrar = { git = "https://github.com/stumpapp/unrar.rs", branch = "feature/typestate" }
 # unrar = { version = "0.5.1" }
+pdf = "0.8.1"
 data-encoding = "2.3.2"
 ring = "0.16.20"
 

--- a/core/src/config/env.rs
+++ b/core/src/config/env.rs
@@ -43,6 +43,7 @@ pub struct StumpEnvironment {
 	pub client_dir: Option<String>,
 	pub config_dir: Option<String>,
 	pub allowed_origins: Option<Vec<String>>,
+	pub pdfium_path: Option<String>,
 }
 
 impl Default for StumpEnvironment {
@@ -55,6 +56,7 @@ impl Default for StumpEnvironment {
 			client_dir: Some(String::from("client")),
 			config_dir: None,
 			allowed_origins: None,
+			pdfium_path: None,
 		}
 	}
 }
@@ -124,6 +126,10 @@ impl StumpEnvironment {
 
 		env.config_dir = Some(get_config_dir().to_string_lossy().to_string());
 
+		if let Ok(pdfium_path) = env::var("PDFIUM_PATH") {
+			env.pdfium_path = Some(pdfium_path);
+		}
+
 		env.write()?;
 
 		Ok(env)
@@ -173,6 +179,12 @@ impl StumpEnvironment {
 		if let Some(allowed_origins) = &self.allowed_origins {
 			if !allowed_origins.is_empty() {
 				env::set_var("STUMP_ALLOWED_ORIGINS", allowed_origins.join(","));
+			}
+		}
+
+		if let Some(pdfium_path) = &self.pdfium_path {
+			if !pdfium_path.is_empty() {
+				env::set_var("PDFIUM_PATH", pdfium_path);
 			}
 		}
 

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -88,3 +88,7 @@ pub fn stump_in_docker() -> bool {
 		})
 		.unwrap_or(false)
 }
+
+pub fn get_pdfium_path() -> Option<PathBuf> {
+	std::env::var("PDFIUM_PATH").ok().map(PathBuf::from)
+}

--- a/core/src/db/entity/metadata.rs
+++ b/core/src/db/entity/metadata.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use pdf::primitive::Dictionary;
 use regex::Regex;
 use serde::{Deserialize, Deserializer, Serialize};
 use specta::Type;
@@ -127,6 +128,7 @@ where
 	Ok(age)
 }
 
+// TODO: author field?
 // NOTE: alias is used primarily to support ComicInfo.xml files, as that metadata
 // is formatted in PascalCase
 /// Struct representing the metadata for a processed file.
@@ -424,6 +426,19 @@ impl From<HashMap<String, Vec<String>>> for MediaMetadata {
 		}
 
 		metadata
+	}
+}
+
+impl From<Dictionary> for MediaMetadata {
+	fn from(dict: Dictionary) -> Self {
+		// FIXME: this is pretty hacky! I need to match on the type of the value
+		let map = dict
+			.into_iter()
+			.map(|(k, v)| v.to_string().map(|v| (k, v)))
+			.filter_map(|result| result.ok())
+			.map(|(k, v)| (k.to_lowercase(), vec![v]))
+			.collect::<HashMap<String, Vec<String>>>();
+		Self::from(map)
 	}
 }
 

--- a/core/src/filesystem/common.rs
+++ b/core/src/filesystem/common.rs
@@ -28,9 +28,9 @@ impl OsStrUtils for OsStr {
 }
 
 pub struct FileParts {
-	file_name: String,
-	file_stem: String,
-	extension: String,
+	pub file_name: String,
+	pub file_stem: String,
+	pub extension: String,
 }
 
 pub trait PathUtils {

--- a/core/src/filesystem/error.rs
+++ b/core/src/filesystem/error.rs
@@ -23,6 +23,8 @@ pub enum FileError {
 	#[error("Could not find an image")]
 	NoImageError,
 	#[error("{0}")]
+	PdfError(#[from] pdf::error::PdfError),
+	#[error("{0}")]
 	RarError(#[from] UnrarError),
 	#[error("Failed to open rar archive: {0}")]
 	RarNulError(#[from] unrar::error::NulError),

--- a/core/src/filesystem/error.rs
+++ b/core/src/filesystem/error.rs
@@ -25,6 +25,12 @@ pub enum FileError {
 	#[error("{0}")]
 	PdfError(#[from] pdf::error::PdfError),
 	#[error("{0}")]
+	PdfRendererError(#[from] pdfium_render::error::PdfiumError),
+	#[error("Stump is not properly configured to render PDFs")]
+	PdfConfigurationError,
+	#[error("Failed to process PDF file: {0}")]
+	PdfProcessingError(String),
+	#[error("{0}")]
 	RarError(#[from] UnrarError),
 	#[error("Failed to open rar archive: {0}")]
 	RarNulError(#[from] unrar::error::NulError),

--- a/core/src/filesystem/image/process.rs
+++ b/core/src/filesystem/image/process.rs
@@ -59,6 +59,21 @@ impl ImageFormat {
 	}
 }
 
+impl From<ImageFormat> for image::ImageOutputFormat {
+	fn from(val: ImageFormat) -> Self {
+		match val {
+			ImageFormat::Webp => {
+				image::ImageOutputFormat::Unsupported(String::from("webp"))
+			},
+			ImageFormat::Jpeg => image::ImageOutputFormat::Jpeg(100),
+			ImageFormat::JpegXl => {
+				image::ImageOutputFormat::Unsupported(String::from("jxl"))
+			},
+			ImageFormat::Png => image::ImageOutputFormat::Png,
+		}
+	}
+}
+
 /// Options for processing images throughout Stump.
 #[derive(Default, Debug, Clone, Serialize, Deserialize, Type)]
 pub struct ImageProcessorOptions {

--- a/core/src/filesystem/media/epub.rs
+++ b/core/src/filesystem/media/epub.rs
@@ -12,6 +12,7 @@ use tracing::{debug, error, trace, warn};
 
 use super::process::{FileProcessor, FileProcessorOptions, ProcessedFile};
 
+/// A file processor for EPUB files.
 pub struct EpubProcessor;
 
 impl FileProcessor for EpubProcessor {

--- a/core/src/filesystem/media/pdf.rs
+++ b/core/src/filesystem/media/pdf.rs
@@ -1,9 +1,10 @@
-use std::{collections::HashMap, path::PathBuf};
+use std::{collections::HashMap, io::Cursor, num::TryFromIntError, path::PathBuf};
 
 use pdf::file::FileOptions;
-use tracing::{debug, warn};
+use pdfium_render::{prelude::Pdfium, render_config::PdfRenderConfig};
 
 use crate::{
+	config,
 	db::entity::metadata::MediaMetadata,
 	filesystem::{error::FileError, hash, ContentType},
 };
@@ -15,15 +16,16 @@ pub struct PdfProcessor;
 
 impl FileProcessor for PdfProcessor {
 	// It is REALLY annoying to work with PDFs, and there is no good way to consume
-	// each page as a vector of bytes. So, we'll just make the sample size approximately
-	// 1/10th of the file size.
+	// each page as a vector of bytes efficiently. Since PDFs don't really have metadata,
+	// I wouldn't expect the file to change much after a scan. So, for now, this will
+	// just make the sample size approximately 1/10th of the file size.
 	fn get_sample_size(path: &str) -> Result<u64, FileError> {
 		let file = std::fs::File::open(path)?;
 		let metadata = file.metadata()?;
 		let size = metadata.len();
 
 		if size < 10 {
-			warn!(path, size, "File is too small to sample!");
+			tracing::warn!(path, size, "File is too small to sample!");
 			return Err(FileError::UnknownError(String::from(
 				"File is too small to sample!",
 			)));
@@ -39,7 +41,7 @@ impl FileProcessor for PdfProcessor {
 			match hash::generate(path, sample) {
 				Ok(digest) => Some(digest),
 				Err(e) => {
-					debug!(error = ?e, path, "Failed to digest PDF file");
+					tracing::debug!(error = ?e, path, "Failed to digest PDF file");
 					None
 				},
 			}
@@ -50,10 +52,6 @@ impl FileProcessor for PdfProcessor {
 
 	fn process(path: &str, _: FileProcessorOptions) -> Result<ProcessedFile, FileError> {
 		let file = FileOptions::cached().open(path)?;
-
-		if let Some(ref info) = file.trailer.info_dict {
-			dbg!(info);
-		}
 
 		let pages = file.pages().count() as i32;
 		let metadata = file.trailer.info_dict.map(MediaMetadata::from);
@@ -66,18 +64,75 @@ impl FileProcessor for PdfProcessor {
 		})
 	}
 
-	fn get_page(_path: &str, _page: i32) -> Result<(ContentType, Vec<u8>), FileError> {
-		Err(FileError::UnsupportedFileType(String::from(
-			"Stump does not currently support getting individual PDF pages",
-		)))
+	fn get_page(path: &str, page: i32) -> Result<(ContentType, Vec<u8>), FileError> {
+		let pdfium = PdfProcessor::renderer()?;
+
+		let document = pdfium.load_pdf_from_file(path, None)?;
+		let document_page =
+			document.pages().get((page - 1).try_into().map_err(
+				|e: TryFromIntError| FileError::UnknownError(e.to_string()),
+			)?)?;
+
+		let render_config = PdfRenderConfig::new();
+
+		let bitmap = document_page.render_with_config(&render_config)?;
+		let dyn_image = bitmap.as_image(); // Renders this page to an image::DynamicImage...
+
+		if let Some(image) = dyn_image.as_rgba8() {
+			let mut buffer = Cursor::new(vec![]);
+			image
+				.write_to(&mut buffer, image::ImageOutputFormat::Png)
+				.map_err(|e| {
+					tracing::error!(error = ?e, "Failed to write image to buffer");
+					FileError::PdfProcessingError(String::from(
+						"An image could not be rendered from the PDF page",
+					))
+				})?;
+			Ok((ContentType::PNG, buffer.into_inner()))
+		} else {
+			tracing::warn!(
+				path,
+				page,
+				"An image could not be rendered from the PDF page"
+			);
+			Err(FileError::PdfProcessingError(String::from(
+				"An image could not be rendered from the PDF page",
+			)))
+		}
 	}
 
 	fn get_page_content_types(
-		_path: &str,
-		_pages: Vec<i32>,
+		_: &str,
+		pages: Vec<i32>,
 	) -> Result<HashMap<i32, ContentType>, FileError> {
-		Err(FileError::UnsupportedFileType(String::from(
-			"Stump does not currently support getting individual PDF pages",
-		)))
+		// Lol this is sorta funny, but right now all PDFProcessor::get_page calls convert the buffer
+		// to PNG format. So, we'll just return that here.
+		Ok(pages
+			.into_iter()
+			.map(|page| (page, ContentType::PNG))
+			.collect())
+	}
+}
+
+impl PdfProcessor {
+	/// Initializes a PDFium renderer. If a path to the PDFium library is not provided
+	pub fn renderer() -> Result<Pdfium, FileError> {
+		let pdfium_path = config::get_pdfium_path();
+
+		if let Some(path) = pdfium_path {
+			let bindings = Pdfium::bind_to_library(&path)
+			.or_else(|e| {
+				tracing::error!(provided_path = ?path, ?e, "Failed to bind to PDFium library at provided path");
+				Pdfium::bind_to_system_library()
+			})?;
+			Ok(Pdfium::new(bindings))
+		} else {
+			tracing::warn!(
+				"No PDFium path provided, will attempt to bind to system library"
+			);
+			Pdfium::bind_to_system_library()
+				.map(Pdfium::new)
+				.map_err(|_| FileError::PdfConfigurationError)
+		}
 	}
 }

--- a/core/src/filesystem/media/pdf.rs
+++ b/core/src/filesystem/media/pdf.rs
@@ -1,9 +1,83 @@
-use crate::filesystem::{error::FileError, ContentType};
+use std::{collections::HashMap, path::PathBuf};
 
+use pdf::file::FileOptions;
+use tracing::{debug, warn};
+
+use crate::{
+	db::entity::metadata::MediaMetadata,
+	filesystem::{error::FileError, hash, ContentType},
+};
+
+use super::{FileProcessor, FileProcessorOptions, ProcessedFile};
+
+/// A file processor for PDF files.
 pub struct PdfProcessor;
 
-pub fn get_page(_file: &str, _page: usize) -> Result<(ContentType, Vec<u8>), FileError> {
-	Err(FileError::UnsupportedFileType(String::from(
-		"Stump does not currently support PDF files",
-	)))
+impl FileProcessor for PdfProcessor {
+	// It is REALLY annoying to work with PDFs, and there is no good way to consume
+	// each page as a vector of bytes. So, we'll just make the sample size approximately
+	// 1/10th of the file size.
+	fn get_sample_size(path: &str) -> Result<u64, FileError> {
+		let file = std::fs::File::open(path)?;
+		let metadata = file.metadata()?;
+		let size = metadata.len();
+
+		if size < 10 {
+			warn!(path, size, "File is too small to sample!");
+			return Err(FileError::UnknownError(String::from(
+				"File is too small to sample!",
+			)));
+		}
+
+		Ok(size / 10)
+	}
+
+	fn hash(path: &str) -> Option<String> {
+		let sample_result = PdfProcessor::get_sample_size(path);
+
+		if let Ok(sample) = sample_result {
+			match hash::generate(path, sample) {
+				Ok(digest) => Some(digest),
+				Err(e) => {
+					debug!(error = ?e, path, "Failed to digest PDF file");
+					None
+				},
+			}
+		} else {
+			None
+		}
+	}
+
+	fn process(path: &str, _: FileProcessorOptions) -> Result<ProcessedFile, FileError> {
+		let file = FileOptions::cached().open(path)?;
+
+		if let Some(ref info) = file.trailer.info_dict {
+			dbg!(info);
+		}
+
+		let pages = file.pages().count() as i32;
+		let metadata = file.trailer.info_dict.map(MediaMetadata::from);
+
+		Ok(ProcessedFile {
+			path: PathBuf::from(path),
+			hash: PdfProcessor::hash(path),
+			metadata,
+			pages,
+		})
+	}
+
+	fn get_page(_path: &str, _page: i32) -> Result<(ContentType, Vec<u8>), FileError> {
+		Err(FileError::UnsupportedFileType(String::from(
+			"Stump does not currently support getting individual PDF pages",
+		)))
+	}
+
+	fn get_page_content_types(
+		_path: &str,
+		_pages: Vec<i32>,
+	) -> Result<HashMap<i32, ContentType>, FileError> {
+		Err(FileError::UnsupportedFileType(String::from(
+			"Stump does not currently support getting individual PDF pages",
+		)))
+	}
 }

--- a/core/src/filesystem/media/process.rs
+++ b/core/src/filesystem/media/process.rs
@@ -129,6 +129,7 @@ pub fn get_page(path: &str, page: i32) -> Result<(ContentType, Vec<u8>), FileErr
 		"application/vnd.rar" => RarProcessor::get_page(path, page),
 		"application/vnd.comicbook-rar" => RarProcessor::get_page(path, page),
 		"application/epub+zip" => EpubProcessor::get_page(path, page),
+		"application/pdf" => PdfProcessor::get_page(path, page),
 		_ => Err(FileError::UnsupportedFileType(path.to_string())),
 	}
 }

--- a/core/src/filesystem/media/process.rs
+++ b/core/src/filesystem/media/process.rs
@@ -15,7 +15,7 @@ use crate::{
 	},
 	filesystem::{
 		content_type::ContentType, epub::EpubProcessor, error::FileError,
-		pdf::PdfProcessor,
+		image::ImageFormat, pdf::PdfProcessor,
 	},
 };
 
@@ -68,6 +68,15 @@ pub trait FileProcessor {
 		path: &str,
 		pages: Vec<i32>,
 	) -> Result<HashMap<i32, ContentType>, FileError>;
+}
+
+/// Trait defining a standard API for converting files throughout Stump.
+pub trait FileConverter {
+	fn to_zip(
+		path: &str,
+		delete_source: bool,
+		image_format: Option<ImageFormat>,
+	) -> Result<PathBuf, FileError>;
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/core/src/filesystem/media/rar.rs
+++ b/core/src/filesystem/media/rar.rs
@@ -21,6 +21,7 @@ use crate::{
 
 use super::{FileProcessor, FileProcessorOptions, ProcessedFile};
 
+/// A file processor for RAR files.
 pub struct RarProcessor;
 
 impl FileProcessor for RarProcessor {

--- a/core/src/filesystem/media/zip.rs
+++ b/core/src/filesystem/media/zip.rs
@@ -16,6 +16,7 @@ use crate::filesystem::{
 
 use super::{FileProcessor, FileProcessorOptions, ProcessedFile};
 
+/// A file processor for ZIP files.
 pub struct ZipProcessor;
 
 impl FileProcessor for ZipProcessor {

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -42,6 +42,7 @@
 		"react-router": "^6.9.0",
 		"react-router-dom": "^6.9.0",
 		"react-swipeable": "^7.0.0",
+		"react-window": "^1.8.9",
 		"remark-gfm": "^3.0.1",
 		"rooks": "^7.9.0",
 		"use-count-up": "^3.0.1",

--- a/packages/interface/src/AppLayout.tsx
+++ b/packages/interface/src/AppLayout.tsx
@@ -18,8 +18,8 @@ export function AppLayout() {
 	const location = useLocation()
 
 	const hideSidebar = useMemo(() => {
-		// hide sidebar when on /books/:id/page/:page or book/:id/epub-reader
-		return location.pathname.match(/\/book\/.+\/(reader|epub-reader)/)
+		// hide sidebar when reading a book
+		return location.pathname.match(/\/book\/.+\/(.*-?reader)/)
 	}, [location])
 
 	useCoreEventHandler()

--- a/packages/interface/src/components/HorizontalCardList.tsx
+++ b/packages/interface/src/components/HorizontalCardList.tsx
@@ -49,7 +49,7 @@ export default function HorizontalCardList({ cards, title, fetchNext }: Props) {
 	const [lowerBound, upperBound] = visibleRef.current
 
 	const canSkipBackward = (lowerBound ?? 0) > 0
-	const canSkipForward = !!cards.length && (upperBound || 0) <= cards.length
+	const canSkipForward = !!cards.length && (upperBound || 0) + 1 < cards.length
 
 	useEffect(
 		() => {

--- a/packages/interface/src/components/readers/pdf/NativePDFViewer.tsx
+++ b/packages/interface/src/components/readers/pdf/NativePDFViewer.tsx
@@ -1,0 +1,62 @@
+import { getMediaDownloadUrl } from '@stump/api'
+import { Link, Text } from '@stump/components'
+import { useEffect, useState } from 'react'
+
+type Props = {
+	/**
+	 * The ID of the media
+	 */
+	id: string
+}
+
+/**
+ * A barebones PDF viewer that uses the native browser PDF viewer. This is done
+ * by fetching the PDF as a blob and creating an object URL for it to be displayed
+ * in an <object> tag.
+ *
+ * Eventually, a custom PDF viewer should be implemented as to support essential features
+ * such as reading progress, bookmarks, and annotations.
+ */
+export default function NativePDFViewer({ id }: Props) {
+	const [pdfObjectUrl, setPdfObjectUrl] = useState<string>()
+
+	/**
+	 * An effect that fetches the PDF and creates an object URL for it.
+	 * When the component unmounts, the object URL is revoked.
+	 */
+	useEffect(
+		() => {
+			async function fetchPdf() {
+				const response = await fetch(getMediaDownloadUrl(id), {
+					credentials: 'include',
+				})
+				const blob = await response.blob()
+				const arrayBuffer = await blob.arrayBuffer()
+				setPdfObjectUrl(URL.createObjectURL(new Blob([arrayBuffer], { type: 'application/pdf' })))
+			}
+			fetchPdf()
+
+			return () => {
+				if (pdfObjectUrl) {
+					URL.revokeObjectURL(pdfObjectUrl)
+				}
+			}
+		},
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[],
+	)
+
+	// TODO: consider some sort of loading state here
+	if (!pdfObjectUrl) {
+		return null
+	}
+
+	return (
+		<object data={pdfObjectUrl} type="application/pdf" width="100%" height="100%">
+			<Text>
+				PDF failed to load. <Link href={getMediaDownloadUrl(id)}>Click here</Link> attempt
+				downloading it directly.
+			</Text>
+		</object>
+	)
+}

--- a/packages/interface/src/paths.ts
+++ b/packages/interface/src/paths.ts
@@ -1,19 +1,16 @@
 type BookReaderParams = {
 	page?: number
 	isEpub?: boolean
+	isPdf?: boolean
 	epubcfi?: string | null
 	isAnimated?: boolean
 }
 
 const paths = {
 	bookOverview: (id: string) => `/book/${id}`,
-	bookReader: (id: string, { isEpub, epubcfi, isAnimated, page }: BookReaderParams) => {
+	bookReader: (id: string, { isEpub, isPdf, epubcfi, isAnimated, page }: BookReaderParams) => {
 		const baseUrl = paths.bookOverview(id)
 		const searchParams = new URLSearchParams()
-
-		if (isAnimated) {
-			searchParams.append('animated', 'true')
-		}
 
 		if (isEpub) {
 			searchParams.append('stream', 'false')
@@ -21,6 +18,15 @@ const paths = {
 				searchParams.append('cfi', encodeURIComponent(epubcfi))
 			}
 			return `${baseUrl}/epub-reader?${searchParams.toString()}`
+		}
+
+		if (isPdf) {
+			// searchParams.append('native', 'true')
+			return `${baseUrl}/pdf-reader?${searchParams.toString()}`
+		}
+
+		if (isAnimated) {
+			searchParams.append('animated', 'true')
 		}
 
 		if (page) {
@@ -35,14 +41,14 @@ const paths = {
 	libraryManage: (id: string) => `/library/${id}/manage`,
 	libraryOverview: (id: string, page?: number) => {
 		if (page !== undefined) {
-			return `/library/${id}/${page}`
+			return `/library/${id}?page=${page}`
 		}
 		return `/library/${id}`
 	},
 	notFound: () => '/404',
 	seriesOverview: (id: string, page?: number) => {
 		if (page !== undefined) {
-			return `/series/${id}/${page}`
+			return `/series/${id}?page=${page}`
 		}
 		return `/series/${id}`
 	},

--- a/packages/interface/src/paths.ts
+++ b/packages/interface/src/paths.ts
@@ -4,11 +4,15 @@ type BookReaderParams = {
 	isPdf?: boolean
 	epubcfi?: string | null
 	isAnimated?: boolean
+	isStreaming?: boolean
 }
 
 const paths = {
 	bookOverview: (id: string) => `/book/${id}`,
-	bookReader: (id: string, { isEpub, isPdf, epubcfi, isAnimated, page }: BookReaderParams) => {
+	bookReader: (
+		id: string,
+		{ isEpub, isPdf, epubcfi, isAnimated, page, isStreaming }: BookReaderParams,
+	) => {
 		const baseUrl = paths.bookOverview(id)
 		const searchParams = new URLSearchParams()
 
@@ -20,8 +24,7 @@ const paths = {
 			return `${baseUrl}/epub-reader?${searchParams.toString()}`
 		}
 
-		if (isPdf) {
-			// searchParams.append('native', 'true')
+		if (isPdf && !isStreaming) {
 			return `${baseUrl}/pdf-reader?${searchParams.toString()}`
 		}
 

--- a/packages/interface/src/scenes/book/BookOverviewScene.tsx
+++ b/packages/interface/src/scenes/book/BookOverviewScene.tsx
@@ -1,5 +1,5 @@
 import { useMediaByIdQuery } from '@stump/client'
-import { Badge, Heading, Spacer, Text } from '@stump/components'
+import { Badge, ButtonOrLink, Heading, Spacer, Text } from '@stump/components'
 import dayjs from 'dayjs'
 import { Suspense } from 'react'
 import { Helmet } from 'react-helmet'
@@ -10,6 +10,8 @@ import LinkBadge from '../../components/LinkBadge'
 import MediaCard from '../../components/media/MediaCard'
 import ReadMore from '../../components/ReadMore'
 import TagList from '../../components/tags/TagList'
+import paths from '../../paths'
+import { PDF_EXTENSION } from '../../utils/patterns'
 import BookFileInformation from './BookFileInformation'
 import BookLibrarySeriesLinks from './BookLibrarySeriesLinks'
 import BookReaderLink from './BookReaderLink'
@@ -79,6 +81,16 @@ export default function BookOverviewScene() {
 
 						<div className="flex w-full flex-col-reverse gap-1 md:flex-row md:gap-2">
 							<BookReaderLink book={media} />
+							{media.extension?.match(PDF_EXTENSION) && (
+								<ButtonOrLink
+									variant="outline"
+									href={paths.bookReader(media.id, { isPdf: true, isStreaming: false })}
+									title="Read with the native PDF viewer"
+									className="w-full md:w-auto"
+								>
+									Read with the native PDF viewer
+								</ButtonOrLink>
+							)}
 							<DownloadMediaButton media={media} />
 						</div>
 					</div>

--- a/packages/interface/src/scenes/book/BookReaderScene.tsx
+++ b/packages/interface/src/scenes/book/BookReaderScene.tsx
@@ -18,6 +18,7 @@ export default function BookReaderScene() {
 
 	const page = search.get('page')
 	const isAnimated = search.get('animated') === 'true'
+	const isStreaming = !search.get('stream') || search.get('stream') === 'true'
 
 	const { isLoading: fetchingBook, media } = useMediaByIdQuery(id)
 	const { updateReadProgress } = useUpdateMediaProgress(id, {
@@ -47,11 +48,12 @@ export default function BookReaderScene() {
 				})}
 			/>
 		)
-	} else if (media.extension.match(PDF_EXTENSION)) {
+	} else if (media.extension.match(PDF_EXTENSION) && !isStreaming) {
 		return (
 			<Navigate
 				to={paths.bookReader(id, {
 					isPdf: true,
+					isStreaming: false,
 				})}
 			/>
 		)
@@ -61,9 +63,8 @@ export default function BookReaderScene() {
 		return <Navigate to={paths.bookReader(id, { isAnimated, page: media.pages })} />
 	}
 
-	if (media.extension.match(ARCHIVE_EXTENSION)) {
+	if (media.extension.match(ARCHIVE_EXTENSION) || media.extension.match(PDF_EXTENSION)) {
 		const animated = !!search.get('animated')
-
 		const Component = animated ? AnimatedImageBasedReader : ImageBasedReader
 
 		return (

--- a/packages/interface/src/scenes/book/BookReaderScene.tsx
+++ b/packages/interface/src/scenes/book/BookReaderScene.tsx
@@ -5,7 +5,7 @@ import { Navigate, useNavigate, useParams, useSearchParams } from 'react-router-
 import AnimatedImageBasedReader from '../../components/readers/image-based/AnimatedImageBasedReader'
 import ImageBasedReader from '../../components/readers/image-based/ImageBasedReader'
 import paths from '../../paths'
-import { ARCHIVE_EXTENSION, EBOOK_EXTENSION } from '../../utils/patterns'
+import { ARCHIVE_EXTENSION, EBOOK_EXTENSION, PDF_EXTENSION } from '../../utils/patterns'
 
 export default function BookReaderScene() {
 	const [search] = useSearchParams()
@@ -44,6 +44,14 @@ export default function BookReaderScene() {
 					epubcfi: media.current_epubcfi || null,
 					isAnimated,
 					isEpub: true,
+				})}
+			/>
+		)
+	} else if (media.extension.match(PDF_EXTENSION)) {
+		return (
+			<Navigate
+				to={paths.bookReader(id, {
+					isPdf: true,
 				})}
 			/>
 		)

--- a/packages/interface/src/scenes/book/BookRouter.tsx
+++ b/packages/interface/src/scenes/book/BookRouter.tsx
@@ -7,13 +7,15 @@ const lazily = (loader: () => unknown) => React.lazy(() => loader() as LazyCompo
 
 const BookOverviewScene = lazily(() => import('./BookOverviewScene.tsx'))
 const BookReaderScene = lazily(() => import('./BookReaderScene.tsx'))
-const EpubReaderScene = lazily(() => import('./epub/EpubReaderScene.tsx'))
+const EpubReaderScene = lazily(() => import('./EpubReaderScene.tsx'))
+const PDFReaderScene = lazily(() => import('./PDFReaderScene.tsx'))
 
 export default function BookRouter() {
 	return (
 		<Routes>
 			<Route path=":id" element={<BookOverviewScene />} />
 			<Route path=":id/epub-reader" element={<EpubReaderScene />} />
+			<Route path=":id/pdf-reader" element={<PDFReaderScene />} />
 			<Route path=":id/reader" element={<BookReaderScene />} />
 			<Route path="*" element={<Navigate to="/404" />} />
 		</Routes>

--- a/packages/interface/src/scenes/book/EpubReaderScene.tsx
+++ b/packages/interface/src/scenes/book/EpubReaderScene.tsx
@@ -1,7 +1,7 @@
 import { Navigate, useParams, useSearchParams } from 'react-router-dom'
 
-import EpubJsReader from '../../../components/readers/epub/EpubJsReader'
-import paths from '../../../paths'
+import EpubJsReader from '../../components/readers/epub/EpubJsReader'
+import paths from '../../paths'
 
 //! NOTE: Only the epub.js reader is supported for now :sob:
 export default function EpubReaderScene() {

--- a/packages/interface/src/scenes/book/PDFReaderScene.tsx
+++ b/packages/interface/src/scenes/book/PDFReaderScene.tsx
@@ -2,11 +2,14 @@ import { useParams } from 'react-router'
 
 import NativePDFViewer from '../../components/readers/pdf/NativePDFViewer'
 
+/**
+ * A scene for reading PDFs using the native PDF viewer in the browser.
+ */
 export default function PDFReaderScene() {
 	const { id } = useParams()
 
 	if (!id) {
-		throw new Error('Media id is required')
+		throw new Error('Media ID is required')
 	}
 
 	return <NativePDFViewer id={id} />

--- a/packages/interface/src/scenes/book/PDFReaderScene.tsx
+++ b/packages/interface/src/scenes/book/PDFReaderScene.tsx
@@ -1,0 +1,13 @@
+import { useParams } from 'react-router'
+
+import NativePDFViewer from '../../components/readers/pdf/NativePDFViewer'
+
+export default function PDFReaderScene() {
+	const { id } = useParams()
+
+	if (!id) {
+		throw new Error('Media id is required')
+	}
+
+	return <NativePDFViewer id={id} />
+}

--- a/packages/interface/src/utils/patterns.ts
+++ b/packages/interface/src/utils/patterns.ts
@@ -1,3 +1,4 @@
 export const ARCHIVE_EXTENSION = /cbr|cbz|zip|rar/
 // export const EBOOK_EXTENSION = /epub|mobi/;
 export const EBOOK_EXTENSION = /epub/
+export const PDF_EXTENSION = /pdf/

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -617,6 +617,9 @@ importers:
       react-swipeable:
         specifier: ^7.0.0
         version: 7.0.0(react@18.2.0)
+      react-window:
+        specifier: ^1.8.9
+        version: 1.8.9(react-dom@18.2.0)(react@18.2.0)
       remark-gfm:
         specifier: ^3.0.1
         version: 3.0.1
@@ -13772,6 +13775,10 @@ packages:
       fs-monkey: 1.0.4
     dev: true
 
+  /memoize-one@5.2.1:
+    resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
+    dev: false
+
   /memoizerific@1.11.3:
     resolution: {integrity: sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==}
     dependencies:
@@ -16617,6 +16624,19 @@ packages:
       react: '>= 18.0.0'
       react-dom: '>= 18.0.0'
     dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /react-window@1.8.9(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-+Eqx/fj1Aa5WnhRfj9dJg4VYATGwIUP2ItwItiJ6zboKWA6EX3lYDAXfGF2hyNqplEprhbtjbipiADEcwQ823Q==}
+    engines: {node: '>8.0.0'}
+    peerDependencies:
+      react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.22.5
+      memoize-one: 5.2.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false

--- a/scripts/lib
+++ b/scripts/lib
@@ -33,3 +33,14 @@ workspaces_sed_correction() {
         sed -i '/apps\/tui/d' Cargo.toml; \
         sed -i '/crates\/prisma-cli/d' Cargo.toml
 }
+
+download_pdfium() {
+    local arch=$1
+    if [ "$arch" = "amd64" ]; then
+        curl -sLo pdfium.tgz https://github.com/bblanchon/pdfium-binaries/releases/chromium/6002/pdfium-linux-x86.tgz
+    elif [ "$arch" = "arm64" ]; then
+        curl -sLo pdfium.tgz https://github.com/bblanchon/pdfium-binaries/releases/download/chromium/6002/pdfium-linux-arm64.tgz
+    fi
+    tar -xzvf pdfium.tgz -C /pdfium
+    rm pdfium.tgz
+}

--- a/scripts/release/Dockerfile.debian
+++ b/scripts/release/Dockerfile.debian
@@ -38,7 +38,6 @@ RUN apt-get update && apt-get install -y \
     pkg-config \
     libsqlite3-dev;
 
-
 COPY . .
 RUN ./scripts/release/build-utils.sh -w;
 
@@ -46,6 +45,29 @@ RUN set -ex; \
     ./scripts/release/build-utils.sh -p; \
     cargo build --package stump_server --bin stump_server --release; \
     cp ./target/release/stump_server ./stump_server
+
+# ------------------------------------------------------------------------------
+# PDFium Stage
+# ------------------------------------------------------------------------------
+
+FROM debian:buster-slim AS pdfium
+ARG TARGETARCH
+
+WORKDIR /
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    tar;
+
+RUN set -ex; \
+    mkdir -p pdfium; \
+    if [ "$TARGETARCH" = "amd64" ]; then \
+        curl -sLo pdfium.tgz https://github.com/bblanchon/pdfium-binaries/releases/chromium/6002/pdfium-linux-x86.tgz; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+        curl -sLo pdfium.tgz https://github.com/bblanchon/pdfium-binaries/releases/download/chromium/6002/pdfium-linux-arm64.tgz; \
+    fi; \
+    tar -xzvf pdfium.tgz -C ./pdfium; \
+    rm pdfium.tgz
 
 # ------------------------------------------------------------------------------
 # Final Stage
@@ -58,17 +80,19 @@ WORKDIR /
 RUN mkdir -p config && mkdir -p data && mkdir -p app
 
 COPY --from=builder /app/stump_server /app/stump
+COPY --from=pdfium /pdfium /lib/pdfium
 COPY --from=frontend /app/build /app/client
 
 COPY scripts/release/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
-
+    
 # Default Stump environment variables
 ENV STUMP_CONFIG_DIR=/config
 ENV STUMP_CLIENT_DIR=/app/client
 ENV STUMP_PROFILE=release
 ENV STUMP_PORT=10801
 ENV STUMP_IN_DOCKER=true
+ENV PDFIUM_PATH=/lib/pdfium
 
 
 ENV API_VERSION=v1

--- a/scripts/release/Dockerfile.debian
+++ b/scripts/release/Dockerfile.debian
@@ -80,11 +80,13 @@ WORKDIR /
 RUN mkdir -p config && mkdir -p data && mkdir -p app
 
 COPY --from=builder /app/stump_server /app/stump
-COPY --from=pdfium /pdfium /lib/pdfium
+COPY --from=pdfium /pdfium /opt/pdfium
 COPY --from=frontend /app/build /app/client
 
 COPY scripts/release/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
+
+RUN ln -s /opt/pdfium/lib/libpdfium.so /lib/libpdfium.so
     
 # Default Stump environment variables
 ENV STUMP_CONFIG_DIR=/config
@@ -92,7 +94,7 @@ ENV STUMP_CLIENT_DIR=/app/client
 ENV STUMP_PROFILE=release
 ENV STUMP_PORT=10801
 ENV STUMP_IN_DOCKER=true
-ENV PDFIUM_PATH=/lib/pdfium
+ENV PDFIUM_PATH=/lib/libpdfium.so
 
 
 ENV API_VERSION=v1

--- a/scripts/release/Dockerfile.debian
+++ b/scripts/release/Dockerfile.debian
@@ -62,7 +62,7 @@ RUN apt-get update && apt-get install -y \
 RUN set -ex; \
     mkdir -p pdfium; \
     if [ "$TARGETARCH" = "amd64" ]; then \
-        curl -sLo pdfium.tgz https://github.com/bblanchon/pdfium-binaries/releases/chromium/6002/pdfium-linux-x86.tgz; \
+        curl -sLo pdfium.tgz https://github.com/bblanchon/pdfium-binaries/releases/download/chromium/6002/pdfium-linux-x86.tgz; \
     elif [ "$TARGETARCH" = "arm64" ]; then \
         curl -sLo pdfium.tgz https://github.com/bblanchon/pdfium-binaries/releases/download/chromium/6002/pdfium-linux-arm64.tgz; \
     fi; \

--- a/scripts/release/build-docker.sh
+++ b/scripts/release/build-docker.sh
@@ -6,4 +6,4 @@ TAG=${3:-nightly}
 GIT_REV=$(git rev-parse --short HEAD)
 
 # docker buildx build -f ./scripts/release/Dockerfile --load --progress=$FORMAT --platform=$PLATFORMS -t aaronleopold/stump:$TAG --build-arg GIT_REV=$GIT_REV .
-docker buildx build -f ./scripts/release/Dockerfile.debian --progress=$FORMAT --platform=$PLATFORMS -t aaronleopold/stump-debian:$TAG --build-arg GIT_REV=$GIT_REV .
+docker buildx build -f ./scripts/release/Dockerfile.debian --load --progress=$FORMAT --platform=$PLATFORMS -t aaronleopold/stump:$TAG --build-arg GIT_REV=$GIT_REV .

--- a/scripts/release/build-utils.sh
+++ b/scripts/release/build-utils.sh
@@ -3,7 +3,8 @@
 SCRIPTS_DIR="${BASH_SOURCE%/*}/.."
 source "${SCRIPTS_DIR}/lib"
 
-while getopts "pwd:" opt; do
+# TODO: use words instead...
+while getopts "pwdg:" opt; do
   case $opt in
     p)
       prisma_sed_correction
@@ -15,6 +16,11 @@ while getopts "pwd:" opt; do
       path="$OPTARG"
       echo "The path provided is $OPTARG"
       create_dummy_rust_file $path
+    ;;
+    g)
+      arch="$OPTARG"
+      echo "The arch provided is $OPTARG"
+      download_pdfium $arch
     ;;
     ?) 
       echo "Invalid option -$OPTARG" >&2


### PR DESCRIPTION
Resolves https://github.com/stumpapp/stump/issues/35

With these changes, PDFs are mostly supported:
- PDFs can be scanned, and metadata (if any) can be extracted
- PDFs can have generated thumbnails
- PDF pages can be streamed
- PDF files can be sent to the client for download and/or viewed in a native PDF viewer

This pulls in two additional libraries in the core:

1. `pdf`
2. `pdfium-render`

The `pdfium-render` allows the core to properly process PDF pages as images. However it should be noted the concerns brought up from https://github.com/stumpapp/stump/issues/156#issuecomment-1712655256. I think, considering how few options there are, this will just have to be tried and tested over time.

There are some areas that need improvements, but I will follow up with them at another time:
- PDF page streaming will **only** output PNG images for the time being. This is hard coded, but will be replaced with some sort of option to configure it
- I added basic PDF-to-ZIP conversion support in the core, but am not hooking it up with UI elements yet. I'll leave that for the dedicated ticket for that feature.