### PR TITLE
👷 Add code coverage tracking

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 25%
+    patch:
+      default:
+        target: 0%

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -2,7 +2,12 @@ coverage:
   status:
     project:
       default:
-        target: 25%
+        target: 10%
     patch:
       default:
         target: 0%
+ignore:
+  - 'crates/cli'
+  - 'crates/codegen'
+  - 'crates/prisma-cli'
+  - 'apps/desktop'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,10 +25,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: >-
-            ${{ runner.os }}-cargo-
-            ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && 'non-fork-' || 'fork-' }}-
-            ${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && 'non-fork-' || 'fork-' }}${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run cargo checks
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,17 +12,31 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
       - name: Setup rust
         uses: ./.github/actions/setup-rust
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: >-
+            ${{ runner.os }}-cargo-
+            ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && 'non-fork-' || 'fork-' }}-
+            ${{ hashFiles('**/Cargo.lock') }}
+
       - name: Run cargo checks
         run: |
           cargo fmt --all -- --check
           cargo clippy -- -D warnings
+
       - name: Run tests
         run: cargo test
-
-      - name: Generate and upload code coverage
-        uses: ./.github/actions/generate-coverage
 
       - name: Install cargo-llvm-cov
         if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
@@ -47,17 +61,24 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - uses: actions/setup-node@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v4
         with:
           node-version: '20.0.0'
+
       - name: Install yarn
         shell: bash
         run: npm install -g yarn
-      - uses: actions/setup-node@v4
+
+      - name: Setup node (yarn cache)
+        uses: actions/setup-node@v4
         with:
           node-version: '20.0.0'
           cache: 'yarn'
+
       - name: Install dependencies
         run: yarn install
+
       - name: Run TypeScript lints
         run: yarn lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,6 @@ jobs:
         if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
         uses: codecov/codecov-action@v3
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           fail_ci_if_error: true
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,11 +1,9 @@
 name: 'Stump Checks CI'
-
 on:
   pull_request:
   push:
     branches:
       - main
-
 jobs:
   check-rust:
     if: "!contains(github.event.pull_request.head.ref, 'release/v')"
@@ -14,18 +12,33 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
       - name: Setup rust
         uses: ./.github/actions/setup-rust
-
       - name: Run cargo checks
         run: |
           cargo fmt --all -- --check
           cargo clippy -- -D warnings
-      # TODO: fix the tests, then uncomment this
-      # - name: Run tests
-      #   run: |
-      #     cargo integration-tests
+      - name: Run tests
+        run: cargo test
+
+      - name: Generate and upload code coverage
+        uses: ./.github/actions/generate-coverage
+
+      - name: Install cargo-llvm-cov
+        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
+        run: cargo install cargo-llvm-cov
+
+      - name: Generate code coverage data
+        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+
+      - name: Upload coverage to Codecov
+        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          fail_ci_if_error: true
 
   check-typescript:
     if: "!contains(github.event.pull_request.head.ref, 'release/v')"
@@ -34,22 +47,17 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
       - uses: actions/setup-node@v4
         with:
           node-version: '20.0.0'
-
       - name: Install yarn
         shell: bash
         run: npm install -g yarn
-
       - uses: actions/setup-node@v4
         with:
           node-version: '20.0.0'
           cache: 'yarn'
-
       - name: Install dependencies
         run: yarn install
-
       - name: Run TypeScript lints
         run: yarn lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,17 +35,15 @@ jobs:
         run: cargo test
 
       - name: Install cargo-llvm-cov
-        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
         run: cargo install cargo-llvm-cov
 
       - name: Generate code coverage data
-        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
 
       - name: Upload coverage to Codecov
-        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           fail_ci_if_error: true
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
 	"[rust]": {
 		"editor.defaultFormatter": "rust-lang.rust-analyzer"
 	},
+	"rust-analyzer.check.command": "clippy",
 	"tailwindCSS.experimental.classRegex": [
 		["cva\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"],
 		["cx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]


### PR DESCRIPTION
This is a redo of a previous pull request attempt that failed because I made it from a fork (#364). I have since closed the pull request, but its text is reproduced below:

> This is a very simple pull request that adds CodeCov-based automated code coverage tracking. It will require some repository owner intervention to get fully functional.
>
> I've added an action that runs [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov). This runs all tests in release mode and generates lcov.info, which contains coverage data (NB: if you're using a coverage tracking extension then you can use visualize this file in your IDE, very helpful for designing tests).
>
> The next action uploads this data to [codecov.io](https://about.codecov.io/), which offers free code coverage hosting for open source projects. To get this working, you'll need to create an account on that website and write the API token to the `secrets.CODECOV_TOKEN` variable. You'll also want to set up their GitHub app and give it permission to access this repository. Once that's done, there should be a handy little bot on each pull request that tracks coverage.
>
> On that front, I've added a bot config file at `.github/codecov.yml` which currently sets no expectations (`target: 0%`). You can increase this percentage to set minimum coverage goals for the project, and I imagine that someday you will want to begin ratcheting it up to prevent regressions in coverage. A bot-initiated task tests coverage against this target on each pull request and can block merge if it's below target.
>
> If you want, you can also copy the badge codecov gives you markdown code for into the readme for a live readout on the repo front page (or maybe wait to do that until the coverage is higher).
>
> Finally, I've re-enabled running tests in the ci (though the integration tests do still need fixing). I think this is a good idea - I've noticed that two of the rar tests currently fail, which they did not when I wrote them. This is a regression that running tests before merge would have caught. I'm going to try and figure out why it's happening and fix it before this merges, because right now the ci should be blocking merge on account of this failing test.