### PR TITLE
:bug: Fix first visit API URL determination

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5,7 +5,7 @@ const getDebugUrl = () => {
 	return `http://${hostname}:10801`
 }
 
-export const baseUrl = import.meta.env.PROD ? window.location.href : getDebugUrl()
+export const baseUrl = import.meta.env.PROD ? window.location.origin : getDebugUrl()
 
 export default function App() {
 	return <StumpWebClient platform={'browser'} baseUrl={baseUrl} />

--- a/packages/client/src/queries/auth.ts
+++ b/packages/client/src/queries/auth.ts
@@ -1,5 +1,5 @@
 import { authApi, authQueryKeys, checkIsClaimed, serverQueryKeys } from '@stump/api'
-import type { User } from '@stump/types'
+import { isUser, type User } from '@stump/types'
 import { useEffect, useState } from 'react'
 
 import { queryClient, QueryOptions, useMutation, useQuery } from '../client'
@@ -9,6 +9,10 @@ export function useAuthQuery(options: QueryOptions<User> = {}) {
 		[authQueryKeys.me],
 		async () => {
 			const { data } = await authApi.me()
+			if (!isUser(data)) {
+				console.debug('Malformed response recieved from server', data)
+				throw new Error('Malformed response recieved from server')
+			}
 			return data
 		},
 		{

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -1,4 +1,9 @@
-import { CursorInfo, Library, Media, PageInfo, Series } from './generated'
+import { CursorInfo, Library, Media, PageInfo, Series, User } from './generated'
+
+export const isUser = (data: unknown): data is User => {
+	const casted = data as User
+	return casted?.id !== undefined && casted?.is_server_owner !== undefined
+}
 
 export enum FileStatus {
 	Unknown = 'UNKNOWN',


### PR DESCRIPTION
Fixes #356

- Replace `window.location.href` with `window.location.origin` when initializing the base URL for the API
- Basic type enforcement for invalid `me` query response

The root cause seems to be that, when in an unauthenticated state, the initial visit to a non-root route would initialize the API URL incorrectly to include the pathname. This was a quick lunch fix, so I'll merge it either after work today or tomorrow