### PR TITLE
:bug: Fix basic auth password parsing breaking on : character

### DIFF
--- a/apps/server/src/routers/api/mod.rs
+++ b/apps/server/src/routers/api/mod.rs
@@ -48,10 +48,7 @@ mod tests {
 			"Please ensure to only generate types using `cargo run --package codegen`"
 		);
 
-		let mut file = std::fs::OpenOptions::new()
-			.write(true)
-			.append(true)
-			.open(path)?;
+		let mut file = std::fs::OpenOptions::new().append(true).open(path)?;
 
 		file.write_all(b"// SERVER TYPE GENERATION\n\n")?;
 

--- a/apps/server/src/utils/auth.rs
+++ b/apps/server/src/utils/auth.rs
@@ -21,14 +21,18 @@ pub fn decode_base64_credentials(
 ) -> Result<DecodedCredentials, AuthError> {
 	let decoded = String::from_utf8(bytes).map_err(|_| AuthError::BadCredentials)?;
 
-	let username = decoded.split(':').next().unwrap_or("").to_string();
-	let password = decoded.split(':').nth(1).unwrap_or("").to_string();
-
-	if username.is_empty() || password.is_empty() {
-		return Err(AuthError::BadCredentials);
+	match decoded.split_once(':') {
+		Some((username, password)) => {
+			if username.is_empty() || password.is_empty() {
+				return Err(AuthError::BadCredentials);
+			} else {
+				Ok(DecodedCredentials { username: username.to_string(), password: password.to_string() })
+			}
+		}
+		None => {
+			return Err(AuthError::BadCredentials);
+		}
 	}
-
-	Ok(DecodedCredentials { username, password })
 }
 
 pub fn get_session_user(session: &Session) -> APIResult<User> {
@@ -153,5 +157,11 @@ mod tests {
 		];
 
 		assert!(user_has_all_permissions(&user, &expected_can_do));
+	}
+
+	#[test]
+	fn test_password_parsing() {
+		let testcreds = decode_base64_credentials("username:pass:$%^word".into());
+		assert_eq!(testcreds.unwrap().password, String::from("pass:$%^word"));
 	}
 }

--- a/apps/server/src/utils/auth.rs
+++ b/apps/server/src/utils/auth.rs
@@ -24,14 +24,15 @@ pub fn decode_base64_credentials(
 	match decoded.split_once(':') {
 		Some((username, password)) => {
 			if username.is_empty() || password.is_empty() {
-				return Err(AuthError::BadCredentials);
+				Err(AuthError::BadCredentials)
 			} else {
-				Ok(DecodedCredentials { username: username.to_string(), password: password.to_string() })
+				Ok(DecodedCredentials {
+					username: username.to_string(),
+					password: password.to_string(),
+				})
 			}
-		}
-		None => {
-			return Err(AuthError::BadCredentials);
-		}
+		},
+		None => Err(AuthError::BadCredentials),
 	}
 }
 

--- a/core/src/filesystem/media/builder.rs
+++ b/core/src/filesystem/media/builder.rs
@@ -193,6 +193,6 @@ mod tests {
 		let series_id = "series_id";
 		let config = Arc::new(StumpConfig::debug());
 
-		MediaBuilder::new(&path, series_id, library_options, &config).build()
+		MediaBuilder::new(path, series_id, library_options, &config).build()
 	}
 }


### PR DESCRIPTION
Fix issue where passwords containing `:` character break Basic Auth used on API endpoints (particularly OPDS).