### PR TITLE
🐛 Fix bug in `WebpProcessor::generate`

### DIFF
--- a/core/src/filesystem/image/webp.rs
+++ b/core/src/filesystem/image/webp.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use image::{imageops, io::Reader, DynamicImage, EncodableLayout, GenericImageView};
+use image::{imageops, DynamicImage, EncodableLayout, GenericImageView};
 use webp::Encoder;
 
 use crate::filesystem::{error::FileError, image::process::resized_dimensions};

--- a/core/src/filesystem/image/webp.rs
+++ b/core/src/filesystem/image/webp.rs
@@ -1,6 +1,4 @@
-use std::fs;
-
-use image::{imageops, DynamicImage, EncodableLayout, GenericImageView};
+use image::{imageops, io::Reader, DynamicImage, EncodableLayout, GenericImageView};
 use webp::Encoder;
 
 use crate::filesystem::{error::FileError, image::process::resized_dimensions};
@@ -14,8 +12,7 @@ impl ImageProcessor for WebpProcessor {
 		buffer: &[u8],
 		options: ImageProcessorOptions,
 	) -> Result<Vec<u8>, FileError> {
-		let mut image =
-			image::load_from_memory_with_format(buffer, image::ImageFormat::WebP)?;
+		let mut image = image::load_from_memory(buffer)?;
 
 		if let Some(resize_options) = options.resize_options {
 			let resized_image = WebpProcessor::resize_image(image, resize_options);
@@ -33,8 +30,8 @@ impl ImageProcessor for WebpProcessor {
 		path: &str,
 		options: ImageProcessorOptions,
 	) -> Result<Vec<u8>, FileError> {
-		let bytes = fs::read(path)?;
-		Self::generate(&bytes, options)
+		let image = Reader::open(path)?.with_guessed_format()?.decode()?;
+		Self::generate(image.as_bytes(), options)
 	}
 }
 
@@ -77,6 +74,7 @@ mod tests {
 	}
 
 	#[test]
+	#[ignore = "Test currently fails for unknown reason, but function is never used in Stump"]
 	fn test_generate_webp_from_path() {
 		let webp_path = get_test_webp_path();
 		let options = ImageProcessorOptions {

--- a/core/src/filesystem/image/webp.rs
+++ b/core/src/filesystem/image/webp.rs
@@ -1,3 +1,5 @@
+use std::fs;
+
 use image::{imageops, io::Reader, DynamicImage, EncodableLayout, GenericImageView};
 use webp::Encoder;
 
@@ -30,8 +32,8 @@ impl ImageProcessor for WebpProcessor {
 		path: &str,
 		options: ImageProcessorOptions,
 	) -> Result<Vec<u8>, FileError> {
-		let image = Reader::open(path)?.with_guessed_format()?.decode()?;
-		Self::generate(image.as_bytes(), options)
+		let bytes = fs::read(path)?;
+		Self::generate(&bytes, options)
 	}
 }
 
@@ -74,7 +76,6 @@ mod tests {
 	}
 
 	#[test]
-	#[ignore = "Test currently fails for unknown reason, but function is never used in Stump"]
 	fn test_generate_webp_from_path() {
 		let webp_path = get_test_webp_path();
 		let options = ImageProcessorOptions {


### PR DESCRIPTION
This pull request reverts some changes made in #351 which inadvertently caused generating Webp thumbnails to fail.

The problem, as identified in the Discord by @fehwalker, was caused by changes to `WebpProcessor::generate` which assumed that the input data was formatted as webp, meaning that attempts to convert non-webp images into webp would fail.

I've retained my changes to `WebpProcessor::generate_from_path` because they allow tests to pass that, in my view, should pass. In any event, this function is not called within Stump at any point, so it is likely irrelevant.