### PR TITLE
:bug: Fix max-depth for collection-priority libraries

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -34,12 +34,14 @@ runs:
     - name: Format tags
       run: |
         echo "FORMATTED_TAGS=$(echo ${{ inputs.tags }} | sed -e 's/,/,aaronleopold\/stump:/g' | sed -e 's/^/aaronleopold\/stump:/')" >> $GITHUB_ENV
+        echo "LOCAL_IMAGES=$(echo ${{ inputs.tags }} | sed -e 's/,/ /g' | sed -e 's/^/localhost\/stump:/')" >> $GITHUB_ENV
       shell: bash
 
     - name: Sanity check
       run: |
         echo "TAGS=${{ inputs.tags }}"
         echo "FORMATTED_TAGS=${{ env.FORMATTED_TAGS }}"
+        echo "LOCAL_IMAGES=${{ env.LOCAL_IMAGES }}"
         echo "GIT_REV=${{ env.GIT_REV }}"
       shell: bash
 
@@ -72,6 +74,11 @@ runs:
       run: |
         sudo apt-get update
         sudo apt-get install -y podman buildah
+      shell: bash
+
+    - name: Remove existing images
+      run: |
+        podman rmi ${{ env.LOCAL_IMAGES }} || true
       shell: bash
 
     - name: Run buildah build

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -34,7 +34,7 @@ runs:
     - name: Format tags
       run: |
         echo "FORMATTED_TAGS=$(echo ${{ inputs.tags }} | sed -e 's/,/,aaronleopold\/stump:/g' | sed -e 's/^/aaronleopold\/stump:/')" >> $GITHUB_ENV
-        echo "LOCAL_IMAGES=$(echo ${{ inputs.tags }} | sed -e 's/,/ /g' | sed -e 's/^/localhost\/stump:/')" >> $GITHUB_ENV
+        echo "LOCAL_IMAGES=$(echo ${{ inputs.tags }} | sed -e 's/,/,localhost\/stump:/g' | sed -e 's/^/localhost\/stump:/')" >> $GITHUB_ENV
       shell: bash
 
     - name: Sanity check

--- a/core/src/filesystem/scanner/library_scan_job.rs
+++ b/core/src/filesystem/scanner/library_scan_job.rs
@@ -409,12 +409,15 @@ impl JobExt for LibraryScanJob {
 					format!("Scanning series at {}", path_buf.display()).as_str(),
 				));
 
-				let series_is_library_root = path_buf == PathBuf::from(&self.path);
+				// If the library is collection-priority, any child directories are 'ignored' and their
+				// files are part of / folded into the top-most folder (series).
+				// If the library is not collection-priority, each subdirectory is its own series.
+				// Therefore, we only scan one level deep when walking a series whose library is not
+				// collection-priority to avoid scanning duplicates which are part of other series
 				let max_depth = self
 					.options
 					.as_ref()
-					.and_then(|o| o.is_collection_based().then_some(1))
-					.or_else(|| series_is_library_root.then_some(1));
+					.and_then(|o| (!o.is_collection_based()).then_some(1));
 
 				let ignore_rules = generate_rule_set(&[
 					path_buf.clone(),

--- a/core/src/filesystem/scanner/series_scan_job.rs
+++ b/core/src/filesystem/scanner/series_scan_job.rs
@@ -109,14 +109,15 @@ impl JobExt for SeriesScanJob {
 			.ok_or(JobError::InitFailed(
 				"Associated library not found".to_string(),
 			))?;
-		let library_path = PathBuf::from(library.path);
 		let library_options = LibraryOptions::from(library.library_options);
-		let series_is_library_root = PathBuf::from(&self.path) == library_path;
 		let ignore_rules = generate_rule_set(&[PathBuf::from(self.path.clone())]);
-		let max_depth = library_options
-			.is_collection_based()
-			.then_some(1)
-			.or_else(|| series_is_library_root.then_some(1));
+
+		// If the library is collection-priority, any child directories are 'ignored' and their
+		// files are part of / folded into the top-most folder (series).
+		// If the library is not collection-priority, each subdirectory is its own series.
+		// Therefore, we only scan one level deep when walking a series whose library is not
+		// collection-priority to avoid scanning duplicates which are part of other series
+		let max_depth = (!library_options.is_collection_based()).then_some(1);
 
 		self.options = Some(library_options);
 


### PR DESCRIPTION
Fixes a bug introduced from the fix which aimed to correct a regression in the scanner lol https://github.com/stumpapp/stump/pull/423

The crux of the issue is outlined in the code to (hopefully) prevent a similar bug from slipping through the cracks again: 

```
If the library is collection-priority, any child directories are 'ignored' and their files are part of / folded into the top-most folder (series).
If the library is not collection-priority, each subdirectory is its own series.
Therefore, we only scan one level deep when walking a series whose library is not collection-priority to avoid scanning duplicates which are part of other series
```