### PR TITLE
:pencil2: Fix infered typo

### DIFF
--- a/core/src/filesystem/content_type.rs
+++ b/core/src/filesystem/content_type.rs
@@ -44,7 +44,7 @@ fn infer_mime_from_bytes(bytes: &[u8]) -> Option<String> {
 fn infer_mime(path: &Path) -> Option<String> {
 	match infer::get_from_path(path) {
 		Ok(result) => {
-			tracing::trace!(?path, ?result, "infered mime");
+			tracing::trace!(?path, ?result, "inferred mime");
 			result.map(|infer_type| infer_type.mime_type().to_string())
 		},
 		Err(e) => {


### PR DESCRIPTION
Quick fix of a typo I noticed while looking at logs (`infered` -> `inferred`). Doesn't appear anywhere else, just this one place.