### PR TITLE
:bug: Attempt to unset invalid or otherwise bad cookies

### DIFF
--- a/apps/server/src/config/session/mod.rs
+++ b/apps/server/src/config/session/mod.rs
@@ -4,5 +4,5 @@ mod utils;
 pub use store::{PrismaSessionStore, SessionError, SessionResult};
 pub use utils::{
 	get_session_expiry_cleanup_interval, get_session_layer, get_session_ttl,
-	SESSION_USER_KEY,
+	handle_session_service_error, SESSION_USER_KEY,
 };

--- a/apps/server/src/config/session/utils.rs
+++ b/apps/server/src/config/session/utils.rs
@@ -1,3 +1,9 @@
+use axum::{
+	body::BoxBody,
+	response::{IntoResponse, Response},
+	BoxError,
+};
+use hyper::StatusCode;
 use std::{env, sync::Arc};
 use stump_core::prisma::PrismaClient;
 use time::Duration;
@@ -7,6 +13,8 @@ use tower_sessions::{cookie::SameSite, SessionManagerLayer};
 use super::store::PrismaSessionStore;
 
 pub const SESSION_USER_KEY: &str = "user";
+pub const SESSION_NAME: &str = "stump_session";
+pub const SESSION_PATH: &str = "/";
 
 pub fn get_session_ttl() -> i64 {
 	env::var("SESSION_TTL")
@@ -47,9 +55,32 @@ pub fn get_session_layer(
 
 	// TODO: This configuration won't work for Tauri Windows app, it requires SameSite::None and Secure=true... Linux and macOS work fine.
 	SessionManagerLayer::new(store)
-		.with_name("stump_session")
+		.with_name(SESSION_NAME)
 		.with_max_age(Duration::seconds(session_ttl))
-		.with_path("/".to_string())
+		.with_path(SESSION_PATH.to_string())
 		.with_same_site(SameSite::Lax)
 		.with_secure(false)
+}
+
+/// Handle a session service error. This will be called when the session service returns an error, and will
+/// attempt to encourage the client to delete their Stump session cookie.
+pub async fn handle_session_service_error(err: BoxError) -> impl IntoResponse {
+	tracing::error!("Failed to handle session: {:?}", err);
+	// We want to ecourage the client to delete their cookies automatically via response headers in the event
+	// that the cookie is just invalid. To do this, we'll just set the cookie on the same name, path and domain,
+	// but with an Expires value in the past. This *should* cause the client to delete the cookie.
+	Response::builder()
+		.status(StatusCode::BAD_REQUEST)
+		.header(
+			"Set-Cookie",
+			format!(
+				"{}={}; Path={}; Domain={}; Expires={}; Max-Age=0",
+				SESSION_NAME, "", SESSION_PATH, "", "Thu, 01 Jan 1970 00:00:00 GMT"
+			),
+		)
+		.body(BoxBody::default())
+		.unwrap_or_else(|e| {
+			tracing::error!(error = ?e, "Failed to build response");
+			StatusCode::INTERNAL_SERVER_ERROR.into_response()
+		})
 }

--- a/apps/server/src/http_server.rs
+++ b/apps/server/src/http_server.rs
@@ -1,14 +1,17 @@
 use std::net::SocketAddr;
 
 use axum::{error_handling::HandleErrorLayer, extract::connect_info::Connected, Router};
-use hyper::{server::conn::AddrStream, StatusCode};
+use hyper::server::conn::AddrStream;
 use stump_core::{event::InternalCoreTask, StumpCore};
 use tokio::sync::oneshot;
-use tower::{BoxError, ServiceBuilder};
+use tower::ServiceBuilder;
 use tower_http::trace::TraceLayer;
 
 use crate::{
-	config::{cors, session},
+	config::{
+		cors,
+		session::{self, handle_session_service_error},
+	},
 	errors::{ServerError, ServerResult},
 	routers,
 	utils::shutdown_signal_with_cleanup,
@@ -44,10 +47,7 @@ pub(crate) async fn run_http_server(port: u16) -> ServerResult<()> {
 	tracing::info!("{}", core.get_shadow_text());
 
 	let session_service = ServiceBuilder::new()
-		.layer(HandleErrorLayer::new(|err: BoxError| async move {
-			tracing::error!("Failed to handle session: {:?}", err);
-			StatusCode::BAD_REQUEST
-		}))
+		.layer(HandleErrorLayer::new(handle_session_service_error))
 		.layer(session::get_session_layer(app_state.db.clone()));
 
 	let app = Router::new()


### PR DESCRIPTION
Extend the session service error handler with a proper response that will set the appropriate headers to encourage the client to remove Stump cookies