### PR TITLE
:bug: Fix OPDS thumbnail endpoint

### DIFF
--- a/apps/server/src/routers/api/v1/media.rs
+++ b/apps/server/src/routers/api/v1/media.rs
@@ -204,8 +204,6 @@ pub(crate) fn apply_media_library_not_hidden_for_user_filter(
 	])])]
 }
 
-// FIXME: hidden libraries introduced a bug here, need to fix!
-
 pub(crate) fn apply_media_filters_for_user(
 	filters: MediaFilter,
 	user: &User,
@@ -955,6 +953,8 @@ async fn get_media_page(
 	}
 }
 
+// TODO: Refactor this transaction. I must have been very tired when I wrote it lol
+// No thoughts, head empty
 pub(crate) async fn get_media_thumbnail_by_id(
 	id: String,
 	db: &PrismaClient,

--- a/apps/server/src/routers/opds/v1_2.rs
+++ b/apps/server/src/routers/opds/v1_2.rs
@@ -20,13 +20,14 @@ use stump_core::{
 	prisma::{active_reading_session, library, media, series, user},
 };
 use tower_sessions::Session;
-use tracing::{debug, trace, warn};
+use tracing::{debug, trace};
 
 use crate::{
 	config::state::AppState,
 	errors::{APIError, APIResult},
 	filter::chain_optional_iter,
 	middleware::auth::Auth,
+	routers::api::v1::media::get_media_thumbnail_by_id,
 	utils::{
 		enforce_session_permissions, get_session_user,
 		http::{ImageResponse, NamedFile, Xml},
@@ -513,6 +514,7 @@ async fn get_series_by_id(
 	}
 }
 
+// TODO: support something like `STRICT_OPDS` to enforce OPDS compliance conditionally
 fn handle_opds_image_response(
 	content_type: ContentType,
 	image_buffer: Vec<u8>,
@@ -521,11 +523,10 @@ fn handle_opds_image_response(
 		trace!("OPDS legacy image detected, returning as-is");
 		Ok(ImageResponse::new(content_type, image_buffer))
 	} else {
-		warn!(
+		tracing::warn!(
 			?content_type,
 			"Unsupported image for OPDS detected, converting to JPEG"
 		);
-		// let jpeg_buffer = image::jpeg_from_bytes(&image_buffer)?;
 		let jpeg_buffer = GenericImageProcessor::generate(
 			&image_buffer,
 			ImageProcessorOptions::jpeg(),
@@ -540,24 +541,9 @@ async fn get_book_thumbnail(
 	State(ctx): State<AppState>,
 	session: Session,
 ) -> APIResult<ImageResponse> {
-	let db = &ctx.db;
-	let user = get_session_user(&session)?;
-	let age_restrictions = user
-		.age_restriction
-		.as_ref()
-		.map(|ar| apply_media_age_restriction(ar.age, ar.restrict_on_unset));
+	let (content_type, image_buffer) =
+		get_media_thumbnail_by_id(id, &ctx.db, &session, &ctx.config).await?;
 
-	let book = db
-		.media()
-		.find_first(chain_optional_iter(
-			[media::id::equals(id.clone())],
-			[age_restrictions],
-		))
-		.exec()
-		.await?
-		.ok_or(APIError::NotFound(String::from("Book not found")))?;
-
-	let (content_type, image_buffer) = get_page(book.path.as_str(), 1, &ctx.config)?;
 	handle_opds_image_response(content_type, image_buffer)
 }
 


### PR DESCRIPTION
Fixes an issue where generated thumbnails aren't actually being loaded, rather the file is being opened. I also made a note for two items:

- Improve a silly query
- Support `STRICT_OPDS` configuration, which will convert any non-compliant OPDS images, rather than just always doing it

I will tackle both alongside the image serving work I plan to do this weekend

See [Discord](https://discord.com/channels/972593831172272148/972595055061794856/1276284767133896856) for additional context