### PR TITLE
🐛 Fix no server owner after migration

### DIFF
--- a/crates/cli/src/commands/account.rs
+++ b/crates/cli/src/commands/account.rs
@@ -220,9 +220,14 @@ async fn change_server_owner() -> CliResult<()> {
 		client
 			.user()
 			.update(
-				user::id::equals(user.id),
+				user::id::equals(user.id.clone()),
 				vec![user::is_server_owner::set(false)],
 			)
+			.exec()
+			.await?;
+		client
+			.session()
+			.delete_many(vec![session::user_id::equals(user.id)])
 			.exec()
 			.await?;
 	}
@@ -231,9 +236,14 @@ async fn change_server_owner() -> CliResult<()> {
 	client
 		.user()
 		.update(
-			user::id::equals(target_user.id),
+			user::id::equals(target_user.id.clone()),
 			vec![user::is_server_owner::set(true)],
 		)
+		.exec()
+		.await?;
+	client
+		.session()
+		.delete_many(vec![session::user_id::equals(target_user.id)])
 		.exec()
 		.await?;
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -20,18 +20,3 @@ pub struct Cli {
 	#[command(subcommand)]
 	pub command: Option<Commands>,
 }
-
-// # start the server
-// $ ./server
-
-// # unlock an account
-// $ ./server account lock --username <username>
-
-// # freeze an account
-// $ ./server account unlock --username <username>
-
-// # list all frozen accounts
-// $ ./server account list --locked
-
-// # reset password for a user
-// $ ./server account reset-password --username <username>

--- a/packages/interface/src/AppRouter.tsx
+++ b/packages/interface/src/AppRouter.tsx
@@ -27,7 +27,7 @@ const ServerConnectionErrorScene = lazily(
 )
 const LoginOrClaimScene = lazily(() => import('./scenes/auth/LoginOrClaimScene.tsx'))
 
-const IS_DEVELOPMENT = import.meta.env.DEV
+const IS_DEVELOPMENT = import.meta.env.MODE === 'development'
 
 export function AppRouter() {
 	const appProps = useAppProps()

--- a/packages/interface/src/components/ApplicationVersion.tsx
+++ b/packages/interface/src/components/ApplicationVersion.tsx
@@ -31,7 +31,7 @@ export default function ApplicationVersion() {
 		>
 			<span>
 				v{version.semver}
-				{!!version.rev && `- ${version.rev}`}
+				{!!version.rev && ` - ${version.rev}`}
 			</span>
 		</Link>
 	)

--- a/packages/interface/src/components/ApplicationVersion.tsx
+++ b/packages/interface/src/components/ApplicationVersion.tsx
@@ -19,6 +19,8 @@ export default function ApplicationVersion() {
 		}
 	}, [version])
 
+	if (!version) return null
+
 	return (
 		<Link
 			href={url}
@@ -28,7 +30,8 @@ export default function ApplicationVersion() {
 			underline={false}
 		>
 			<span>
-				v{version?.semver} - {version?.rev}
+				v{version.semver}
+				{!!version.rev && `- ${version.rev}`}
 			</span>
 		</Link>
 	)


### PR DESCRIPTION
The migration from https://github.com/stumpapp/stump/pull/186 causes the server owner status to not be reassigned after removing the old representation, so you'd have no server owner afterwards. To remedy this, I've added a new CLI command to assign a user the server owner status:

```bash
./stump account reset-owner
```

If you have direct database access you can of course just flip the boolean value of `is_server_owner` manually