### PR TITLE
:arrow_down: Downgrade `react-hook-form` to `7.47.0` (#316)

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -39,7 +39,7 @@
 		"react-dropzone": "^14.2.3",
 		"react-error-boundary": "^4.0.13",
 		"react-helmet": "^6.1.0",
-		"react-hook-form": "^7.51.3",
+		"react-hook-form": "=7.47.0",
 		"react-hot-toast": "^2.4.1",
 		"react-hotkeys-hook": "^4.5.0",
 		"react-i18next": "^14.1.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -48,7 +48,7 @@
 		"react": "^18.2.0",
 		"react-day-picker": "^8.10.0",
 		"react-dom": "^18.2.0",
-		"react-hook-form": "^7.51.3",
+		"react-hook-form": "=7.47.0",
 		"react-router": "^6.22.3",
 		"react-router-dom": "^6.22.3",
 		"tailwind-merge": "^1.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16253,15 +16253,15 @@ react-helmet@^6.1.0:
     react-fast-compare "^3.1.1"
     react-side-effect "^2.1.0"
 
+react-hook-form@=7.47.0:
+  version "7.47.0"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.47.0.tgz#a42f07266bd297ddf1f914f08f4b5f9783262f31"
+  integrity sha512-F/TroLjTICipmHeFlMrLtNLceO2xr1jU3CyiNla5zdwsGUGu2UOxxR4UyJgLlhMwLW/Wzp4cpJ7CPfgJIeKdSg==
+
 react-hook-form@^7.50.1:
   version "7.50.1"
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.50.1.tgz#f6aeb17a863327e5a0252de8b35b4fc8990377ed"
   integrity sha512-3PCY82oE0WgeOgUtIr3nYNNtNvqtJ7BZjsbxh6TnYNbXButaD5WpjOmTjdxZfheuHKR68qfeFnEDVYoSSFPMTQ==
-
-react-hook-form@^7.51.3:
-  version "7.51.3"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.51.3.tgz#7486dd2d52280b6b28048c099a98d2545931cab3"
-  integrity sha512-cvJ/wbHdhYx8aviSWh28w9ImjmVsb5Y05n1+FW786vEZQJV5STNM0pW6ujS+oiBecb0ARBxJFyAnXj9+GHXACQ==
 
 react-hot-toast@^2.4.1:
   version "2.4.1"


### PR DESCRIPTION
Relates to #315