### PR TITLE
:bug: Fix Cantook crash on Android

### DIFF
--- a/apps/server/src/config/session/mod.rs
+++ b/apps/server/src/config/session/mod.rs
@@ -4,4 +4,4 @@ mod utils;
 
 pub use cleanup::SessionCleanupJob;
 pub use store::PrismaSessionStore;
-pub use utils::{get_session_layer, SESSION_USER_KEY};
+pub use utils::{delete_cookie_header, get_session_layer, SESSION_USER_KEY};

--- a/apps/server/src/config/session/utils.rs
+++ b/apps/server/src/config/session/utils.rs
@@ -38,3 +38,16 @@ pub fn get_session_layer(ctx: Arc<Ctx>) -> SessionManagerLayer<PrismaSessionStor
 		.with_same_site(SameSite::Lax)
 		.with_secure(false)
 }
+
+/// Returns a tuple with the Set-Cookie header name and value to delete the session cookie.
+/// To do this, we'll just set the cookie on the same name, path and domain, but with an
+/// Expires value in the past. This *should* hopefully trigger the client to delete the cookie.
+pub fn delete_cookie_header() -> (String, String) {
+	(
+		"Set-Cookie".to_string(),
+		format!(
+			"{}={}; Path={}; Domain={}; Expires={}; Max-Age=0",
+			SESSION_NAME, "", SESSION_PATH, "", "Thu, 01 Jan 1970 00:00:00 GMT"
+		),
+	)
+}

--- a/apps/server/src/errors.rs
+++ b/apps/server/src/errors.rs
@@ -26,6 +26,8 @@ use utoipa::ToSchema;
 use std::{net, num::TryFromIntError};
 use thiserror::Error;
 
+use crate::config::session::delete_cookie_header;
+
 /// A type alias for the result of a server operation
 pub type ServerResult<T> = Result<T, ServerError>;
 /// A type alias for the result of an API operation, e.g. the response of an axum handler
@@ -311,9 +313,19 @@ impl IntoResponse for APIErrorResponse {
 		});
 
 		let base_response = Json(body).into_response();
-		Response::builder()
+
+		let mut builder = Response::builder()
 			.status(self.status)
-			.header("Content-Type", "application/json")
+			.header("Content-Type", "application/json");
+
+		// if the status is 401, we want to encourage the client to delete their
+		// session cookie
+		if self.status == StatusCode::UNAUTHORIZED {
+			let (name, value) = delete_cookie_header();
+			builder = builder.header(name, value);
+		}
+
+		builder
 			.body(base_response.into_body())
 			.unwrap_or_else(|error| {
 				tracing::error!(?error, "Failed to build response");

--- a/apps/server/src/routers/api/v1/media.rs
+++ b/apps/server/src/routers/api/v1/media.rs
@@ -355,7 +355,7 @@ pub fn apply_media_restrictions_for_user(user: &User) -> Vec<WhereParam> {
 )]
 /// Get all media accessible to the requester. This is a paginated request, and
 /// has various pagination params available.
-#[tracing::instrument(err, ret, skip(ctx))]
+#[tracing::instrument(err, skip(ctx))]
 async fn get_media(
 	filter_query: QsQuery<FilterableQuery<MediaFilter>>,
 	pagination_query: Query<PaginationQuery>,


### PR DESCRIPTION
This PR contains two (and potentially 3) fixes relating to using the experimental OPDS V2 with Cantook on Android:

1. The `id` field in the auth document is now the full service URL, not the relative path. This caused an immediate crash on Android for whatever reason
2. The route handler which serves the auth document is now excluded from any auth guard. I am personally not a huge fan of this, as I like to minimize the surface of unauthenticated endpoints. However, there seems to be no other way around it
3. Instances of `APIError` (and a few other OPDS-specific 401 responses) will attempt to instruct the client to remove any cookies. The former _used_ to exist, however seems to have been accidentally removed as of https://github.com/stumpapp/stump/pull/400

I want to note that none of these issues surfaced in the Cantook iOS app. In fact, wrt the second fix mentioned above, iOS _correctly_ handles the 401 response which contains the auth document whereas the Android app doesn't 🤷 

See [discord thread](https://discord.com/channels/972593831172272148/972595055061794856/1285641670712623174) for more context