### PR TITLE
:arrow_up: Update bundled `PDFium` version in Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -67,9 +67,9 @@ RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/
         mkdir -p pdfium; \
         if [ "$TARGETARCH" = "amd64" ]; then \
             # NOTE: This was previously -x86, need to test more on amd64-compatible systems to ensure I have the right one
-            curl -sLo pdfium.tgz https://github.com/bblanchon/pdfium-binaries/releases/download/chromium/6406/pdfium-linux-x64.tgz; \
+            curl -sLo pdfium.tgz https://github.com/bblanchon/pdfium-binaries/releases/download/chromium/6707/pdfium-linux-x64.tgz; \
         elif [ "$TARGETARCH" = "arm64" ]; then \
-            curl -sLo pdfium.tgz https://github.com/bblanchon/pdfium-binaries/releases/download/chromium/6406/pdfium-linux-arm64.tgz; \
+            curl -sLo pdfium.tgz https://github.com/bblanchon/pdfium-binaries/releases/download/chromium/6707/pdfium-linux-arm64.tgz; \
         fi; \
         tar -xzvf pdfium.tgz -C ./pdfium; \
         rm pdfium.tgz


### PR DESCRIPTION
The updates from https://github.com/stumpapp/stump/pull/433 required updating the PDFium library, but that was missed. This PR updates to the latest `chromium/6707`

See https://discord.com/channels/972593831172272148/1283431932830547979 for more context