### PR TITLE
:lipstick: Pin actions column on user table

### DIFF
--- a/packages/browser/src/scenes/settings/server/users/user-table/UserTable.tsx
+++ b/packages/browser/src/scenes/settings/server/users/user-table/UserTable.tsx
@@ -120,6 +120,9 @@ export default function UserTable() {
 					onPaginationChange: setPagination,
 					pageCount,
 					state: {
+						columnPinning: {
+							right: ['actions'],
+						},
 						pagination,
 					},
 				}}


### PR DESCRIPTION
This pull request addresses an issue reported in #372. Although that issue has been closed with the addition of a scroll bar to the table, this pull request additionally pins the `actions` column on the user table to the right so that it will always be visible regardless of where the table has been scrolled to.