### PR TITLE
:bug: Render `SmartListRouter` outside of development

### DIFF
--- a/interface/src/AppRouter.tsx
+++ b/interface/src/AppRouter.tsx
@@ -50,7 +50,7 @@ export function AppRouter() {
 					<Route path="series/*" element={<SeriesRouter />} />
 					<Route path="books/*" element={<BookRouter />} />
 					{IS_DEVELOPMENT && <Route path="book-clubs/*" element={<BookClubRouter />} />}
-					{IS_DEVELOPMENT && <Route path="/smart-lists/*" element={<SmartListRouter />} />}
+					<Route path="/smart-lists/*" element={<SmartListRouter />} />
 					<Route path="settings/*" element={<SettingsRouter />} />
 				</Route>
 


### PR DESCRIPTION
Accidentally left the conditional rendering on the last PR, this removes it so you can access the smart list pages