### PR TITLE
👷 Release server binary

### DIFF
--- a/.github/actions/build-server/action.yml
+++ b/.github/actions/build-server/action.yml
@@ -1,10 +1,5 @@
-name: 'Build Stump server'
-description: 'Compile the Stump Rust server'
-
-inputs:
-  platform:
-    description: 'The plaform of the runner'
-    required: true
+name: Build Stump server
+description: Compile the Stump Rust server
 
 runs:
   using: composite
@@ -16,11 +11,19 @@ runs:
       uses: ./.github/actions/setup-rust
 
     - name: Copy bundled web app
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: webapp
         path: ./apps/server/dist
 
-    - name: Compile server
+    # This action can be called to build in a Linux or Windows runner
+    # This step only runs when using Linux
+    - name: Compile server (Linux)
+      if: runner.os == 'Linux'
       shell: bash
+      run: cargo build --package stump_server --release
+    - name: Compile server (Windows)
+      # Alternatively, when running Windows
+      if: runner.os == 'Windows'
+      shell: powershell
       run: cargo build --package stump_server --release

--- a/.github/actions/build-server/action.yml
+++ b/.github/actions/build-server/action.yml
@@ -10,12 +10,6 @@ runs:
     - name: Setup rust
       uses: ./.github/actions/setup-rust
 
-    - name: Copy bundled web app
-      uses: actions/download-artifact@v4
-      with:
-        name: webapp
-        path: ./apps/server/dist
-
     # This action can be called to build in a Linux or Windows runner
     # This step only runs when using Linux
     - name: Compile server (Linux)

--- a/.github/actions/build-web/action.yml
+++ b/.github/actions/build-web/action.yml
@@ -1,5 +1,5 @@
-name: 'Compile Web Application'
-description: 'Compile stump web'
+name: Compile Web Application
+description: Compile stump web
 
 runs:
   using: composite

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,8 +1,8 @@
-name: 'Setup system dependencies'
-description: 'Install system dependencies and setup cache'
+name: Setup system dependencies
+description: Install system dependencies and setup cache
 
 runs:
-  using: 'composite'
+  using: composite
   steps:
     - name: Install Rust
       uses: actions-rs/toolchain@v1

--- a/.github/actions/upload-artifact/action.yml
+++ b/.github/actions/upload-artifact/action.yml
@@ -1,16 +1,16 @@
-name: 'Upload Local'
-description: 'Upload artifact to local action'
+name: Upload Local
+description: Upload artifact to local action
 
 inputs:
   upload-name:
     required: true
-    description: 'Name of the upload'
+    description: Name of the upload
   upload-path:
     required: true
-    description: 'Path to the upload data'
+    description: Path to the upload data
 
 runs:
-  using: 'composite'
+  using: composite
   steps:
     # https://github.com/actions/upload-artifact/issues/337
     - name: Normalize
@@ -22,7 +22,7 @@ runs:
         echo "normalized_path=$UPLOAD_PATH" >> $GITHUB_OUTPUT
 
     - name: Upload
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.upload-name }}
         path: ${{ env.normalized_path || inputs.upload-path }}

--- a/.github/workflows/release_binary.yml
+++ b/.github/workflows/release_binary.yml
@@ -1,0 +1,94 @@
+name: 'Binary release'
+
+# Manual release with input version number
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Enter the release version (e.g., 0.1.0)'
+        required: true
+
+jobs:
+  # This job builds the binaries for each release
+  build-binary:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            artifact_name: 'linux-artifact'
+            artifact_filename: 'stump_server.o'
+          - os: windows-latest
+            artifact_name: 'windows-artifact'
+            artifact_filename: 'stump_server.exe'
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Build web application
+        uses: ./.github/actions/build-web
+
+      - name: Build stump server
+        uses: ./.github/actions/build-server
+
+      - name: Upload server artifact
+        uses: ./.github/actions/upload-artifact
+        with:
+          upload-name: ${{ matrix.artifact_name }}
+          upload-path: target/release/${{ matrix.artifact_filename }}
+  # This job creates the release and organizes associated files
+  create-release:
+    needs: build-binary
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - name: Download artifact (Linux)
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-artifact
+          path: StumpServer-linux
+
+      - name: Download artifact (Windows)
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-artifact
+          path: StumpServer-windows
+
+      - name: Zip artifacts
+        run: |
+          sudo apt-get install -y zip
+          cd StumpServer-linux
+          zip -r ../linux-build-results.zip *
+          cd ../StumpServer-windows
+          zip -r ../windows-build-results.zip *
+          cd ..
+
+      - name: Create release
+        uses: actions/create-release@v1
+        id: create_release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          draft: true
+          prerelease: false
+          release_name: Release ${{ github.event.inputs.version }}
+          tag_name: v${{ github.event.inputs.version }}
+          body_path: ./.github/CHANGELOG.md
+
+      - name: Upload release artifact (Linux)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: linux-build-results.zip
+          asset_name: StumpServer-${{ github.event.inputs.version }}-x64-Linux.zip
+          asset_content_type: application/zip
+
+      - name: Upload release artifact (Windows)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: windows-build-results.zip
+          asset_name: StumpServer-${{ github.event.inputs.version }}-x64-Windows.zip
+          asset_content_type: application/zip

