### PR TITLE
:construction_worker: Add `macOS` platform to binary release workflow

### DIFF
--- a/.github/actions/build-server/action.yml
+++ b/.github/actions/build-server/action.yml
@@ -10,10 +10,15 @@ runs:
     - name: Setup rust
       uses: ./.github/actions/setup-rust
 
-    # This action can be called to build in a Linux or Windows runner
+    # This action can be called to build in a Linux, macOS, or Windows runner
     # This step only runs when using Linux
     - name: Compile server (Linux)
       if: runner.os == 'Linux'
+      shell: bash
+      run: cargo build --package stump_server --release
+    - name: Compile server (macOS)
+      # Alternatively, when running macOS
+      if: runner.os == 'macOS'
       shell: bash
       run: cargo build --package stump_server --release
     - name: Compile server (Windows)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,8 +5,24 @@ on:
     branches:
       - main
 jobs:
+  code-changes-check:
+    runs-on: [ubuntu-22.04]
+    outputs:
+      changes: ${{steps.filter.outputs.changes}}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            apps: ./apps/**
+            crates: ./crates/**
+            docker: ./docker/**
+            packages: ./packages/**
+
   check-rust:
-    if: "!contains(github.event.pull_request.head.ref, 'release/v')"
+    needs: code-changes-check
+    if: "!contains(github.event.pull_request.head.ref, 'release/v') && needs.code-changes-check.outputs.changes != '[]'"
     name: Rust checks
     runs-on: [ubuntu-22.04]
     steps:
@@ -48,7 +64,8 @@ jobs:
           fail_ci_if_error: true
 
   check-typescript:
-    if: "!contains(github.event.pull_request.head.ref, 'release/v')"
+    needs: code-changes-check
+    if: "!contains(github.event.pull_request.head.ref, 'release/v') && needs.code-changes-check.outputs.changes != '[]'"
     name: TypeScript checks
     runs-on: [ubuntu-22.04]
     steps:

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -17,9 +17,26 @@ env:
   DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
 
 jobs:
+  code-changes-check:
+    runs-on: [ubuntu-22.04]
+    outputs:
+      changes: ${{steps.filter.outputs.changes}}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            apps: ./apps/**
+            crates: ./crates/**
+            docker: ./docker/**
+            packages: ./packages/**
+
   nightly-docker-build:
+    needs: code-changes-check
     name: Build docker image
     runs-on: [ubuntu-22.04]
+    if: ${{ needs.code-changes-check.outputs.changes != '[]' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,8 +17,24 @@ env:
   DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
 
 jobs:
+  code-changes-check:
+    runs-on: [ubuntu-22.04]
+    outputs:
+      changes: ${{steps.filter.outputs.changes}}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            apps: ./apps/**
+            crates: ./crates/**
+            docker: ./docker/**
+            packages: ./packages/**
+
   nightly-docker-build:
-    if: "!contains(github.event.pull_request.head.ref, 'release/v')"
+    needs: code-changes-check
+    if: "!contains(github.event.pull_request.head.ref, 'release/v') && needs.code-changes-check.outputs.changes != '[]'"
     name: Build docker image
     runs-on: [ubuntu-22.04]
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: 'Release CI'
+name: Release CI
 
 # This workflow triggers when a PR is merged into `main`, but jobs have conditions to only run when:
 # - A PR is closed, merged into `main`, from a branch that matches the pattern `release/v*.*.*`
@@ -86,65 +86,3 @@ jobs:
           push: ${{ needs.push-or-load.outputs.push }}
           platforms: ${{ needs.push-or-load.outputs.platforms }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}
-
-  # build-web-app:
-  #   name: Build web app
-  #   runs-on: [self-hosted]
-  #   if: false # TODO: Enable this once 0.1.0 is ready
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v3
-
-  #     - name: Build the app
-  #       uses: ./.github/actions/build-web
-
-  #     - name: Upload the build
-  #       uses: ./.github/actions/upload-artifact
-  #       with:
-  #         upload-name: webapp
-  #         upload-path: apps/web/dist
-
-  # build-server:
-  #   strategy:
-  #     fail-fast: true
-  #     matrix:
-  #       platform: [macos, windows]
-  #   name: Build server app
-  #   needs: build-web
-  #   runs-on: ${{ matrix.platform }}
-  #   if: false # TODO: Enable this once 0.1.0 is ready
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v3
-
-  #     - name: Build the server
-  #       uses: ./.github/actions/build-server
-  #       with:
-  #         platform: ${{ matrix.platform }}
-
-  #     - name: Upload the server binary
-  #       uses: ./.github/actions/upload-artifact
-  #       with:
-  #         upload-name: stump_server-${{ matrix.platform }}
-  #         upload-path: target/release/stump_server
-
-  # # TODO: Investigate if I can just merge this with the above
-  # build-linux-server:
-  #   name: Build server app (self-hosted runner)
-  #   needs: build-web
-  #   runs-on: [self-hosted]
-  #   if: false # TODO: Enable this once 0.1.0 is ready
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v3
-
-  #     - name: Build the server
-  #       uses: ./.github/actions/build-server
-  #       with:
-  #         platform: 'linux'
-
-  #     - name: Upload the server binary
-  #       uses: ./.github/actions/upload-artifact
-  #       with:
-  #         upload-name: stump_server-linux
-  #         upload-path: target/release/stump_server

--- a/.github/workflows/release_binary.yml
+++ b/.github/workflows/release_binary.yml
@@ -7,9 +7,6 @@ on:
       version:
         description: Enter the release version (e.g., 0.1.0)
         required: true
-  push:
-    branches:
-      - al/macos-binary
 
 jobs:
   # This job builds the common webapp HTML/JS/CSS used for all platforms
@@ -118,12 +115,12 @@ jobs:
 
       - name: Create release and upload artifacts
         run: |
-          gh release create v${{ github.event.inputs.version || '0.0.test' }} \
+          gh release create v${{ github.event.inputs.version }} \
             --draft \
             --target main \
-            --title 'v${{ github.event.inputs.version || '0.0.test' }}' \
+            --title 'v${{ github.event.inputs.version }}' \
             --generate-notes \
-            linux-build-results.zip#StumpServer-${{ github.event.inputs.version || '0.0.test' }}-linux-x86_64.zip \
-            macos-intel-build-results.zip#StumpServer-${{ github.event.inputs.version || '0.0.test' }}-macos-intel.zip \
-            macos-arm-build-results.zip#StumpServer-${{ github.event.inputs.version || '0.0.test' }}-macos-arm.zip \
-            windows-build-results.zip#StumpServer-${{ github.event.inputs.version || '0.0.test' }}-windows-x86_64.zip
+            linux-build-results.zip#StumpServer-${{ github.event.inputs.version }}-linux-x86_64.zip \
+            macos-intel-build-results.zip#StumpServer-${{ github.event.inputs.version }}-macos-intel.zip \
+            macos-arm-build-results.zip#StumpServer-${{ github.event.inputs.version }}-macos-arm.zip \
+            windows-build-results.zip#StumpServer-${{ github.event.inputs.version }}-windows-x86_64.zip

--- a/.github/workflows/release_binary.yml
+++ b/.github/workflows/release_binary.yml
@@ -24,13 +24,18 @@ jobs:
     needs: build-webapp
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # Note: macos-13 is intel-based, macos-latest is M1-based
+        # See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+        os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
         include:
           - os: ubuntu-latest
             artifact_name: linux-artifact
             artifact_filename: stump_server
+          - os: macos-13
+            artifact_name: macos-intel-artifact
+            artifact_filename: stump_server
           - os: macos-latest
-            artifact_name: macos-artifact
+            artifact_name: macos-arm-artifact
             artifact_filename: stump_server
           - os: windows-latest
             artifact_name: windows-artifact
@@ -57,6 +62,7 @@ jobs:
         with:
           upload-name: ${{ matrix.artifact_name }}
           upload-path: staging
+
   # This job creates the release and organizes associated files
   create-release:
     needs: build-binary
@@ -74,11 +80,17 @@ jobs:
           name: linux-artifact
           path: StumpServer-linux
 
-      - name: Download artifact (macOS)
+      - name: Download artifact (macOS Intel)
         uses: actions/download-artifact@v4
         with:
-          name: macos-artifact
-          path: StumpServer-macos
+          name: macos-intel-artifact
+          path: StumpServer-macos-intel
+
+      - name: Download artifact (macOS ARM)
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-arm-artifact
+          path: StumpServer-macos-arm
 
       - name: Download artifact (Windows)
         uses: actions/download-artifact@v4
@@ -93,8 +105,10 @@ jobs:
         run: |
           cd StumpServer-linux
           zip -r ../linux-build-results.zip *
-          cd ../StumpServer-macos
-          zip -r ../macos-build-results.zip *
+          cd ../StumpServer-macos-intel
+          zip -r ../macos-intel-build-results.zip *
+          cd ../StumpServer-macos-arm
+          zip -r ../macos-arm-build-results.zip *
           cd ../StumpServer-windows
           zip -r ../windows-build-results.zip *
           cd ..
@@ -106,6 +120,7 @@ jobs:
             --target main \
             --title 'v${{ github.event.inputs.version }}' \
             --generate-notes \
-            linux-build-results.zip#StumpServer-${{ github.event.inputs.version }}-x64-Linux.zip \
-            macos-build-results.zip#StumpServer-${{ github.event.inputs.version }}-x64-macOS.zip \
-            windows-build-results.zip#StumpServer-${{ github.event.inputs.version }}-x64-Windows.zip
+            linux-build-results.zip#StumpServer-${{ github.event.inputs.version }}-linux-x86_64.zip \
+            macos-intel-build-results.zip#StumpServer-${{ github.event.inputs.version }}-macos-intel.zip \
+            macos-arm-build-results.zip#StumpServer-${{ github.event.inputs.version }}-macos-arm.zip \
+            windows-build-results.zip#StumpServer-${{ github.event.inputs.version }}-windows-x86_64.zip

--- a/.github/workflows/release_binary.yml
+++ b/.github/workflows/release_binary.yml
@@ -7,6 +7,9 @@ on:
       version:
         description: Enter the release version (e.g., 0.1.0)
         required: true
+  push:
+    branches:
+      - al/macos-binary
 
 jobs:
   # This job builds the common webapp HTML/JS/CSS used for all platforms
@@ -115,12 +118,12 @@ jobs:
 
       - name: Create release and upload artifacts
         run: |
-          gh release create v${{ github.event.inputs.version }} \
+          gh release create v${{ github.event.inputs.version || '0.0.test' }} \
             --draft \
             --target main \
-            --title 'v${{ github.event.inputs.version }}' \
+            --title 'v${{ github.event.inputs.version || '0.0.test' }}' \
             --generate-notes \
-            linux-build-results.zip#StumpServer-${{ github.event.inputs.version }}-linux-x86_64.zip \
-            macos-intel-build-results.zip#StumpServer-${{ github.event.inputs.version }}-macos-intel.zip \
-            macos-arm-build-results.zip#StumpServer-${{ github.event.inputs.version }}-macos-arm.zip \
-            windows-build-results.zip#StumpServer-${{ github.event.inputs.version }}-windows-x86_64.zip
+            linux-build-results.zip#StumpServer-${{ github.event.inputs.version || '0.0.test' }}-linux-x86_64.zip \
+            macos-intel-build-results.zip#StumpServer-${{ github.event.inputs.version || '0.0.test' }}-macos-intel.zip \
+            macos-arm-build-results.zip#StumpServer-${{ github.event.inputs.version || '0.0.test' }}-macos-arm.zip \
+            windows-build-results.zip#StumpServer-${{ github.event.inputs.version || '0.0.test' }}-windows-x86_64.zip

--- a/.github/workflows/release_binary.yml
+++ b/.github/workflows/release_binary.yml
@@ -24,10 +24,13 @@ jobs:
     needs: build-webapp
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           - os: ubuntu-latest
             artifact_name: linux-artifact
+            artifact_filename: stump_server
+          - os: macos-latest
+            artifact_name: macos-artifact
             artifact_filename: stump_server
           - os: windows-latest
             artifact_name: windows-artifact
@@ -71,6 +74,12 @@ jobs:
           name: linux-artifact
           path: StumpServer-linux
 
+      - name: Download artifact (macOS)
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-artifact
+          path: StumpServer-macos
+
       - name: Download artifact (Windows)
         uses: actions/download-artifact@v4
         with:
@@ -84,6 +93,8 @@ jobs:
         run: |
           cd StumpServer-linux
           zip -r ../linux-build-results.zip *
+          cd ../StumpServer-macos
+          zip -r ../macos-build-results.zip *
           cd ../StumpServer-windows
           zip -r ../windows-build-results.zip *
           cd ..
@@ -93,7 +104,8 @@ jobs:
           gh release create v${{ github.event.inputs.version }} \
             --draft \
             --target main \
-            --title 'Release ${{ github.event.inputs.version }}' \
+            --title 'v${{ github.event.inputs.version }}' \
             --generate-notes \
             linux-build-results.zip#StumpServer-${{ github.event.inputs.version }}-x64-Linux.zip \
+            macos-build-results.zip#StumpServer-${{ github.event.inputs.version }}-x64-macOS.zip \
             windows-build-results.zip#StumpServer-${{ github.event.inputs.version }}-x64-Windows.zip


### PR DESCRIPTION
This builds off of the work from #369 to close #310

I'll try to test it during the week with some debug commits to trigger the workflow before merging this in