### PR TITLE
:art: Session cleanup as queueable job

### DIFF
--- a/apps/server/src/config/session/cleanup.rs
+++ b/apps/server/src/config/session/cleanup.rs
@@ -1,0 +1,41 @@
+use prisma_client_rust::chrono::Utc;
+use stump_core::{
+	job::{Job, JobError, JobTrait, WorkerCtx},
+	prisma::session,
+};
+
+pub const SESSION_CLEANUP_JOB_NAME: &str = "session_cleanup";
+
+pub struct SessionCleanupJob;
+
+impl SessionCleanupJob {
+	pub fn new() -> Box<Job<SessionCleanupJob>> {
+		Job::new(Self)
+	}
+}
+
+#[async_trait::async_trait]
+impl JobTrait for SessionCleanupJob {
+	fn name(&self) -> &'static str {
+		SESSION_CLEANUP_JOB_NAME
+	}
+
+	fn description(&self) -> Option<Box<&str>> {
+		None
+	}
+
+	async fn run(&mut self, ctx: WorkerCtx) -> Result<u64, JobError> {
+		tracing::trace!("Deleting expired sessions");
+
+		let client = ctx.core_ctx.db.clone();
+		let affected_rows = client
+			.session()
+			.delete_many(vec![session::expires_at::lt(Utc::now().into())])
+			.exec()
+			.await?;
+
+		tracing::trace!(affected_rows = ?affected_rows, "Deleted expired sessions");
+
+		Ok(1)
+	}
+}

--- a/apps/server/src/config/session/mod.rs
+++ b/apps/server/src/config/session/mod.rs
@@ -1,7 +1,9 @@
+mod cleanup;
 mod store;
 mod utils;
 
-pub use store::{PrismaSessionStore, SessionError, SessionResult};
+pub use cleanup::SessionCleanupJob;
+pub use store::{PrismaSessionStore, SessionError};
 pub use utils::{
 	get_session_expiry_cleanup_interval, get_session_layer, get_session_ttl,
 	handle_session_service_error, SESSION_USER_KEY,

--- a/apps/server/src/http_server.rs
+++ b/apps/server/src/http_server.rs
@@ -48,7 +48,7 @@ pub(crate) async fn run_http_server(port: u16) -> ServerResult<()> {
 
 	let session_service = ServiceBuilder::new()
 		.layer(HandleErrorLayer::new(handle_session_service_error))
-		.layer(session::get_session_layer(app_state.db.clone()));
+		.layer(session::get_session_layer(app_state.clone()));
 
 	let app = Router::new()
 		.merge(routers::mount(app_state.clone()))


### PR DESCRIPTION
In an effort to reduce the liklihood of multiple DB writers at a given time, I made the session cleanup task a job. This way, it has to be queued before it can do its thing and potentially interfere with scans.

I also bumped the default interval from every minute to every 24 hours