--- a/.github/workflows/release_binary.yml
+++ b/.github/workflows/release_binary.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           gh release create v${{ github.event.inputs.version }} \
             --draft \
-            --target binary-release \
+            --target main \
             --title 'Release ${{ github.event.inputs.version }}' \
             --generate-notes \
             linux-build-results.zip#StumpServer-${{ github.event.inputs.version }}-x64-Linux.zip \

--- a/.github/workflows/release_binary.yml
+++ b/.github/workflows/release_binary.yml
@@ -26,6 +26,9 @@ jobs:
             artifact_filename: stump_server.exe
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: Build web application
         uses: ./.github/actions/build-web
 

--- a/.github/workflows/release_binary.yml
+++ b/.github/workflows/release_binary.yml
@@ -12,8 +12,19 @@ on:
       - binary-release
 
 jobs:
+  # This job builds the common webapp HTML/JS/CSS used for all platforms
+  build-webapp:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Build web application/upload artifact
+        uses: ./.github/actions/build-web
+
   # This job builds the binaries for each release
   build-binary:
+    needs: build-webapp
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
@@ -28,9 +39,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
-      - name: Build web application
-        uses: ./.github/actions/build-web
 
       - name: Build stump server
         uses: ./.github/actions/build-server

--- a/.github/workflows/release_binary.yml
+++ b/.github/workflows/release_binary.yml
@@ -7,6 +7,9 @@ on:
       version:
         description: Enter the release version (e.g., 0.1.0)
         required: true
+  push:
+    branches:
+      - binary-release
 
 jobs:
   # This job builds the binaries for each release
@@ -17,7 +20,7 @@ jobs:
         include:
           - os: ubuntu-latest
             artifact_name: linux-artifact
-            artifact_filename: stump_server.o
+            artifact_filename: stump_server
           - os: windows-latest
             artifact_name: windows-artifact
             artifact_filename: stump_server.exe
@@ -69,10 +72,10 @@ jobs:
       - name: Create release and upload artifacts
         run: |
           gh auth login --with-token ${{ github.token }}
-          gh release create v${{github.event.inputs.version}} \
+          gh release create v${{ github.event.inputs.version || '0.0.test' }} \
             --draft \
-            --target main \
-            --title 'Release ${{ github.event.inputs.version }}' \
+            --target binary-release \
+            --title 'Release ${{ github.event.inputs.version || '0.0.test' }}' \
             --generate-notes \
-            linux-build-results.zip#StumpServer-${{ github.event.inputs.version }}-x64-Linux.zip \
-            windows-build-results.zip#StumpServer-${{ github.event.inputs.version }}-x64-Windows.zip
+            linux-build-results.zip#StumpServer-${{ github.event.inputs.version || '0.0.test' }}-x64-Linux.zip \
+            windows-build-results.zip#StumpServer-${{ github.event.inputs.version || '0.0.test' }}-x64-Windows.zip

--- a/.github/workflows/release_binary.yml
+++ b/.github/workflows/release_binary.yml
@@ -1,11 +1,11 @@
-name: 'Binary release'
+name: Binary release
 
 # Manual release with input version number
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Enter the release version (e.g., 0.1.0)'
+        description: Enter the release version (e.g., 0.1.0)
         required: true
 
 jobs:
@@ -16,11 +16,11 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         include:
           - os: ubuntu-latest
-            artifact_name: 'linux-artifact'
-            artifact_filename: 'stump_server.o'
+            artifact_name: linux-artifact
+            artifact_filename: stump_server.o
           - os: windows-latest
-            artifact_name: 'windows-artifact'
-            artifact_filename: 'stump_server.exe'
+            artifact_name: windows-artifact
+            artifact_filename: stump_server.exe
     runs-on: ${{ matrix.os }}
     steps:
       - name: Build web application
@@ -40,6 +40,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: Download artifact (Linux)
         uses: actions/download-artifact@v4
         with:
@@ -52,43 +55,24 @@ jobs:
           name: windows-artifact
           path: StumpServer-windows
 
