### PR TITLE
:hammer: Update docker-compose file example in docs to remove version

### DIFF
--- a/docs/pages/installation/docker.mdx
+++ b/docs/pages/installation/docker.mdx
@@ -40,7 +40,6 @@ echo -e "PUID=$(id -u)\nPGID=$(id -g)"
 Below is an example of a Docker Compose file you can use to bootstrap your Stump server:
 
 ```yaml
-version: '3.3'
 services:
   stump:
     image: aaronleopold/stump:latest


### PR DESCRIPTION
Current `docker compose` file standard no longer uses the `version` element and having it throws a warning.

```
WARN[0000] ./stump/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```

https://docs.docker.com/compose/compose-file/04-version-and-name/

Updated the example in the docs to remove `version`.

\* let me know if you want an issue opened as well, but this seemed tiny.