### PR TITLE
:bug: Fix regression in scanner for root-level series

### DIFF
--- a/core/src/db/entity/library/entity.rs
+++ b/core/src/db/entity/library/entity.rs
@@ -5,11 +5,10 @@ use specta::Type;
 use utoipa::ToSchema;
 
 use crate::{
+	db::entity::{Cursor, Series, Tag},
 	filesystem::image::ImageProcessorOptions,
 	prisma::{self, library},
 };
-
-use super::{common::Cursor, series::Series, tag::Tag};
 
 //////////////////////////////////////////////
 //////////////// PRISMA MACROS ///////////////

--- a/core/src/db/entity/library/mod.rs
+++ b/core/src/db/entity/library/mod.rs
@@ -1,0 +1,4 @@
+mod entity;
+pub(crate) mod prisma_macros;
+
+pub use entity::*;

--- a/core/src/db/entity/library/prisma_macros.rs
+++ b/core/src/db/entity/library/prisma_macros.rs
@@ -1,0 +1,14 @@
+use crate::prisma::library;
+
+library::select!(library_tags_select {
+	id
+	tags: select {
+		id
+		name
+	}
+});
+
+library::select!(library_path_with_options_select {
+	path
+	library_options
+});

--- a/core/src/db/entity/mod.rs
+++ b/core/src/db/entity/mod.rs
@@ -39,6 +39,7 @@ pub use common::{
 
 pub mod macros {
 	pub use super::book_club::prisma_macros::*;
+	pub use super::library::prisma_macros::*;
 	pub use super::media::prisma_macros::*;
 	pub use super::metadata::prisma_macros::*;
 	pub use super::smart_list::prisma_macros::*;

--- a/core/src/filesystem/scanner/library_scan_job.rs
+++ b/core/src/filesystem/scanner/library_scan_job.rs
@@ -409,10 +409,12 @@ impl JobExt for LibraryScanJob {
 					format!("Scanning series at {}", path_buf.display()).as_str(),
 				));
 
+				let series_is_library_root = path_buf == PathBuf::from(&self.path);
 				let max_depth = self
 					.options
 					.as_ref()
-					.and_then(|o| o.is_collection_based().then_some(1));
+					.and_then(|o| o.is_collection_based().then_some(1))
+					.or_else(|| series_is_library_root.then_some(1));
 
 				let ignore_rules = generate_rule_set(&[
 					path_buf.clone(),

--- a/core/src/filesystem/scanner/series_scan_job.rs
+++ b/core/src/filesystem/scanner/series_scan_job.rs
@@ -5,7 +5,9 @@ use specta::Type;
 
 use crate::{
 	db::{
-		entity::{CoreJobOutput, LibraryOptions},
+		entity::{
+			macros::library_path_with_options_select, CoreJobOutput, LibraryOptions,
+		},
 		FileStatus,
 	},
 	filesystem::image::{ThumbnailGenerationJob, ThumbnailGenerationJobParams},
@@ -13,7 +15,7 @@ use crate::{
 		error::JobError, Executor, JobExt, JobOutputExt, JobProgress, JobTaskOutput,
 		WorkerCtx, WorkerSendExt, WorkingState, WrappedJob,
 	},
-	prisma::{library, library_options, media, series, PrismaClient},
+	prisma::{library, media, series, PrismaClient},
 	utils::chain_optional_iter,
 	CoreEvent,
 };
@@ -94,23 +96,27 @@ impl JobExt for SeriesScanJob {
 		ctx: &WorkerCtx,
 	) -> Result<WorkingState<Self::Output, Self::Task>, JobError> {
 		let mut output = Self::Output::default();
-		let library_options = ctx
+		let library = ctx
 			.db
-			.library_options()
-			.find_first(vec![library_options::library::is(vec![
-				library::series::some(vec![
-					series::id::equals(self.id.clone()),
-					series::path::equals(self.path.clone()),
-				]),
+			.library()
+			.find_first(vec![library::series::some(vec![
+				series::id::equals(self.id.clone()),
+				series::path::equals(self.path.clone()),
 			])])
+			.select(library_path_with_options_select::select())
 			.exec()
 			.await?
-			.map(LibraryOptions::from)
 			.ok_or(JobError::InitFailed(
-				"Associated library options not found".to_string(),
+				"Associated library not found".to_string(),
 			))?;
+		let library_path = PathBuf::from(library.path);
+		let library_options = LibraryOptions::from(library.library_options);
+		let series_is_library_root = PathBuf::from(&self.path) == library_path;
 		let ignore_rules = generate_rule_set(&[PathBuf::from(self.path.clone())]);
-		let max_depth = library_options.is_collection_based().then_some(1);
+		let max_depth = library_options
+			.is_collection_based()
+			.then_some(1)
+			.or_else(|| series_is_library_root.then_some(1));
 
 		self.options = Some(library_options);
 

--- a/core/src/filesystem/scanner/walk.rs
+++ b/core/src/filesystem/scanner/walk.rs
@@ -235,13 +235,19 @@ pub async fn walk_series(path: &Path, ctx: WalkerCtx) -> CoreResult<WalkedSeries
 	}
 
 	let WalkerCtx {
-		db, ignore_rules, ..
+		db,
+		ignore_rules,
+		max_depth,
 	} = ctx;
 
 	tracing::debug!("Walking series at {}", path.display());
 
+	let mut walker = WalkDir::new(path);
+	if let Some(num) = max_depth {
+		walker = walker.max_depth(num);
+	}
+
 	let walk_start = std::time::Instant::now();
-	let walker = WalkDir::new(path);
 	let (valid_entries, ignored_entries) = walker
 		.into_iter()
 		.filter_map(|e| e.ok())


### PR DESCRIPTION
A cherry-pick of https://github.com/stumpapp/stump/pull/422/commits/61e7dbdd03b296bae40340a379c0b476a238c4fc which contains a fix for root-level series scanning (i.e. the library itself is a series)