+      - name: Install dependencies
+        run: sudo apt-get install -y gh zip
+
       - name: Zip artifacts
         run: |
-          sudo apt-get install -y zip
           cd StumpServer-linux
           zip -r ../linux-build-results.zip *
           cd ../StumpServer-windows
           zip -r ../windows-build-results.zip *
           cd ..
 
-      - name: Create release
-        uses: actions/create-release@v1
-        id: create_release
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          draft: true
-          prerelease: false
-          release_name: Release ${{ github.event.inputs.version }}
-          tag_name: v${{ github.event.inputs.version }}
-          body_path: ./.github/CHANGELOG.md
-
-      - name: Upload release artifact (Linux)
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: linux-build-results.zip
-          asset_name: StumpServer-${{ github.event.inputs.version }}-x64-Linux.zip
-          asset_content_type: application/zip
-
-      - name: Upload release artifact (Windows)
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: windows-build-results.zip
-          asset_name: StumpServer-${{ github.event.inputs.version }}-x64-Windows.zip
-          asset_content_type: application/zip
+      - name: Create release and upload artifacts
+        run: |
+          gh auth login --with-token ${{ github.token }}
+          gh release create v${{github.event.inputs.version}} \
+            --draft \
+            --target main \
+            --title 'Release ${{ github.event.inputs.version }}' \
+            --generate-notes \
+            linux-build-results.zip#StumpServer-${{ github.event.inputs.version }}-x64-Linux.zip \
+            windows-build-results.zip#StumpServer-${{ github.event.inputs.version }}-x64-Windows.zip

--- a/.github/workflows/release_binary.yml
+++ b/.github/workflows/release_binary.yml
@@ -53,6 +53,8 @@ jobs:
     needs: build-binary
     runs-on: ubuntu-latest
     permissions: write-all
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -82,7 +84,6 @@ jobs:
 
       - name: Create release and upload artifacts
         run: |
-          gh auth login --with-token ${{ github.token }}
           gh release create v${{ github.event.inputs.version || '0.0.test' }} \
             --draft \
             --target binary-release \

--- a/.github/workflows/release_binary.yml
+++ b/.github/workflows/release_binary.yml
@@ -43,11 +43,20 @@ jobs:
       - name: Build stump server
         uses: ./.github/actions/build-server
 
+      - name: Copy bundled web app
+        uses: actions/download-artifact@v4
+        with:
+          name: webapp
+          path: ./staging/client
+
+      - name: Prepare artifact
+        run: mv target/release/${{ matrix.artifact_filename }} ./staging/${{ matrix.artifact_filename }}
+
       - name: Upload server artifact
         uses: ./.github/actions/upload-artifact
         with:
           upload-name: ${{ matrix.artifact_name }}
-          upload-path: target/release/${{ matrix.artifact_filename }}
+          upload-path: staging
   # This job creates the release and organizes associated files
   create-release:
     needs: build-binary

--- a/.github/workflows/release_binary.yml
+++ b/.github/workflows/release_binary.yml
@@ -7,9 +7,6 @@ on:
       version:
         description: Enter the release version (e.g., 0.1.0)
         required: true
-  push:
-    branches:
-      - binary-release
 
 jobs:
   # This job builds the common webapp HTML/JS/CSS used for all platforms
@@ -93,10 +90,10 @@ jobs:
 
       - name: Create release and upload artifacts
         run: |
-          gh release create v${{ github.event.inputs.version || '0.0.test' }} \
+          gh release create v${{ github.event.inputs.version }} \
             --draft \
             --target binary-release \
-            --title 'Release ${{ github.event.inputs.version || '0.0.test' }}' \
+            --title 'Release ${{ github.event.inputs.version }}' \
             --generate-notes \
-            linux-build-results.zip#StumpServer-${{ github.event.inputs.version || '0.0.test' }}-x64-Linux.zip \
-            windows-build-results.zip#StumpServer-${{ github.event.inputs.version || '0.0.test' }}-x64-Windows.zip
+            linux-build-results.zip#StumpServer-${{ github.event.inputs.version }}-x64-Linux.zip \
+            windows-build-results.zip#StumpServer-${{ github.event.inputs.version }}-x64-Windows.zip


### PR DESCRIPTION
This pull request adds a new workflow to build and release a binary package of the Stump server, so that users can directly run the server rather than using a Docker container. It aims to close #310 once complete.

The workflow is intended to be manually triggered, with the desired version number/tag for the release being input at that time. For example, the user could trigger the workflow with `version = 1.0.0` and the result would be a draft release called "Release 1.0.0" tagged "v1.0.0."