### PR TITLE
feat: add support for arrow key navigation

### DIFF
--- a/packages/interface/src/components/readers/epub/EpubJsReader.tsx
+++ b/packages/interface/src/components/readers/epub/EpubJsReader.tsx
@@ -1,3 +1,5 @@
+import test from 'node:test'
+
 import { API, updateEpubProgress } from '@stump/api'
 import {
 	type EpubReaderPreferences,
@@ -168,6 +170,24 @@ export default function EpubJsReader({ id, initialCfi }: EpubJsReaderProps) {
 					//* Color manipulation reference: https://github.com/futurepress/epub.js/issues/1019
 					rendition_.themes.register('stump-dark', stumpDark)
 					rendition_.on('relocated', handleLocationChange)
+
+					// This callback is used to change the page when a keydown
+					// event is recieved.
+					const keydown_callback = (event: KeyboardEvent) => {
+						// Check arrow keys
+						if (event.key == 'ArrowLeft') {
+							rendition_.prev()
+						}
+						if (event.key == 'ArrowRight') {
+							rendition_.next()
+						}
+					}
+					// The rendition fires the event when the epub page is in focus
+					rendition_.on('keydown', keydown_callback)
+					// The window should fire the event when the epub page isn't in focus
+					// However turning the page doesn't work, possibly because
+					// rendition.start() hasn't been called yet?
+					window.addEventListener('keydown', keydown_callback)
 
 					applyEpubPreferences(rendition_, epubPreferences)
 					setRendition(rendition_)

--- a/packages/interface/src/components/readers/epub/EpubJsReader.tsx
+++ b/packages/interface/src/components/readers/epub/EpubJsReader.tsx
@@ -1,5 +1,3 @@
-import test from 'node:test'
-
 import { API, updateEpubProgress } from '@stump/api'
 import {
 	type EpubReaderPreferences,

--- a/packages/interface/src/components/readers/epub/EpubJsReader.tsx
+++ b/packages/interface/src/components/readers/epub/EpubJsReader.tsx
@@ -169,8 +169,7 @@ export default function EpubJsReader({ id, initialCfi }: EpubJsReaderProps) {
 					rendition_.themes.register('stump-dark', stumpDark)
 					rendition_.on('relocated', handleLocationChange)
 
-					// This callback is used to change the page when a keydown
-					// event is recieved.
+					// This callback is used to change the page when a keydown event is recieved.
 					const keydown_callback = (event: KeyboardEvent) => {
 						// Check arrow keys
 						if (event.key == 'ArrowLeft') {
@@ -180,11 +179,9 @@ export default function EpubJsReader({ id, initialCfi }: EpubJsReaderProps) {
 							rendition_.next()
 						}
 					}
-					// The rendition fires the event when the epub page is in focus
+					// The rendition fires keydown events when the epub page is in focus
 					rendition_.on('keydown', keydown_callback)
-					// The window should fire the event when the epub page isn't in focus
-					// However turning the page doesn't work, possibly because
-					// rendition.start() hasn't been called yet?
+					// When the epub page isn't in focus, the window fires them instead
 					window.addEventListener('keydown', keydown_callback)
 
 					applyEpubPreferences(rendition_, epubPreferences)

--- a/packages/interface/src/scenes/book/BookReaderScene.tsx
+++ b/packages/interface/src/scenes/book/BookReaderScene.tsx
@@ -38,33 +38,6 @@ export default function BookReaderScene() {
 		}
 	}, [])
 
-	/**
-	 * An effect to allow handling key down events so that navigation can be done when
-	 * the left and right arrow keys are pressed.
-	 */
-	useEffect(() => {
-		function handleKeyDown(event: KeyboardEvent) {
-			if (!page || !media) return
-
-			const currentPage = parseInt(page, 10)
-
-			// Check arrow keys
-			if (event.key == 'ArrowLeft' && currentPage > 1) {
-				handleChangePage(currentPage - 1)
-			}
-			if (event.key == 'ArrowRight' && currentPage < media.pages) {
-				handleChangePage(currentPage + 1)
-			}
-		}
-
-		// Add event listener
-		window.addEventListener('keydown', handleKeyDown)
-		// Remove listener on unmount
-		return () => {
-			window.removeEventListener('keydown', handleKeyDown)
-		}
-	})
-
 	function handleChangePage(newPage: number) {
 		updateReadProgress(newPage)
 		navigate(paths.bookReader(id!, { isAnimated, page: newPage }))

--- a/packages/interface/src/scenes/book/BookReaderScene.tsx
+++ b/packages/interface/src/scenes/book/BookReaderScene.tsx
@@ -38,6 +38,33 @@ export default function BookReaderScene() {
 		}
 	}, [])
 
+	/**
+	 * An effect to allow handling key down events so that navigation can be done when
+	 * the left and right arrow keys are pressed.
+	 */
+	useEffect(() => {
+		function handleKeyDown(event: KeyboardEvent) {
+			if (!page || !media) return
+
+			const currentPage = parseInt(page, 10)
+
+			// Check arrow keys
+			if (event.key == 'ArrowLeft' && currentPage > 1) {
+				handleChangePage(currentPage - 1)
+			}
+			if (event.key == 'ArrowRight' && currentPage < media.pages) {
+				handleChangePage(currentPage + 1)
+			}
+		}
+
+		// Add event listener
+		window.addEventListener('keydown', handleKeyDown)
+		// Remove listener on unmount
+		return () => {
+			window.removeEventListener('keydown', handleKeyDown)
+		}
+	})
+
 	function handleChangePage(newPage: number) {
 		updateReadProgress(newPage)
 		navigate(paths.bookReader(id!, { isAnimated, page: newPage }))


### PR DESCRIPTION
This pull request is a response to issue #123, which requested the left/right arrow keys be usable for previous/next page navigation when reading books.

I implemented this with a new effect in BookReaderScene.tsx which adds a keydown listener and navigates on `ArrowLeft` and `ArrowLeft` if the current page isn't the first/last page.

Happy to make any changes needed, I'm less familiar with React so I may not have done this the ideal way.