### PR TITLE
:adhesive_bandage: Fix path filter on push

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: dorny/paths-filter@v2
         id: filter
         with:
+          base: 'experimental'
           filters: |
             apps: ./apps/**
             crates: ./crates/**

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: dorny/paths-filter@v2
         id: filter
         with:
+          base: 'develop'
           filters: |
             apps: ./apps/**
             crates: ./crates/**


### PR DESCRIPTION
I noticed that while the path filters work as expected for PR events, once merged the base which it uses to diff against is main, which means there will almost always be code-related changes and so the builds don't get skipped. By specifying the base, I'm hoping this gets fixed. The docs state this arg is ignored for PR events, so should have no effect there