### PR TITLE
🔨 Fix docker `dav1d` shared library linking 

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,15 +63,7 @@ WORKDIR /app
 
 COPY . .
 
-#Prisma generate makes running the Docker build locally/directly possible without extra config and shouldn't cause extra build time in CI because of caching
-#RUN cargo prisma generate --schema=./core/prisma/schema.prisma; \
-#    ./scripts/release/utils.sh -w; \
-#    set -ex; \
-#    ./scripts/release/utils.sh -p; \
-#    cargo build --package stump_server --bin stump_server --release; \
-#    cp ./target/release/stump_server ./stump_server
-
-RUN cargo codegen #cargo prisma generate --schema=./core/prisma/schema.prisma
+RUN cargo codegen
 RUN ./scripts/release/utils.sh -w 
 RUN set -ex
 RUN ./scripts/release/utils.sh -p

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 # Frontend Build Stage
 # ------------------------------------------------------------------------------
 
-FROM node:20.0.0-alpine3.16 as frontend
+FROM node:20.0.0-alpine3.16 AS frontend
 ARG TARGETARCH
 
 WORKDIR /app
@@ -51,18 +51,32 @@ WORKDIR /dav1d/build
 
 RUN meson setup ../; \ 
     ninja; \
-    ninja install 
+    ninja install; \
+    ln -s /usr/local/lib/x86_64-linux-gnu/libdav1d.so.7.0.0 /usr/local/lib/libdav1d.so.7; \
+    ln -s /usr/local/lib/x86_64-linux-gnu/libdav1d.so.7.0.0 /usr/local/lib/libdav1d.so.7.0; \
+    ln -s /usr/local/lib/x86_64-linux-gnu/libdav1d.so.7.0.0 /usr/local/lib/libdav1d.so.7.0.0; \
+    echo "/usr/local/lib" >> /etc/ld.so.conf.d/mylibs.conf \
+    && ldconfig
 
 #Cargo build for stump
 WORKDIR /app
 
 COPY . .
 
-RUN ./scripts/release/utils.sh -w; \
-    set -ex; \
-    ./scripts/release/utils.sh -p; \
-    cargo build --package stump_server --bin stump_server --release; \
-    cp ./target/release/stump_server ./stump_server
+#Prisma generate makes running the Docker build locally/directly possible without extra config and shouldn't cause extra build time in CI because of caching
+#RUN cargo prisma generate --schema=./core/prisma/schema.prisma; \
+#    ./scripts/release/utils.sh -w; \
+#    set -ex; \
+#    ./scripts/release/utils.sh -p; \
+#    cargo build --package stump_server --bin stump_server --release; \
+#    cp ./target/release/stump_server ./stump_server
+
+RUN cargo codegen #cargo prisma generate --schema=./core/prisma/schema.prisma
+RUN ./scripts/release/utils.sh -w 
+RUN set -ex
+RUN ./scripts/release/utils.sh -p
+RUN cargo build --package stump_server --bin stump_server --release
+RUN cp ./target/release/stump_server ./stump_server
 
 # ------------------------------------------------------------------------------
 # PDFium Stage

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,7 +63,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN cargo codegen
+RUN cargo prisma generate --schema ./core/prisma/schema.prisma
 RUN ./scripts/release/utils.sh -w 
 RUN set -ex
 RUN ./scripts/release/utils.sh -p

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,9 @@ RUN yarn config set network-timeout 300000 && \
 
 FROM rust:1.79.0-slim-buster AS builder
 
+# ARG TARGETARCH
 ARG GIT_REV
+
 ENV GIT_REV=${GIT_REV}
 
 ARG TAGS
@@ -40,7 +42,7 @@ RUN apt-get update && apt-get install -y \
     nasm \
     libsqlite3-dev;
 
-#Building dav1d for AVIF Support
+# Building dav1d for AVIF Support
 RUN git clone https://github.com/stumpapp/dav1d.git
 
 WORKDIR /dav1d
@@ -51,14 +53,9 @@ WORKDIR /dav1d/build
 
 RUN meson setup ../; \ 
     ninja; \
-    ninja install; \
-    ln -s /usr/local/lib/x86_64-linux-gnu/libdav1d.so.7.0.0 /usr/local/lib/libdav1d.so.7; \
-    ln -s /usr/local/lib/x86_64-linux-gnu/libdav1d.so.7.0.0 /usr/local/lib/libdav1d.so.7.0; \
-    ln -s /usr/local/lib/x86_64-linux-gnu/libdav1d.so.7.0.0 /usr/local/lib/libdav1d.so.7.0.0; \
-    echo "/usr/local/lib" >> /etc/ld.so.conf.d/mylibs.conf \
-    && ldconfig
+    ninja install
 
-#Cargo build for stump
+# Cargo build for stump
 WORKDIR /app
 
 COPY . .
@@ -90,6 +87,22 @@ RUN apt-get update && apt-get install -y curl tar; \
     rm pdfium.tgz
 
 # ------------------------------------------------------------------------------
