### PR TITLE
:bug: Fix inverted swipe handlers in EPUB reader

### DIFF
--- a/packages/browser/src/components/readers/epub/EpubReaderHeader.tsx
+++ b/packages/browser/src/components/readers/epub/EpubReaderHeader.tsx
@@ -14,6 +14,8 @@ import {
 } from './controls'
 import { LocationManager } from './locations'
 
+// TODO(UX): gather feedback on the header design. I am worried the actionable items are too small on
+// mobile devices.
 export default function EpubReaderHeader() {
 	const {
 		readerMeta: { bookEntity },

--- a/packages/browser/src/components/readers/epub/controls/EpubNavigationControls.tsx
+++ b/packages/browser/src/components/readers/epub/controls/EpubNavigationControls.tsx
@@ -11,8 +11,6 @@ type Props = {
 	children: React.ReactNode
 }
 
-// TODO: allow config to hide the icons, this will allow for a less intrusive reading experience IMO without
-// sacrificing accessibility for those who want the icon always visible
 export default function EpubNavigationControls({ children }: Props) {
 	const { visible, onPaginateBackward, onPaginateForward, setVisible } = useEpubReaderControls()
 
@@ -22,7 +20,14 @@ export default function EpubNavigationControls({ children }: Props) {
 
 	const invertControls = readingDirection === 'rtl'
 
-	const onLeftNavigate = useCallback(() => {
+	/**
+	 * A callback to navigate backward in the book, wrt the natural reading
+	 * progression direction.
+	 *
+	 * If the reading direction is RTL, then the backward navigation is actually
+	 * forward in the book.
+	 */
+	const onBackwardNavigation = useCallback(() => {
 		if (invertControls) {
 			onPaginateForward()
 		} else {
@@ -30,7 +35,14 @@ export default function EpubNavigationControls({ children }: Props) {
 		}
 	}, [invertControls, onPaginateBackward, onPaginateForward])
 
-	const onRightNavigate = useCallback(() => {
+	/**
+	 * A callback to navigate forward in the book, wrt the natural reading
+	 * progression direction.
+	 *
+	 * If the reading direction is RTL, then the forward navigation is actually
+	 * backwards in the book.
+	 */
+	const onForwardNavigation = useCallback(() => {
 		if (invertControls) {
 			onPaginateBackward()
 		} else {
@@ -38,16 +50,21 @@ export default function EpubNavigationControls({ children }: Props) {
 		}
 	}, [invertControls, onPaginateBackward, onPaginateForward])
 
+	/**
+	 * A swipe handler to navigate forward or backward in the book.
+	 *
+	 * Note that the swip handler function semantics are inverted wrt the reading direction.
+	 */
 	const swipeHandlers = useSwipeable({
-		onSwipedLeft: onLeftNavigate,
-		onSwipedRight: onRightNavigate,
+		onSwipedLeft: onForwardNavigation,
+		onSwipedRight: onBackwardNavigation,
 		preventScrollOnSwipe: true,
 	})
 
 	return (
 		<div className="relative flex h-full w-full flex-1 items-center gap-1" aria-hidden="true">
 			<div className="fixed left-2 z-[100] hidden h-1/2 w-12 items-center md:flex">
-				<ControlButton className={cx({ hidden: !visible })} onClick={onLeftNavigate}>
+				<ControlButton className={cx({ hidden: !visible })} onClick={onBackwardNavigation}>
 					<ChevronLeft className="h-5 w-5" />
 				</ControlButton>
 			</div>
@@ -58,7 +75,7 @@ export default function EpubNavigationControls({ children }: Props) {
 			/>
 			{children}
 			<div className="fixed right-2 z-[100] hidden h-1/2 w-12 items-center justify-end md:flex">
-				<ControlButton className={cx({ hidden: !visible })} onClick={onRightNavigate}>
+				<ControlButton className={cx({ hidden: !visible })} onClick={onForwardNavigation}>
 					<ChevronRight className="h-5 w-5" />
 				</ControlButton>
 			</div>

--- a/packages/browser/src/scenes/book/EpubReaderScene.tsx
+++ b/packages/browser/src/scenes/book/EpubReaderScene.tsx
@@ -8,6 +8,11 @@ import paths from '../../paths'
 
 //! NOTE: Only the epub.js reader is supported for now :sob:
 export default function EpubReaderScene() {
+	const { id } = useParams()
+	if (!id) {
+		throw new Error('Media id is required')
+	}
+
 	const [search, setSearch] = useSearchParams()
 
 	const [initialCfi] = useState(() => decodeURIComponent(search.get('cfi') || ''))
@@ -27,11 +32,6 @@ export default function EpubReaderScene() {
 			setSearch(search)
 		}
 	}, [initialCfi, startOver, search, setSearch])
-
-	const { id } = useParams()
-	if (!id) {
-		throw new Error('Media id is required')
-	}
 
 	const { isLoading: fetchingBook, media } = useMediaByIdQuery(id)
 


### PR DESCRIPTION
Fixes #323

I accidentally inverted the swipe handlers, e.g. assigning `onLeftNavigate` to `onSwipedLeft`. Semantically, this is a mess. I'm being a bit pedantic, but I did not land on variable names I like lol I just added comments to hopefully prevent the mix up again.

Also noticed the header action items on mobile are rather small, so I made a [note to gather feedback](https://github.com/stumpapp/stump/commit/afa00c03b60a022dfb905271d8bdadcc0b992aaf#diff-3333bd75c34b2849159b045890e068e9e7bbd84bf64f6f57f0e642724ed2b427R17-R18). If anyone has thoughts, please reach out.