### PR TITLE
:bug: Fix cast error for file size calculation

### DIFF
--- a/core/prisma/migrations/20240428193209_bigint_media_size/migration.sql
+++ b/core/prisma/migrations/20240428193209_bigint_media_size/migration.sql
@@ -1,0 +1,28 @@
+/*
+  Warnings:
+
+  - You are about to alter the column `size` on the `media` table. The data in that column could be lost. The data in that column will be cast from `Int` to `BigInt`.
+
+*/
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_media" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "size" BIGINT NOT NULL,
+    "extension" TEXT NOT NULL,
+    "pages" INTEGER NOT NULL,
+    "updated_at" DATETIME NOT NULL,
+    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "modified_at" DATETIME,
+    "hash" TEXT,
+    "path" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'READY',
+    "series_id" TEXT,
+    CONSTRAINT "media_series_id_fkey" FOREIGN KEY ("series_id") REFERENCES "series" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_media" ("created_at", "extension", "hash", "id", "modified_at", "name", "pages", "path", "series_id", "size", "status", "updated_at") SELECT "created_at", "extension", "hash", "id", "modified_at", "name", "pages", "path", "series_id", "size", "status", "updated_at" FROM "media";
+DROP TABLE "media";
+ALTER TABLE "new_media" RENAME TO "media";
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/core/prisma/schema.prisma
+++ b/core/prisma/schema.prisma
@@ -178,7 +178,7 @@ model Media {
   id String @id @default(uuid())
 
   name        String // derived from filename
-  size        Int // in bytes
+  size        BigInt // in bytes
   extension   String
   pages       Int
   updated_at  DateTime  @updatedAt

--- a/core/src/db/entity/media/entity.rs
+++ b/core/src/db/entity/media/entity.rs
@@ -21,7 +21,7 @@ pub struct Media {
 	/// The name of the media. ex: "The Amazing Spider-Man (2018) #69"
 	pub name: String,
 	/// The size of the media in bytes.
-	pub size: i32,
+	pub size: i64,
 	/// The file extension of the media. ex: "cbz"
 	pub extension: String,
 	/// The number of pages in the media. ex: "69"

--- a/core/src/filesystem/media/builder.rs
+++ b/core/src/filesystem/media/builder.rs
@@ -65,7 +65,7 @@ impl MediaBuilder {
 			(m.len(), last_modified_at)
 		})?;
 		let size = raw_size.try_into().unwrap_or_else(|_| {
-			tracing::error!(?raw_size, "Failed to convert file size to i32");
+			tracing::error!(?raw_size, ?path, "Failed to convert file size to i64");
 			0
 		});
 

--- a/packages/browser/src/components/media/MediaCard.tsx
+++ b/packages/browser/src/components/media/MediaCard.tsx
@@ -75,7 +75,7 @@ export default function MediaCard({
 		return (
 			<div className="flex items-center justify-between">
 				<Text size="xs" variant="muted">
-					{formatBytes(media.size)}
+					{formatBytes(media.size.valueOf())}
 				</Text>
 			</div>
 		)

--- a/packages/browser/src/scenes/book/BookFileInformation.tsx
+++ b/packages/browser/src/scenes/book/BookFileInformation.tsx
@@ -38,7 +38,7 @@ export default function BookFileInformation({ media }: Props) {
 			<Heading size="xs">File Information</Heading>
 			<div className="flex space-x-4">
 				<Text size="sm" variant="muted">
-					Size: {formatBytes(media.size)}
+					Size: {formatBytes(media.size.valueOf())}
 				</Text>
 				<Text size="sm" variant="muted">
 					Kind: {media.extension?.toUpperCase()}

--- a/packages/types/generated.ts
+++ b/packages/types/generated.ts
@@ -101,7 +101,7 @@ export type Series = { id: string; name: string; path: string; description: stri
  */
 export type MediaMetadata = { title: string | null; series: string | null; number: number | null; volume: number | null; summary: string | null; notes: string | null; age_rating?: number | null; genre?: string[] | null; year: number | null; month: number | null; day: number | null; writers?: string[] | null; pencillers?: string[] | null; inkers?: string[] | null; colorists?: string[] | null; letterers?: string[] | null; cover_artists?: string[] | null; editors?: string[] | null; publisher: string | null; links?: string[] | null; characters?: string[] | null; teams?: string[] | null; page_count: number | null }
 
-export type Media = { id: string; name: string; size: number; extension: string; pages: number; updated_at: string; created_at: string; modified_at: string | null; hash: string | null; path: string; status: FileStatus; series_id: string; metadata: MediaMetadata | null; series?: Series | null; read_progresses?: ReadProgress[] | null; current_page?: number | null; current_epubcfi?: string | null; is_completed?: boolean | null; tags?: Tag[] | null; bookmarks?: Bookmark[] | null }
+export type Media = { id: string; name: string; size: BigInt; extension: string; pages: number; updated_at: string; created_at: string; modified_at: string | null; hash: string | null; path: string; status: FileStatus; series_id: string; metadata: MediaMetadata | null; series?: Series | null; read_progresses?: ReadProgress[] | null; current_page?: number | null; current_epubcfi?: string | null; is_completed?: boolean | null; tags?: Tag[] | null; bookmarks?: Bookmark[] | null }
 
 /**
  * A model representing a bookmark in the database. Bookmarks are used to save specific locations


### PR DESCRIPTION
Files which are >2.35 GB do not fit within `i32`, which is used for the `size` field on `media`. I have added a migration to store media size as an `i64`, so unless you have a file which is ~9223372036.85 GB you should be good lol