### PR TITLE
:pushpin: Pin `@icons-pack/react-simple-icons` to `9.1.0`

### DIFF
--- a/docs/components/DownloadLinks.tsx
+++ b/docs/components/DownloadLinks.tsx
@@ -29,6 +29,7 @@ export default function DownloadLinks() {
 						target="_blank"
 						rel="noreferrer"
 					>
+						{/* @ts-expect-error: Its fine */}
 						<link.icon className="h-5 w-5" />
 					</a>
 				</motion.div>

--- a/docs/components/Footer.tsx
+++ b/docs/components/Footer.tsx
@@ -70,6 +70,7 @@ export default function Footer() {
 							className="text-gray-750 hover:text-gray-650 dark:text-gray-300 dark:hover:text-gray-100"
 						>
 							<span className="sr-only">{item.name}</span>
+							{/* @ts-expect-error: Its fine */}
 							<item.icon className="h-6 w-6" aria-hidden="true" />
 						</a>
 					))}

--- a/docs/components/Hero.tsx
+++ b/docs/components/Hero.tsx
@@ -53,6 +53,7 @@ export default function Hero() {
 							href="https://www.github.com/stumpapp/stump"
 							target="_blank"
 						>
+							{/* @ts-expect-error: its fine */}
 							<SiGithub />
 
 							<span>See on Github</span>

--- a/docs/package.json
+++ b/docs/package.json
@@ -17,7 +17,7 @@
 	"author": "",
 	"license": "ISC",
 	"dependencies": {
-		"@icons-pack/react-simple-icons": "^9.1.0",
+		"@icons-pack/react-simple-icons": "=9.1.0",
 		"clsx": "2.0.0",
 		"framer-motion": "^10.16.4",
 		"next": "^13.5.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2757,10 +2757,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz#d9fae00a2d5cb40f92cfe64b47ad749fbc38f917"
   integrity sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==
 
-"@icons-pack/react-simple-icons@^9.1.0":
-  version "9.3.0"
-  resolved "https://registry.yarnpkg.com/@icons-pack/react-simple-icons/-/react-simple-icons-9.3.0.tgz#a3901d7eb0f2f4109d8f2c584f537cea056aa238"
-  integrity sha512-e2VRDFrhI9rCkEdkuAUhf/Ool0cwusWnwKqMACbIRMLHXxnHp1SdnGlRaEEjDeF4R0pQaEkmVNs2x2vn1sl+7A==
+"@icons-pack/react-simple-icons@=9.1.0":
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/@icons-pack/react-simple-icons/-/react-simple-icons-9.1.0.tgz#8267121647e979daf1f84ea9c7a87fb7a6a8ca0a"
+  integrity sha512-3v6W4SgkYX6bHfKrFvRZrxilv+4wXKYQ2DVRldqaZgcwGK5ajsW4PzLlqF9aw+uT/NeoMklunonoYwZlx9Kbwg==
 
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"


### PR DESCRIPTION
See https://github.com/simple-icons/simple-icons/issues/11236

This PR pins the dependency as an immediate and temporary fix. The full fix will be to remove the pin and manually get the Microsoft approved icons to use