### PR TITLE
Modify scripts to support building on windows

### DIFF
--- a/scripts/lib
+++ b/scripts/lib
@@ -22,7 +22,11 @@ create_dummy_rust_file() {
 # it's a bit of a hack, but it works lol
 prisma_sed_correction() {
     set -ex; \
-        sed -i 's|\/.*\/core\/prisma\/schema.prisma|\/app\/core\/prisma\/schema.prisma|g' core/src/prisma.rs; \
+        # Match windows paths
+        sed -i 's|[A-Z]:\\\\.*\\\\core\\\\prisma\\\\schema\.prisma|\/app\/core\/prisma\/schema.prisma|g' core/src/prisma.rs; \
+        sed -i 's|[A-Z]:\\\\.*\\\\core\\\\prisma\\\\migrations|\/app\/core\/prisma\/migrations|g' core/src/prisma.rs; \
+        # Match Unix paths
+        sed -i 's|\/.*\/core\/prisma\/schema\.prisma|\/app\/core\/prisma\/schema.prisma|g' core/src/prisma.rs; \
         sed -i 's|\/.*\/core\/prisma\/migrations|\/app\/core\/prisma\/migrations|g' core/src/prisma.rs
 }
 

--- a/scripts/release/build-docker.ps1
+++ b/scripts/release/build-docker.ps1
@@ -1,0 +1,16 @@
+# Set default values for arguments if they are not provided
+$FORMAT = if ($args[0]) { $args[0] } else { "auto" }
+$PLATFORMS = if ($args[1]) { $args[1] } else { "linux/amd64" }
+$TAG = if ($args[2]) { $args[2] } else { "nightly" }
+
+# Get the current Git revision
+$GIT_REV = git rev-parse --short HEAD
+
+# Build the Docker image
+docker buildx build `
+    -f ./scripts/release/Dockerfile.debian `
+    --load `
+    --progress=$FORMAT `
+    --platform=$PLATFORMS `
+    -t aaronleopold/stump:$TAG `
+    --build-arg GIT_REV=$GIT_REV .


### PR DESCRIPTION
Added a Power Shell version of ./scripts/release/build-docker.sh and changed ./scripts/lib to support windows paths in prisma.rs, making it easier for Windows developers to build the Docker container locally.