+# dav1d Copy Stage
+# ------------------------------------------------------------------------------
+
+FROM debian:buster-slim AS dav1d
+ARG TARGETARCH
+
+COPY --from=builder /usr/local/lib /usr/local/lib
+
+RUN set -ex; \
+    if [ "$TARGETARCH" = "amd64" ]; then \
+        cp -r /usr/local/lib/x86_64-linux-gnu/* /usr/local/lib; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+        cp -r /usr/local/lib/aarch64-linux-gnu/* /usr/local/lib; \
+    fi
+
+# ------------------------------------------------------------------------------
 # Final Stage
 # ------------------------------------------------------------------------------
 
@@ -98,15 +111,17 @@ FROM debian:buster-slim
 RUN apt-get update && apt-get install -y locales-all && rm -rf /var/lib/apt/lists/*; \
     mkdir -p config && mkdir -p data && mkdir -p app
 
-COPY --from=builder /usr/local/lib /usr/local/lib
-COPY --from=builder /etc/ld.so.conf.d/mylibs.conf  /etc/ld.so.conf.d/mylibs.conf
 COPY --from=builder /app/stump_server /app/stump
 COPY --from=pdfium /pdfium /opt/pdfium
+COPY --from=dav1d /usr/local/lib/ /usr/local/lib/
 COPY --from=frontend /app/build /app/client
 COPY docker/entrypoint.sh /entrypoint.sh
 
+
 RUN chmod +x /entrypoint.sh; \
     ln -s /opt/pdfium/lib/libpdfium.so /lib/libpdfium.so; \
+    echo "/usr/local/lib" >> /etc/ld.so.conf.d/mylibs.conf \
+    && ldconfig; \
     if [ ! -d "/app/client" ] || [ ! "$(ls -A /app/client)" ]; then exit 1; fi
 
 # Default Stump environment variables

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,12 +63,11 @@ WORKDIR /app
 
 COPY . .
 
-RUN cargo prisma generate --schema ./core/prisma/schema.prisma
-RUN ./scripts/release/utils.sh -w 
-RUN set -ex
-RUN ./scripts/release/utils.sh -p
-RUN cargo build --package stump_server --bin stump_server --release
-RUN cp ./target/release/stump_server ./stump_server
+RUN ./scripts/release/utils.sh -w; \
+    set -ex; \
+    ./scripts/release/utils.sh -p; \
+    cargo build --package stump_server --bin stump_server --release; \
+    cp ./target/release/stump_server ./stump_server
 
 # ------------------------------------------------------------------------------
 # PDFium Stage

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -98,6 +98,8 @@ FROM debian:buster-slim
 RUN apt-get update && apt-get install -y locales-all && rm -rf /var/lib/apt/lists/*; \
     mkdir -p config && mkdir -p data && mkdir -p app
 
+COPY --from=builder /usr/local/lib /usr/local/lib
+COPY --from=builder /etc/ld.so.conf.d/mylibs.conf  /etc/ld.so.conf.d/mylibs.conf
 COPY --from=builder /app/stump_server /app/stump
 COPY --from=pdfium /pdfium /opt/pdfium
 COPY --from=frontend /app/build /app/client

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,9 +63,9 @@ WORKDIR /app
 
 COPY . .
 
-RUN ./scripts/release/utils.sh -w; \
+RUN cargo prisma generate --schema ./core/prisma/schema.prisma; \
+    ./scripts/release/utils.sh -w; \
     set -ex; \
-    ./scripts/release/utils.sh -p; \
     cargo build --package stump_server --bin stump_server --release; \
     cp ./target/release/stump_server ./stump_server
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -54,6 +54,9 @@ fi
 # Change current working directory
 cd /app
 
+# Make sure shared libraries are linked
+echo '/usr/local/lib' >> /etc/ld.so.conf.d/mylibs.conf && ldconfig
+
 if [[ "$PUID" -eq 0 ]]; then
     # Run as root
     /app/stump


### PR DESCRIPTION
Adding explicit linking to the process appears to fix the error that I was experiencing in Docker builds that I mentioned in [#406](https://github.com/stumpapp/stump/issues/406#issuecomment-2299452296):

```
stump  | /app/stump: error while loading shared libraries: libdav1d.so.7: cannot open shared object file: No such file or directory
stump exited with code 0
```

The Dockerfile still does not build locally despite adding a step to generate `prisma.rs` because of this error but that seems to be a separate issue:
```
                                                      ^^^^^^^^^^^^ help: a static with a similar name exists: `DATAMODEL_STR`
175.6
175.6 error[E0425]: cannot find value `MIGRATIONS_DIR` in module `super`
175.6  --> core/src/prisma.rs:3:3446816
175.6   |
175.6 3 | ...igrate_deploy (super :: DATAMODEL_STR , super :: MIGRATIONS_DIR , & self . 0 . url ()) . await ; :: prisma_client_rust :: tokio :: tim...
175.6   |                                                     ^^^^^^^^^^^^^^ not found in `super`
175.6
175.6 error[E0425]: cannot find value `MIGRATIONS_DIR` in module `super`
175.6  --> core/src/prisma.rs:3:3447215
175.6   |
175.6 3 | ...e (migration , super :: DATAMODEL_STR , super :: MIGRATIONS_DIR , & self . 0 . url () ,) . await } pub fn _db_push (& self) -> :: pris...
175.6   |                                                     ^^^^^^^^^^^^^^ not found in `super`
175.6
175.6 For more information about this error, try `rustc --explain E0425`.
175.6 error: could not compile `stump_core` (lib) due to 5 previous errors
```