### PR TITLE
:white_check_mark: Fix stump_config tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6423,6 +6423,7 @@ dependencies = [
  "serde-xml-rs",
  "serde_json",
  "specta",
+ "temp-env",
  "tempfile",
  "thiserror",
  "tokio",
@@ -6833,6 +6834,15 @@ dependencies = [
  "quick-xml",
  "strum",
  "windows 0.39.0",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot 0.12.1",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -52,6 +52,7 @@ regex = "1.10.4"
 alphanumeric-sort = "1.5.3"
 
 [dev-dependencies]
+temp-env = "0.3.6"
 tempfile = { workspace = true }
 criterion = { version = "0.5.1", features = ["html_reports", "async_tokio"] }
 

--- a/core/src/config/stump_config.rs
+++ b/core/src/config/stump_config.rs
@@ -525,42 +525,49 @@ mod tests {
 
 	#[test]
 	fn test_getting_config_from_environment() {
-		// Set environment variables
-		env::set_var(PROFILE_KEY, "release");
-		env::set_var(PORT_KEY, "1337");
-		env::set_var(VERBOSITY_KEY, "3");
-		env::set_var(DB_PATH_KEY, "not_a_real_path");
-		env::set_var(CLIENT_KEY, "not_a_real_dir");
-		env::set_var(CONFIG_DIR_KEY, "also_not_a_real_dir");
-		env::set_var(DISABLE_SWAGGER_KEY, "true");
-		env::set_var(HASH_COST_KEY, "24");
-		env::set_var(SESSION_TTL_KEY, (3600 * 24).to_string());
-		env::set_var(SESSION_EXPIRY_INTERVAL_KEY, (60 * 60 * 8).to_string());
+		temp_env::with_vars(
+			[
+				(PROFILE_KEY, Some("release")),
+				(PORT_KEY, Some("1337")),
+				(VERBOSITY_KEY, Some("2")),
+				(DB_PATH_KEY, Some("not_a_real_path")),
+				(CLIENT_KEY, Some("not_a_real_dir")),
+				(CONFIG_DIR_KEY, Some("also_not_a_real_dir")),
+				(DISABLE_SWAGGER_KEY, Some("true")),
+				(HASH_COST_KEY, Some("24")),
+				(SESSION_TTL_KEY, Some(&(3600 * 24).to_string())),
+				(
+					SESSION_EXPIRY_INTERVAL_KEY,
+					Some(&(60 * 60 * 8).to_string()),
+				),
+			],
+			|| {
+				// Create a new StumpConfig and load values from the environment.
+				let config = StumpConfig::new("not_a_dir".to_string())
+					.with_environment()
+					.unwrap();
 
-		// Create a new StumpConfig and load values from the environment.
-		let config = StumpConfig::new("not_a_dir".to_string())
-			.with_environment()
-			.unwrap();
-
-		// Confirm values are as expected
-		assert_eq!(
-			config,
-			StumpConfig {
-				profile: "release".to_string(),
-				port: 1337,
-				verbosity: 3,
-				pretty_logs: true,
-				db_path: Some("not_a_real_path".to_string()),
-				client_dir: "not_a_real_dir".to_string(),
-				config_dir: "also_not_a_real_dir".to_string(),
-				allowed_origins: vec![],
-				pdfium_path: None,
-				disable_swagger: true,
-				password_hash_cost: 24,
-				session_ttl: 3600 * 24,
-				expired_session_cleanup_interval: 60 * 60 * 8,
-				scanner_chunk_size: DEFAULT_SCANNER_CHUNK_SIZE,
-			}
+				// Confirm values are as expected
+				assert_eq!(
+					config,
+					StumpConfig {
+						profile: "release".to_string(),
+						port: 1337,
+						verbosity: 2,
+						pretty_logs: true,
+						db_path: Some("not_a_real_path".to_string()),
+						client_dir: "not_a_real_dir".to_string(),
+						config_dir: "also_not_a_real_dir".to_string(),
+						allowed_origins: vec![],
+						pdfium_path: None,
+						disable_swagger: true,
+						password_hash_cost: 24,
+						session_ttl: 3600 * 24,
+						expired_session_cleanup_interval: 60 * 60 * 8,
+						scanner_chunk_size: DEFAULT_SCANNER_CHUNK_SIZE,
+					}
+				);
+			},
 		);
 	}
 
@@ -670,38 +677,46 @@ mod tests {
 
 	#[test]
 	fn test_simulate_first_boot() {
-		env::set_var(PORT_KEY, "1337");
-		env::set_var(VERBOSITY_KEY, "2");
-		env::set_var(DISABLE_SWAGGER_KEY, "true");
-		env::set_var(HASH_COST_KEY, "1");
+		temp_env::with_vars(
+			[
+				(PORT_KEY, Some("1337")),
+				(VERBOSITY_KEY, Some("2")),
+				(DISABLE_SWAGGER_KEY, Some("true")),
+				(HASH_COST_KEY, Some("1")),
+			],
+			|| {
+				let tempdir =
+					tempfile::tempdir().expect("Failed to create temporary directory");
+				// Now we can create a StumpConfig rooted at the temporary directory
+				let config_dir = tempdir.path().to_string_lossy().to_string();
+				let generated = StumpConfig::new(config_dir.clone())
+					.with_config_file()
+					.expect("Failed to generate StumpConfig from Stump.toml")
+					.with_environment()
+					.expect("Failed to generate StumpConfig from environment");
 
-		let tempdir = tempfile::tempdir().expect("Failed to create temporary directory");
-		// Now we can create a StumpConfig rooted at the temporary directory
-		let config_dir = tempdir.path().to_string_lossy().to_string();
-		let generated = StumpConfig::new(config_dir.clone())
-			.with_config_file()
-			.expect("Failed to generate StumpConfig from Stump.toml")
-			.with_environment()
-			.expect("Failed to generate StumpConfig from environment");
-
-		let expected = StumpConfig {
-			profile: "debug".to_string(),
-			port: 1337,
-			verbosity: 2,
-			pretty_logs: true,
-			db_path: None,
-			client_dir: "./dist".to_string(),
-			config_dir,
-			allowed_origins: vec![],
-			pdfium_path: None,
-			disable_swagger: true,
-			password_hash_cost: 1,
-			session_ttl: DEFAULT_SESSION_TTL,
-			expired_session_cleanup_interval: DEFAULT_SESSION_EXPIRY_CLEANUP_INTERVAL,
-			scanner_chunk_size: DEFAULT_SCANNER_CHUNK_SIZE,
-		};
-
-		assert_eq!(generated, expected);
+				assert_eq!(
+					generated,
+					StumpConfig {
+						profile: "debug".to_string(),
+						port: 1337,
+						verbosity: 2,
+						pretty_logs: true,
+						db_path: None,
+						client_dir: "./dist".to_string(),
+						config_dir,
+						allowed_origins: vec![],
+						pdfium_path: None,
+						disable_swagger: true,
+						password_hash_cost: 1,
+						session_ttl: DEFAULT_SESSION_TTL,
+						expired_session_cleanup_interval:
+							DEFAULT_SESSION_EXPIRY_CLEANUP_INTERVAL,
+						scanner_chunk_size: DEFAULT_SCANNER_CHUNK_SIZE,
+					}
+				);
+			},
+		);
 	}
 
 	fn get_mock_config_file() -> String {

--- a/crates/integrations/src/notifier/discord_client.rs
+++ b/crates/integrations/src/notifier/discord_client.rs
@@ -76,6 +76,7 @@ mod tests {
 		DiscordClient::new(webhook_url)
 	}
 
+	#[ignore = "No token"]
 	#[tokio::test]
 	async fn test_send_message() {
 		let client = get_debug_client();

--- a/crates/integrations/src/notifier/telegram_client.rs
+++ b/crates/integrations/src/notifier/telegram_client.rs
@@ -61,6 +61,8 @@ mod tests {
 		let chat_id = std::env::var("DUMMY_TG_CHAT_ID").expect("Failed to load chat ID");
 		TelegramClient::new(token, chat_id)
 	}
+
+	#[ignore = "No token"]
 	#[tokio::test]
 	async fn test_send_message() {
 		let client = get_debug_client();


### PR DESCRIPTION
So I was investigating the failing tests as mentioned in the Discord earlier and I happened on a solution that seems sensible.

The crate [temp-env](https://crates.io/crates/temp-env) provides a way to set environment variables, run a test, then unset those variables. Embedding the tests involving environment variables in this crate's wrapper both makes it more ergonomic and also fixes the inconsistent passing of tests that I was experiencing (I interpret this as confirming that the previous tests were causing some sort of race condition where the environment variables for each were fighting each other).

Also, I set the telegram and discord tests to be ignored since they rely on local variables being set. It's probably a good idea to fix those in the future, but this will also open the way for automated benchmarking since that will need to rely on running tests and gauging their performance anyway.