### PR TITLE
:adhesive_bandage: Fix dark styles in light theme

### DIFF
--- a/packages/browser/src/scenes/book-club/home/BookClubNavigation.tsx
+++ b/packages/browser/src/scenes/book-club/home/BookClubNavigation.tsx
@@ -55,7 +55,7 @@ export default function BookClubNavigation() {
 	const preferTopBar = primary_navigation_mode === 'TOPBAR'
 
 	return (
-		<div className="sticky top-0 z-10 w-full border-b border-gray-75 bg-white md:relative md:top-[unset] md:z-[unset] dark:border-gray-850 dark:bg-gray-975">
+		<div className="sticky top-0 z-10 w-full border-b border-edge bg-background md:relative md:top-[unset] md:z-[unset]">
 			<nav
 				className={cn(
 					'-mb-px flex gap-x-6 overflow-x-scroll px-3 scrollbar-hide md:overflow-x-hidden',

--- a/packages/browser/src/scenes/library/LibraryNavigation.tsx
+++ b/packages/browser/src/scenes/library/LibraryNavigation.tsx
@@ -54,7 +54,7 @@ export default function LibraryNavigation() {
 	const preferTopBar = primary_navigation_mode === 'TOPBAR'
 
 	return (
-		<div className="sticky top-0 z-10 w-full border-b border-gray-75 bg-white md:relative md:top-[unset] md:z-[unset] dark:border-gray-850 dark:bg-gray-975">
+		<div className="sticky top-0 z-10 w-full border-b border-edge bg-background md:relative md:top-[unset] md:z-[unset]">
 			<nav
 				className={cn(
 					'-mb-px flex gap-x-6 overflow-x-scroll px-3 scrollbar-hide md:overflow-x-hidden',

--- a/packages/browser/src/scenes/series/SeriesNavigation.tsx
+++ b/packages/browser/src/scenes/series/SeriesNavigation.tsx
@@ -48,7 +48,7 @@ export default function SeriesNavigation() {
 	const preferTopBar = primary_navigation_mode === 'TOPBAR'
 
 	return (
-		<div className="sticky top-0 z-10 w-full border-b border-gray-75 bg-white md:relative md:top-[unset] md:z-[unset] dark:border-gray-850 dark:bg-gray-975">
+		<div className="sticky top-0 z-10 w-full border-b border-edge bg-background md:relative md:top-[unset] md:z-[unset]">
 			<nav
 				className={cn(
 					'-mb-px flex gap-x-6 overflow-x-scroll px-3 scrollbar-hide md:overflow-x-hidden',


### PR DESCRIPTION
Backport the main stylistic fix from https://github.com/stumpapp/stump/pull/322. This does not include some of the small improvements to the light mode, though, just the small fix.