### PR TITLE
👷 Run ci on pushes to develop

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+      - develop
+
 jobs:
   code-changes-check:
     runs-on: [ubuntu-22.04]


### PR DESCRIPTION
This small change will run the CI when a change is made to `develop` (in addition to `main`) and should make it easier to track improvements in coverage over time.