### PR TITLE
🐛 Fix opening RAR files with unicode characters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4444,8 +4444,8 @@ dependencies = [
 
 [[package]]
 name = "prisma-client-rust"
-version = "0.6.10"
-source = "git+https://github.com/Brendonovich/prisma-client-rust.git?tag=0.6.10#948642d876c342f5925695bc3e487df6a02af9b2"
+version = "0.6.11"
+source = "git+https://github.com/Brendonovich/prisma-client-rust.git?tag=0.6.11#3ac68d0052533d3ae0332d93a56a8ad169c2ee18"
 dependencies = [
  "base64 0.13.1",
  "bigdecimal",
@@ -4478,8 +4478,8 @@ dependencies = [
 
 [[package]]
 name = "prisma-client-rust-cli"
-version = "0.6.10"
-source = "git+https://github.com/Brendonovich/prisma-client-rust.git?tag=0.6.10#948642d876c342f5925695bc3e487df6a02af9b2"
+version = "0.6.11"
+source = "git+https://github.com/Brendonovich/prisma-client-rust.git?tag=0.6.11#3ac68d0052533d3ae0332d93a56a8ad169c2ee18"
 dependencies = [
  "directories",
  "flate2",
@@ -4498,8 +4498,8 @@ dependencies = [
 
 [[package]]
 name = "prisma-client-rust-macros"
-version = "0.6.10"
-source = "git+https://github.com/Brendonovich/prisma-client-rust.git?tag=0.6.10#948642d876c342f5925695bc3e487df6a02af9b2"
+version = "0.6.11"
+source = "git+https://github.com/Brendonovich/prisma-client-rust.git?tag=0.6.11#3ac68d0052533d3ae0332d93a56a8ad169c2ee18"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -4509,8 +4509,8 @@ dependencies = [
 
 [[package]]
 name = "prisma-client-rust-sdk"
-version = "0.6.10"
-source = "git+https://github.com/Brendonovich/prisma-client-rust.git?tag=0.6.10#948642d876c342f5925695bc3e487df6a02af9b2"
+version = "0.6.11"
+source = "git+https://github.com/Brendonovich/prisma-client-rust.git?tag=0.6.11#3ac68d0052533d3ae0332d93a56a8ad169c2ee18"
 dependencies = [
  "convert_case 0.5.0",
  "dml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3022,9 +3022,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "libdbus-sys"
@@ -6024,6 +6024,7 @@ dependencies = [
  "image",
  "infer 0.15.0",
  "itertools 0.12.0",
+ "libc",
  "pdf",
  "pdfium-render",
  "prisma-client-rust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,13 @@ rust-version = "1.72.1"
 async-trait = "0.1.74"
 async-stream = "0.3.5"
 bcrypt = "0.15.0"
-prisma-client-rust = { git = "https://github.com/Brendonovich/prisma-client-rust.git", tag = "0.6.10", features = [
+prisma-client-rust = { git = "https://github.com/Brendonovich/prisma-client-rust.git", tag = "0.6.11", features = [
   "sqlite-create-many",
   "migrations",
   "sqlite",
   "mocking"
 ], default-features = false }
-prisma-client-rust-cli = { git = "https://github.com/Brendonovich/prisma-client-rust.git", tag = "0.6.10", features = [
+prisma-client-rust-cli = { git = "https://github.com/Brendonovich/prisma-client-rust.git", tag = "0.6.11", features = [
   "sqlite-create-many",
   "migrations",
   "sqlite",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -56,3 +56,6 @@ tempfile = { workspace = true }
 
 [build-dependencies]
 chrono = "0.4.31"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = "0.2.152"

--- a/core/src/filesystem/media/rar.rs
+++ b/core/src/filesystem/media/rar.rs
@@ -33,6 +33,8 @@ impl RarProcessor {
 		{
 			let locale =
 				std::env::var("LIBC_LOCALE").unwrap_or_else(|_| "en_US.utf8".to_string());
+			tracing::debug!(?locale, "Setting locale for unrar");
+
 			let locale =
 				std::ffi::CString::new(locale).expect("Failed to convert locale!");
 			unsafe { libc::setlocale(libc::LC_ALL, locale.as_ptr()) };

--- a/core/src/filesystem/media/rar.rs
+++ b/core/src/filesystem/media/rar.rs
@@ -5,7 +5,7 @@ use std::{
 	path::{Path, PathBuf},
 };
 use tracing::{debug, error, trace, warn};
-use unrar::Archive;
+use unrar::{Archive, CursorBeforeHeader, List, OpenArchive, Process, UnrarResult};
 
 use crate::{
 	config::StumpConfig,
@@ -25,6 +25,34 @@ use super::{process::FileConverter, FileProcessor, FileProcessorOptions, Process
 
 /// A file processor for RAR files.
 pub struct RarProcessor;
+
+impl RarProcessor {
+	fn init() {
+		// See https://github.com/muja/unrar.rs/issues/44
+		#[cfg(target_os = "linux")]
+		{
+			let locale =
+				std::env::var("LIBC_LOCALE").unwrap_or_else(|_| "en_US.utf8".to_string());
+			let locale =
+				std::ffi::CString::new(locale).expect("Failed to convert locale!");
+			unsafe { libc::setlocale(libc::LC_ALL, locale.as_ptr()) };
+		}
+	}
+
+	fn open_for_processing(
+		path: &str,
+	) -> UnrarResult<OpenArchive<Process, CursorBeforeHeader>> {
+		Self::init();
+		Archive::new(path).open_for_processing()
+	}
+
+	fn open_for_listing(
+		path: &str,
+	) -> UnrarResult<OpenArchive<List, CursorBeforeHeader>> {
+		Self::init();
+		Archive::new(path).open_for_listing()
+	}
+}
 
 impl FileProcessor for RarProcessor {
 	fn get_sample_size(path: &str) -> Result<u64, FileError> {
@@ -88,7 +116,7 @@ impl FileProcessor for RarProcessor {
 
 		let hash: Option<String> = RarProcessor::hash(path);
 
-		let mut archive = Archive::new(&path).open_for_processing()?;
+		let mut archive = RarProcessor::open_for_processing(path)?;
 		let mut pages = 0;
 		let mut metadata_buf = None;
 
@@ -125,7 +153,7 @@ impl FileProcessor for RarProcessor {
 		page: i32,
 		_: &StumpConfig,
 	) -> Result<(ContentType, Vec<u8>), FileError> {
-		let archive = Archive::new(file).open_for_listing()?;
+		let archive = RarProcessor::open_for_listing(file)?;
 
 		let mut valid_entries = archive
 			.into_iter()
@@ -151,7 +179,7 @@ impl FileProcessor for RarProcessor {
 			.ok_or(FileError::RarReadError)?;
 
 		let mut bytes = None;
-		let mut archive = Archive::new(file).open_for_processing()?;
+		let mut archive = RarProcessor::open_for_processing(file)?;
 		while let Ok(Some(header)) = archive.read_header() {
 			let is_target =
 				header.entry().filename.as_os_str() == target_entry.filename.as_os_str();
@@ -164,15 +192,25 @@ impl FileProcessor for RarProcessor {
 			}
 		}
 
-		// TODO: don't hard code content type!
-		Ok((ContentType::JPEG, bytes.ok_or(FileError::NoImageError)?))
+		let content_type = if let Some(bytes) = &bytes {
+			if bytes.len() < 5 {
+				return Err(FileError::NoImageError);
+			}
+			let mut magic_header = [0; 5];
+			magic_header.copy_from_slice(&bytes[0..5]);
+			ContentType::from_bytes(&magic_header)
+		} else {
+			ContentType::UNKNOWN
+		};
+
+		Ok((content_type, bytes.ok_or(FileError::NoImageError)?))
 	}
 
 	fn get_page_content_types(
 		path: &str,
 		pages: Vec<i32>,
 	) -> Result<HashMap<i32, ContentType>, FileError> {
-		let archive = Archive::new(path).open_for_listing()?;
+		let archive = RarProcessor::open_for_listing(path)?;
 
 		let entries = archive
 			.into_iter()
@@ -194,7 +232,7 @@ impl FileProcessor for RarProcessor {
 			.collect::<HashMap<_, _>>();
 
 		let mut content_types = HashMap::new();
-		let mut archive = Archive::new(path).open_for_processing()?;
+		let mut archive = RarProcessor::open_for_processing(path)?;
 		while let Ok(Some(header)) = archive.read_header() {
 			archive = if let Some(tuple) =
 				entries.get_key_value(&PathBuf::from(header.entry().filename.as_os_str()))
@@ -248,7 +286,7 @@ impl FileConverter for RarProcessor {
 
 		trace!(?unpacked_path, "Extracting RAR to cache");
 
-		let mut archive = Archive::new(path).open_for_processing()?;
+		let mut archive = RarProcessor::open_for_processing(path)?;
 		while let Ok(Some(header)) = archive.read_header() {
 			archive = if header.entry().is_file() {
 				header.extract_to(&unpacked_path)?

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -76,6 +76,8 @@ RUN set -ex; \
 
 FROM debian:buster-slim
 
+RUN apt-get update && apt-get install -y locales-all
+
 WORKDIR /
 
 RUN mkdir -p config && mkdir -p data && mkdir -p app

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -76,7 +76,7 @@ RUN set -ex; \
 
 FROM debian:buster-slim
 
-RUN apt-get update && apt-get install -y locales-all
+RUN apt-get update && apt-get install -y locales-all && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /
 


### PR DESCRIPTION
PR fixes an issue that caused `unrar` to error when encountering unicode characters in the file name

- Pull in `libc` as Linux-only dep
- Explicitly set the locale before interacting with RAR files (when OS is Linux)