### PR TITLE
:bug: Fix invalid SQL for library stats query

### DIFF
--- a/packages/browser/src/scenes/book/BookOverviewScene.tsx
+++ b/packages/browser/src/scenes/book/BookOverviewScene.tsx
@@ -78,7 +78,6 @@ export default function BookOverviewScene() {
 		)
 	}
 
-	// TODO(historical-read-session): double check default order
 	const completedAt = sortBy(media.finished_reading_sessions, ({ completed_at }) =>
 		dayjs(completed_at).toDate(),
 	).at(-1)?.completed_at


### PR DESCRIPTION
This was missed before the historical read history feature was merged, the SQL referenced a now non-existent table