### PR TITLE
:bug: Fix image reader navigation (tablet)

### DIFF
--- a/packages/browser/src/components/readers/image-based/PagedReader.tsx
+++ b/packages/browser/src/components/readers/image-based/PagedReader.tsx
@@ -7,6 +7,7 @@ import { useHotkeys } from 'react-hotkeys-hook'
 import { useSwipeable } from 'react-swipeable'
 import { useMediaMatch, useWindowSize } from 'rooks'
 
+import { useDetectZoom } from '@/hooks/useDetectZoom'
 import { useReaderStore } from '@/stores'
 
 export type PagedReaderProps = {
@@ -35,6 +36,7 @@ function PagedReader({ currentPage, media, onPageChange, getPageUrl }: PagedRead
 		showToolBar: state.showToolBar,
 	}))
 	const { innerWidth } = useWindowSize()
+	const { isZoomed } = useDetectZoom()
 
 	const isMobile = useMediaMatch('(max-width: 768px)')
 	const [imageWidth, setImageWidth] = React.useState<number | null>(null)
@@ -111,15 +113,20 @@ function PagedReader({ currentPage, media, onPageChange, getPageUrl }: PagedRead
 	})
 
 	const swipeHandlers = useSwipeable({
+		delta: 150,
 		onSwipedLeft: () => handlePageChange(currentPage + 1),
 		onSwipedRight: () => handlePageChange(currentPage - 1),
 		preventScrollOnSwipe: true,
 	})
+	const swipeEnabled = useMemo(
+		() => !isZoomed && !showToolBar && isMobile,
+		[isZoomed, showToolBar, isMobile],
+	)
 
 	return (
 		<div
 			className="relative flex h-full w-full items-center justify-center"
-			{...(isMobile ? swipeHandlers : {})}
+			{...(swipeEnabled ? swipeHandlers : {})}
 		>
 			<SideBarControl
 				fixed={fixSideNavigation}

--- a/packages/browser/src/hooks/index.ts
+++ b/packages/browser/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export { useDetectZoom } from './useDetectZoom'
 export { useLayoutMode } from './useLayoutMode'
 export { usePageParam } from './usePageParam'
 export { usePreferences } from './usePreferences'

--- a/packages/browser/src/hooks/useDetectZoom.ts
+++ b/packages/browser/src/hooks/useDetectZoom.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * A hook to detect the zoom level of the browser.
+ */
+export function useDetectZoom() {
+	const [zoom, setZoom] = useState<number>()
+
+	useEffect(() => {
+		const handleResize = () => {
+			setZoom(window.visualViewport?.scale)
+		}
+
+		window.visualViewport?.addEventListener('resize', handleResize)
+		handleResize()
+		return () => window.visualViewport?.removeEventListener('resize', handleResize)
+	}, [])
+
+	return {
+		isZoomed: zoom !== undefined && zoom > 1,
+		ratio: zoom,
+	}
+}

--- a/packages/browser/src/scenes/book-club/home/BookClubNavigation.tsx
+++ b/packages/browser/src/scenes/book-club/home/BookClubNavigation.tsx
@@ -71,9 +71,8 @@ export default function BookClubNavigation() {
 						key={tab.to}
 						underline={false}
 						className={cx('whitespace-nowrap border-b-2 px-1 py-3 text-sm font-medium', {
-							'border-brand-500 text-brand-600 dark:text-brand-400': tab.isActive,
-							'border-transparent text-gray-800 hover:border-gray-200 hover:text-gray-700 dark:text-gray-400 dark:hover:border-gray-700 dark:hover:text-gray-200':
-								!tab.isActive,
+							'border-brand-500 text-brand-500': tab.isActive,
+							'border-transparent text-muted hover:border-edge': !tab.isActive,
 						})}
 					>
 						{tab.label}

--- a/packages/browser/src/scenes/library/LibraryNavigation.tsx
+++ b/packages/browser/src/scenes/library/LibraryNavigation.tsx
@@ -71,9 +71,8 @@ export default function LibraryNavigation() {
 						underline={false}
 						onMouseEnter={tab.onHover}
 						className={cn('whitespace-nowrap border-b-2 px-1 py-3 text-sm font-medium', {
-							'border-brand-500 text-brand-600 dark:text-brand-400': tab.isActive,
-							'border-transparent text-gray-800 hover:border-gray-200 hover:text-gray-700 dark:text-gray-400 dark:hover:border-gray-700 dark:hover:text-gray-200':
-								!tab.isActive,
+							'border-brand-500 text-brand-500': tab.isActive,
+							'border-transparent text-muted hover:border-edge': !tab.isActive,
 						})}
 					>
 						{tab.label}

--- a/packages/browser/src/scenes/series/SeriesNavigation.tsx
+++ b/packages/browser/src/scenes/series/SeriesNavigation.tsx
@@ -67,9 +67,8 @@ export default function SeriesNavigation() {
 						className={cn(
 							'whitespace-nowrap border-b-2 px-1 py-3 text-sm font-medium',
 							{
-								'border-brand-500 text-brand-600 dark:text-brand-400': tab.isActive,
-								'border-transparent text-gray-800 hover:border-gray-200 hover:text-gray-700 dark:text-gray-400 dark:hover:border-gray-700 dark:hover:text-gray-200':
-									!tab.isActive,
+								'border-brand-500 text-brand-500': tab.isActive,
+								'border-transparent text-muted hover:border-edge': !tab.isActive,
 							},
 							// {
 							// 	'pointer-events-none !text-opacity-40': tab.disabled,


### PR DESCRIPTION
Resolves (hopefully) #328

I've adjusted the reader to be more programmatic and less CSS-centric for computing the navigation tap boundaries:

- If the loaded image is >= 80% of the width of the viewport, the navigation divs will be fixed to the left/right with a fixed 10% width
- If the loaded image is < 80%, the navigation divs will be inline left/right to the image and fill any available space

I've also added swipe handlers on mobile viewport sizes. I tested this on an iPad mini, and then a few other tablet sizes in my dev tools.