### PR TITLE
:bug: Fix create user form submit

### DIFF
--- a/packages/browser/src/paths.ts
+++ b/packages/browser/src/paths.ts
@@ -22,8 +22,6 @@ type SettingsPage =
 type DocTopic = 'access-control' | 'book-club'
 type BookClubTab = 'overview' | 'members' | 'chat-board' | 'settings'
 
-const IS_DEV = import.meta.env.DEV
-
 const paths = {
 	bookClub: (id: string, tab?: BookClubTab) => `/book-clubs/${id}${tab ? `/${tab}` : ''}`,
 	bookClubChatBoard: (id: string, chatBoardId?: string) => {
@@ -113,8 +111,7 @@ const paths = {
 	serverLogs: (jobId?: string) => paths.settings('server/logs') + (jobId ? `?job_id=${jobId}` : ''),
 	settings: (subpath: SettingsPage = 'app/general') => `/settings/${subpath || ''}`,
 	smartList: (id: string) => `/smart-lists/${id}`,
-	smartListCreate: () =>
-		IS_DEV ? '/smart-lists/create' : 'https://stumpapp.dev/guides/smart-list#creating-a-smart-list',
+	smartListCreate: () => '/smart-lists/create',
 	smartLists: () => '/smart-lists',
 	updateUser: (id: string) => `${paths.settings('server/users')}/${id}/manage`,
 } as const

--- a/packages/browser/src/scenes/settings/app/general/ProfileForm.tsx
+++ b/packages/browser/src/scenes/settings/app/general/ProfileForm.tsx
@@ -11,6 +11,8 @@ import { useUser } from '@/stores'
 
 import AvatarPicker from './AvatarPicker'
 
+// TODO(testing): extract schema and test components individually
+
 export default function ProfileForm() {
 	const { t } = useLocaleContext()
 	const { updateAsync } = useUpdateUser()

--- a/packages/browser/src/scenes/settings/server/users/create-or-update/AccountDetails.tsx
+++ b/packages/browser/src/scenes/settings/server/users/create-or-update/AccountDetails.tsx
@@ -1,32 +1,35 @@
 import { Button, IconButton, Input } from '@stump/components'
 import { Eye, EyeOff, Shield } from 'lucide-react'
 import React, { useState } from 'react'
-import { useFormContext } from 'react-hook-form'
+import { useFormContext, useFormState } from 'react-hook-form'
 
-import { Schema } from './CreateOrUpdateUserForm'
+import { CreateOrUpdateUserSchema } from './schema'
 
 export default function AccountDetails() {
-	const form = useFormContext<Schema>()
+	const form = useFormContext<CreateOrUpdateUserSchema>()
+	const { errors } = useFormState({ control: form.control })
 
 	const [passwordVisible, setPasswordVisible] = useState(false)
 
 	return (
 		<div className="flex flex-col gap-4 pb-4 pt-1 md:max-w-md">
 			<Input
+				id="username"
 				variant="primary"
 				fullWidth
 				label="Username"
 				placeholder="Username"
 				autoComplete="off"
-				errorMessage={form.formState.errors.username?.message}
+				errorMessage={errors.username?.message}
 				{...form.register('username')}
 			/>
 			<Input
+				id="password"
 				variant="primary"
 				fullWidth
 				label="Password"
 				placeholder="Password"
-				errorMessage={form.formState.errors.password?.message}
+				errorMessage={errors.password?.message}
 				type={passwordVisible ? 'text' : 'password'}
 				autoComplete="off"
 				rightDecoration={
@@ -36,6 +39,7 @@ export default function AccountDetails() {
 						size="xs"
 						onClick={() => setPasswordVisible(!passwordVisible)}
 						className="text-foreground-muted"
+						data-testid="togglePasswordVisibility"
 					>
 						{passwordVisible ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
 					</IconButton>
@@ -44,7 +48,11 @@ export default function AccountDetails() {
 			/>
 
 			<div className="flex items-center gap-1">
-				<Button type="button" onClick={() => form.setValue('password', generateRandomPassword())}>
+				<Button
+					type="button"
+					onClick={() => form.setValue('password', generateRandomPassword())}
+					data-testid="generatePassword"
+				>
 					<Shield className="mr-1.5 h-4 w-4" /> Generate Random Password
 				</Button>
 			</div>

--- a/packages/browser/src/scenes/settings/server/users/create-or-update/CreateOrUpdateUserForm.tsx
+++ b/packages/browser/src/scenes/settings/server/users/create-or-update/CreateOrUpdateUserForm.tsx
@@ -5,10 +5,9 @@ import { Alert, Button, Form, Heading, Text } from '@stump/components'
 import { useLocaleContext } from '@stump/i18n'
 import { User } from '@stump/types'
 import React, { useMemo } from 'react'
-import { useForm } from 'react-hook-form'
+import { useForm, useFormState } from 'react-hook-form'
 import toast from 'react-hot-toast'
 import { useNavigate } from 'react-router'
-import z from 'zod'
 
 import { ContentContainer } from '@/components/container'
 import paths from '@/paths'
@@ -16,45 +15,15 @@ import paths from '@/paths'
 import { useUserManagementContext } from '../context'
 import AccountDetails from './AccountDetails'
 import MaxSessionsAllowed from './MaxSessionsAllowed'
-import UserPermissionsForm, { userPermissionSchema } from './UserPermissionsForm'
+import { buildSchema, CreateOrUpdateUserSchema, formDefaults } from './schema'
+import UserPermissionsForm from './UserPermissionsForm'
 import UserRestrictionsForm from './UserRestrictionsForm'
-
-const buildSchema = (t: (key: string) => string, existingUsers: User[], updatingUser?: User) =>
-	z.object({
-		age_restriction: z
-			.number()
-			.optional()
-			.refine((value) => value == undefined || value >= 0, {
-				message: t('settingsScene.server/users.createOrUpdateForm.validation.ageRestrictionTooLow'),
-			}),
-		age_restriction_on_unset: z.boolean().optional(),
-		forbidden_tags: z.array(z.string()).optional(),
-		max_sessions_allowed: z.number().optional(),
-		password: z
-			.string()
-			// .min(1, { message: t('authScene.form.validation.missingPassword') })
-			.optional()
-			.refine(
-				// if we are updating a user, we don't need to validate the password
-				(value) => !!updatingUser || !!value,
-				() => ({ message: t('authScene.form.validation.missingPassword') }),
-			),
-		permissions: z.array(userPermissionSchema).optional(),
-		username: z
-			.string()
-			.min(1, { message: t('authScene.form.validation.missingUsername') })
-			.refine(
-				(value) =>
-					(!!updatingUser && value === updatingUser.username) ||
-					existingUsers.every((user) => user.username !== value),
-				(value) => ({ message: `${value} is already taken` }),
-			),
-	})
-export type Schema = z.infer<ReturnType<typeof buildSchema>>
 
 type Props = {
 	user?: User
 }
+
+// TODO(design): stepped form from bookclub feature branch
 
 export default function CreateOrUpdateUserForm({ user }: Props) {
 	const navigate = useNavigate()
@@ -64,19 +33,15 @@ export default function CreateOrUpdateUserForm({ user }: Props) {
 
 	const isCreating = !user
 	const schema = useMemo(() => buildSchema(t, users, user), [t, users, user])
-	const form = useForm<Schema>({
-		defaultValues: {
-			age_restriction: user?.age_restriction?.age,
-			age_restriction_on_unset: user?.age_restriction?.restrict_on_unset,
-			max_sessions_allowed: user?.max_sessions_allowed ?? undefined,
-			permissions: user?.permissions,
-			username: user?.username,
-		},
+
+	const form = useForm<CreateOrUpdateUserSchema>({
+		defaultValues: formDefaults(user),
 		resolver: zodResolver(schema),
 	})
+	const { errors: formErrors } = useFormState({ control: form.control })
 	const formHasErrors = useMemo(() => {
-		return Object.keys(form.formState.errors).length > 0
-	}, [form.formState])
+		return Object.keys(formErrors).length > 0
+	}, [formErrors])
 
 	const { createAsync, error: createError } = useCreateUser()
 	const { updateAsync, error: updateError } = useUpdateUser(user?.id)
@@ -87,7 +52,7 @@ export default function CreateOrUpdateUserForm({ user }: Props) {
 		permissions,
 		max_sessions_allowed,
 		...ageRestrictions
-	}: Schema) => {
+	}: CreateOrUpdateUserSchema) => {
 		try {
 			const age_restriction = ageRestrictions.age_restriction
 				? {
@@ -176,7 +141,12 @@ export default function CreateOrUpdateUserForm({ user }: Props) {
 				)}
 
 				<div className="mt-6 flex w-full md:max-w-sm">
-					<Button className="w-full md:max-w-sm" variant="primary" disabled={formHasErrors}>
+					<Button
+						type="submit"
+						className="w-full md:max-w-sm"
+						variant="primary"
+						disabled={formHasErrors}
+					>
 						{t(
 							isCreating
 								? 'settingsScene.server/users.createOrUpdateForm.createSubmitButton'

--- a/packages/browser/src/scenes/settings/server/users/create-or-update/MaxSessionsAllowed.tsx
+++ b/packages/browser/src/scenes/settings/server/users/create-or-update/MaxSessionsAllowed.tsx
@@ -1,48 +1,49 @@
 import { Input } from '@stump/components'
-import React, { useEffect } from 'react'
-import { useFormContext } from 'react-hook-form'
+import React, { useCallback, useEffect } from 'react'
+import { useFormContext, useFormState } from 'react-hook-form'
 
-import { Schema } from './CreateOrUpdateUserForm'
+import { CreateOrUpdateUserSchema } from './schema'
 
 export default function MaxSessionsAllowed() {
-	const form = useFormContext<Schema>()
+	const form = useFormContext<CreateOrUpdateUserSchema>()
+	const { errors } = useFormState({ control: form.control })
 
 	const [max_sessions_allowed] = form.watch(['max_sessions_allowed'])
 
-	useEffect(
-		() => {
-			if (max_sessions_allowed == undefined) {
+	useEffect(() => {
+		const isSameValue = max_sessions_allowed === form.getValues('max_sessions_allowed')
+		if (max_sessions_allowed == undefined && !isSameValue) {
+			form.setValue('max_sessions_allowed', undefined)
+			form.clearErrors('max_sessions_allowed')
+		}
+	}, [form, max_sessions_allowed])
+
+	const handleChange = useCallback(
+		(e: React.ChangeEvent<HTMLInputElement>) => {
+			const { value } = e.target
+
+			if (value === '' || value == undefined) {
 				form.setValue('max_sessions_allowed', undefined)
-				form.clearErrors('max_sessions_allowed')
+			} else {
+				const parsed = parseInt(value)
+				if (!isNaN(parsed)) {
+					form.setValue('max_sessions_allowed', parsed)
+				}
 			}
 		},
-
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-		[max_sessions_allowed],
+		[form],
 	)
-
-	const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		const { value } = e.target
-
-		if (value === '' || value == undefined) {
-			form.setValue('max_sessions_allowed', undefined)
-		} else {
-			const parsed = parseInt(value)
-			if (!isNaN(parsed)) {
-				form.setValue('max_sessions_allowed', parsed)
-			}
-		}
-	}
 
 	return (
 		<Input
+			id="max_sessions_allowed"
 			variant="primary"
 			label="Max sessions allowed"
 			description="The maximum number of valid sessions allowed at a time. If a user tries to log in once this limit is reached, the oldest session will be invalidated."
 			type="number"
 			name="max_sessions_allowed"
 			value={max_sessions_allowed}
-			errorMessage={form.formState.errors.max_sessions_allowed?.message}
+			errorMessage={errors.max_sessions_allowed?.message}
 			onChange={handleChange}
 		/>
 	)

--- a/packages/browser/src/scenes/settings/server/users/create-or-update/UserPermissionsForm.tsx
+++ b/packages/browser/src/scenes/settings/server/users/create-or-update/UserPermissionsForm.tsx
@@ -3,40 +3,12 @@ import { useLocaleContext } from '@stump/i18n'
 import { UserPermission } from '@stump/types'
 import { useEffect } from 'react'
 import { useFormContext } from 'react-hook-form'
-import z from 'zod'
 
 import paths from '@/paths'
 
-import { Schema } from './CreateOrUpdateUserForm'
+import { allPermissions, CreateOrUpdateUserSchema } from './schema'
 
-export const allPermissions = [
-	'bookclub:read',
-	'bookclub:create',
-	'email:arbitrary_send',
-	'email:send',
-	'emailer:create',
-	'emailer:manage',
-	'emailer:read',
-	'file:explorer',
-	'file:upload',
-	'file:download',
-	'library:create',
-	'library:edit',
-	'library:scan',
-	'library:manage',
-	'library:delete',
-	'user:read',
-	'user:manage',
-	'server:manage',
-	'smartlist:read',
-	'notifier:read',
-	'notifier:create',
-	'notifier:delete',
-	'notifier:manage',
-] as const
-export const userPermissionSchema = z.enum(allPermissions)
-
-const associatedPermissions: Record<UserPermission, UserPermission[]> = {
+export const associatedPermissions: Record<UserPermission, UserPermission[]> = {
 	'bookclub:create': ['bookclub:read'],
 	'bookclub:read': [],
 	'email:arbitrary_send': ['email:send'],
@@ -62,7 +34,16 @@ const associatedPermissions: Record<UserPermission, UserPermission[]> = {
 	'user:read': [],
 }
 
-const prefixes = ['bookclub', 'file', 'library', 'user', 'server', 'smartlist'] as const
+const prefixes = [
+	'bookclub',
+	'file',
+	'emailer',
+	'email',
+	'library',
+	'user',
+	'server',
+	'smartlist',
+] as const
 
 const LOCAL_BASE = 'settingsScene.server/users.createOrUpdateForm.permissions'
 const getLocaleKey = (path: string) => `${LOCAL_BASE}.${path}`
@@ -78,25 +59,25 @@ const getPermissionDescription = (permission: UserPermission) => {
 }
 const getPrefixLabel = (prefix: string) => getLocaleKey(`${prefix}.label`)
 
+// TODO(design): refactor this monolith of checkboxes
+
 export default function UserPermissionsForm() {
 	const { t } = useLocaleContext()
-	const form = useFormContext<Schema>()
 
-	const selectedPermissions = form.watch('permissions') ?? []
+	const form = useFormContext<CreateOrUpdateUserSchema>()
 
-	useEffect(
-		() => {
-			const selectionsWithAssociations = selectedPermissions.reduce<UserPermission[]>(
-				(acc, permission) => [...acc, permission, ...associatedPermissions[permission]],
-				[],
-			)
-			const uniqueSelections = [...new Set(selectionsWithAssociations)]
+	const selectedPermissions = form.watch('permissions')
+
+	useEffect(() => {
+		const selectionsWithAssociations = (selectedPermissions || []).reduce<UserPermission[]>(
+			(acc, permission) => [...acc, permission, ...associatedPermissions[permission]],
+			[],
+		)
+		const uniqueSelections = [...new Set(selectionsWithAssociations)]
+		if (uniqueSelections.length !== selectedPermissions?.length) {
 			form.setValue('permissions', uniqueSelections)
-		},
-
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-		[selectedPermissions],
-	)
+		}
+	}, [form, selectedPermissions])
 
 	const handlePermissionClick = (permission: UserPermission) => {
 		const selected = form.getValues('permissions') ?? []
@@ -122,8 +103,9 @@ export default function UserPermissionsForm() {
 					<CheckBox
 						id={permission}
 						variant="primary"
+						name={permission}
 						label={label}
-						checked={selectedPermissions.includes(permission)}
+						checked={selectedPermissions?.includes(permission) ?? false}
 						onClick={() => handlePermissionClick(permission)}
 						value={permission}
 					/>
@@ -169,7 +151,9 @@ export default function UserPermissionsForm() {
 					return (
 						<div key={prefix} className="flex flex-col gap-3">
 							<Label>{label}</Label>
-							{renderSection(allPermissions.filter((permission) => permission.startsWith(prefix)))}
+							{renderSection(
+								allPermissions.filter((permission) => splitPermission(permission)[0] === prefix),
+							)}
 						</div>
 					)
 				})}

--- a/packages/browser/src/scenes/settings/server/users/create-or-update/__tests__/AccountDetails.test.tsx
+++ b/packages/browser/src/scenes/settings/server/users/create-or-update/__tests__/AccountDetails.test.tsx
@@ -1,0 +1,79 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Form } from '@stump/components'
+import { User } from '@stump/types'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useForm } from 'react-hook-form'
+
+import AccountDetails from '../AccountDetails'
+import { buildSchema, CreateOrUpdateUserSchema, formDefaults } from '../schema'
+
+const onSubmit = jest.fn()
+
+type SubjectProps = {
+	formState?: Partial<Pick<CreateOrUpdateUserSchema, 'username' | 'password'>>
+	existingUsers?: User[]
+}
+
+const Subject = ({ formState, existingUsers = [] }: SubjectProps) => {
+	const form = useForm<Pick<CreateOrUpdateUserSchema, 'username' | 'password'>>({
+		defaultValues: formDefaults(formState as User | undefined),
+		resolver: zodResolver(buildSchema((t) => t, existingUsers, formState as User | undefined)),
+	})
+
+	return (
+		<Form form={form} onSubmit={onSubmit}>
+			<AccountDetails />
+
+			<button type="submit">Submit</button>
+		</Form>
+	)
+}
+
+describe('AccountDetails', () => {
+	beforeEach(() => {
+		jest.clearAllMocks()
+	})
+
+	it('should render', () => {
+		expect(render(<Subject />).container).not.toBeEmptyDOMElement()
+	})
+
+	it('should mask the password by default and allow toggling visibility', async () => {
+		const { getByTestId } = render(<Subject />)
+
+		const passwordInput = getByTestId('password') as HTMLInputElement
+		expect(passwordInput.type).toBe('password')
+
+		await act(async () => {
+			fireEvent.click(getByTestId('togglePasswordVisibility'))
+		})
+
+		expect(passwordInput.type).toBe('text')
+	})
+
+	it('should generate a random password', () => {
+		const { getByTestId } = render(<Subject />)
+		// value empty
+		const passwordInput = getByTestId('password') as HTMLInputElement
+		expect(passwordInput.value).toBe('')
+
+		const generatePasswordButton = getByTestId('generatePassword')
+		fireEvent.click(generatePasswordButton)
+		expect(passwordInput.value).not.toBe('')
+		expect(passwordInput.value).toHaveLength(16)
+	})
+
+	it('should properly display errors', async () => {
+		const { getByTestId } = render(<Subject existingUsers={[{ username: 'bob' } as any]} />)
+
+		const user = userEvent.setup()
+
+		await user.type(getByTestId('username'), 'bob') // Duplicate username
+		await user.click(screen.getByRole('button', { name: /submit/i })) // No password
+
+		expect(onSubmit).not.toHaveBeenCalled()
+		expect(screen.getByText(/usernameAlreadyExists/i)).toBeInTheDocument()
+		expect(screen.getByText(/missingPassword/i)).toBeInTheDocument()
+	})
+})

--- a/packages/browser/src/scenes/settings/server/users/create-or-update/__tests__/MaxSessionsAllowed.test.tsx
+++ b/packages/browser/src/scenes/settings/server/users/create-or-update/__tests__/MaxSessionsAllowed.test.tsx
@@ -1,0 +1,78 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Form } from '@stump/components'
+import { User } from '@stump/types'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useForm } from 'react-hook-form'
+
+import MaxSessionsAllowed from '../MaxSessionsAllowed'
+import { buildSchema, CreateOrUpdateUserSchema, formDefaults } from '../schema'
+
+const onSubmit = jest.fn()
+
+type SubjectProps = {
+	formState?: Partial<Pick<CreateOrUpdateUserSchema, 'max_sessions_allowed'>>
+}
+
+const Subject = ({ formState }: SubjectProps) => {
+	const form = useForm<Pick<CreateOrUpdateUserSchema, 'max_sessions_allowed'>>({
+		defaultValues: formDefaults(formState as User | undefined),
+		resolver: zodResolver(buildSchema((t) => t, [], formState as User | undefined)),
+	})
+
+	return (
+		<Form form={form} onSubmit={onSubmit}>
+			<MaxSessionsAllowed />
+			<button type="submit">Submit</button>
+		</Form>
+	)
+}
+
+describe('MaxSessionsAllowed', () => {
+	// TODO: fix the warning about uncontrolled input
+	const originalError = console.error
+	beforeAll(() => {
+		console.error = jest.fn()
+	})
+	afterAll(() => {
+		console.error = originalError
+	})
+
+	beforeEach(() => {
+		jest.clearAllMocks()
+	})
+
+	it('should render', () => {
+		expect(render(<Subject />).container).not.toBeEmptyDOMElement()
+	})
+
+	it('should not allow an invalid number', async () => {
+		render(<Subject />)
+
+		const user = userEvent.setup()
+
+		await user.type(screen.getByTestId('max_sessions_allowed'), 'abc')
+		await user.click(screen.getByRole('button', { name: /submit/i }))
+
+		expect(onSubmit).not.toHaveBeenCalled()
+	})
+
+	it('should display errors', async () => {
+		render(
+			<Subject
+				formState={{
+					max_sessions_allowed: 1,
+				}}
+			/>,
+		)
+
+		const user = userEvent.setup()
+
+		await user.clear(screen.getByTestId('max_sessions_allowed'))
+		await user.type(screen.getByTestId('max_sessions_allowed'), '-1')
+		await user.click(screen.getByRole('button', { name: /submit/i }))
+
+		expect(onSubmit).not.toHaveBeenCalled()
+		expect(screen.getByText(/maxSessionsAllowedTooLow/i)).toBeInTheDocument()
+	})
+})

--- a/packages/browser/src/scenes/settings/server/users/create-or-update/__tests__/UserPermissionsForm.test.tsx
+++ b/packages/browser/src/scenes/settings/server/users/create-or-update/__tests__/UserPermissionsForm.test.tsx
@@ -1,0 +1,68 @@
+import '@/__mocks__/resizeObserver'
+
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Form } from '@stump/components'
+import { User, UserPermission } from '@stump/types'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useForm } from 'react-hook-form'
+
+import { buildSchema, CreateOrUpdateUserSchema, formDefaults } from '../schema'
+import UserPermissionsForm, { associatedPermissions } from '../UserPermissionsForm'
+
+const onSubmit = jest.fn()
+
+const userDefaults = {
+	username: 'test',
+} as User
+
+const Subject = () => {
+	const form = useForm<Pick<CreateOrUpdateUserSchema, 'permissions'>>({
+		defaultValues: formDefaults(userDefaults),
+		resolver: zodResolver(buildSchema((t) => t, [], userDefaults)),
+	})
+
+	return (
+		<Form form={form} onSubmit={onSubmit}>
+			<UserPermissionsForm />
+			<button type="submit">Submit</button>
+		</Form>
+	)
+}
+
+describe('UserPermissionsForm', () => {
+	beforeEach(() => {
+		jest.clearAllMocks()
+	})
+
+	it('should render', () => {
+		expect(render(<Subject />).container).not.toBeEmptyDOMElement()
+	})
+
+	it('should automatically select associated permissions', async () => {
+		const user = userEvent.setup()
+
+		const experiments = Object.entries(associatedPermissions)
+			.filter(([, associations]) => associations.length > 0)
+			.filter(([permission]) => !permission.startsWith('notifier')) // TODO: undo when notifier features available
+			.map(([permission]) => permission) as UserPermission[]
+
+		for (const permission of experiments) {
+			const { unmount } = render(<Subject />)
+
+			await user.click(screen.getByTestId(permission))
+			await user.click(screen.getByRole('button', { name: /submit/i }))
+
+			const expected = associatedPermissions[permission]
+
+			expect(onSubmit).toHaveBeenCalledWith(
+				expect.objectContaining({
+					permissions: expect.arrayContaining(expected),
+				}),
+				expect.anything(), // event
+			)
+			onSubmit.mockClear()
+			unmount()
+		}
+	})
+})

--- a/packages/browser/src/scenes/settings/server/users/create-or-update/__tests__/UserRestrictionsForm.test.tsx
+++ b/packages/browser/src/scenes/settings/server/users/create-or-update/__tests__/UserRestrictionsForm.test.tsx
@@ -1,0 +1,90 @@
+import '@/__mocks__/resizeObserver'
+
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Form } from '@stump/components'
+import { User } from '@stump/types'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useForm } from 'react-hook-form'
+
+import { buildSchema, CreateOrUpdateUserSchema, formDefaults } from '../schema'
+import UserRestrictionsForm from '../UserRestrictionsForm'
+
+const onSubmit = jest.fn()
+
+const userDefaults = {
+	username: 'test',
+} as User
+
+const Subject = () => {
+	const form = useForm<
+		Pick<CreateOrUpdateUserSchema, 'age_restriction_on_unset' | 'age_restriction'>
+	>({
+		defaultValues: formDefaults(userDefaults),
+		resolver: zodResolver(buildSchema((t) => t, [], userDefaults)),
+	})
+
+	return (
+		<Form form={form} onSubmit={onSubmit}>
+			<UserRestrictionsForm />
+			<button type="submit">Submit</button>
+		</Form>
+	)
+}
+
+describe('UserRestrictionsForm', () => {
+	beforeEach(() => {
+		jest.clearAllMocks()
+	})
+
+	it('should render', () => {
+		expect(render(<Subject />).container).not.toBeEmptyDOMElement()
+	})
+
+	it('should not allow an invalid number', async () => {
+		render(<Subject />)
+
+		const user = userEvent.setup()
+
+		await user.type(screen.getByTestId('age_restriction'), 'abc')
+		await user.click(screen.getByRole('button', { name: /submit/i }))
+
+		expect(onSubmit).toHaveBeenCalledWith(
+			expect.objectContaining({ age_restriction: undefined }),
+			expect.anything(), // event
+		)
+	})
+
+	it('should uncheck the age_restriction_on_unset if age_restriction is unset', async () => {
+		render(<Subject />)
+
+		const user = userEvent.setup()
+
+		await user.type(screen.getByTestId('age_restriction'), '12')
+		await user.click(screen.getByTestId('age_restriction_enabled'))
+		await user.click(screen.getByRole('button', { name: /submit/i }))
+
+		expect(onSubmit).toHaveBeenCalledWith(
+			expect.objectContaining({ age_restriction: 12, age_restriction_on_unset: true }),
+			expect.anything(), // event
+		)
+
+		onSubmit.mockClear()
+
+		await user.clear(screen.getByTestId('age_restriction'))
+		await user.click(screen.getByRole('button', { name: /submit/i }))
+		expect(onSubmit).toHaveBeenCalledWith(
+			expect.objectContaining({ age_restriction: undefined, age_restriction_on_unset: undefined }),
+			expect.anything(), // event
+		)
+	})
+
+	it('should disable the age_restriction_on_unset if age_restriction is unset', async () => {
+		render(<Subject />)
+
+		const user = userEvent.setup()
+		expect(screen.getByTestId('age_restriction_enabled')).toBeDisabled()
+		await user.type(screen.getByTestId('age_restriction'), '12')
+		expect(screen.getByTestId('age_restriction_enabled')).not.toBeDisabled()
+	})
+})

--- a/packages/browser/src/scenes/settings/server/users/create-or-update/__tests__/schema.test.ts
+++ b/packages/browser/src/scenes/settings/server/users/create-or-update/__tests__/schema.test.ts
@@ -1,0 +1,65 @@
+import { User } from '@stump/types'
+
+import { allPermissions, buildSchema } from '../schema'
+
+const validUser = {
+	id: '1',
+	permissions: [],
+	username: 'test',
+} as unknown as User
+
+const createUser = (overrides: Partial<User> & { password?: string } = {}): User => ({
+	...validUser,
+	...overrides,
+})
+
+describe('CreateOrUpdateUserSchema', () => {
+	describe('base', () => {
+		it('should enforce a non-empty username', () => {
+			const schema = buildSchema(() => '', [], createUser())
+
+			const result = schema.safeParse({ username: '' })
+			expect(result.success).toBe(false)
+		})
+
+		it('should enforce a non-empty password when creating', () => {
+			const schema = buildSchema(() => '', [])
+
+			const result = schema.safeParse(createUser({ password: '' }))
+			expect(result.success).toBe(false)
+		})
+
+		it('should allow no password when updating', () => {
+			const schema = buildSchema(() => '', [], createUser())
+
+			// This gets treated as no update in the backend
+			const result = schema.safeParse(createUser({ password: '' }))
+			expect(result.success).toBe(true)
+		})
+
+		it('should enforce a non-negative age restriction', () => {
+			const schema = buildSchema(() => '', [], createUser())
+
+			const result = schema.safeParse({ age_restriction: -1 })
+			expect(result.success).toBe(false)
+		})
+	})
+
+	describe('userPermissionSchema', () => {
+		it('should allow all valid permissions', () => {
+			const schema = buildSchema(() => '', [], createUser())
+
+			allPermissions.forEach((permission) => {
+				const result = schema.safeParse({ permissions: [permission] })
+				expect(result.success).toBe(true)
+			})
+		})
+
+		it('should not allow invalid permissions', () => {
+			const schema = buildSchema(() => '', [], createUser())
+
+			const result = schema.safeParse({ permissions: ['invalid'] })
+			expect(result.success).toBe(false)
+		})
+	})
+})

--- a/packages/browser/src/scenes/settings/server/users/create-or-update/schema.ts
+++ b/packages/browser/src/scenes/settings/server/users/create-or-update/schema.ts
@@ -1,0 +1,89 @@
+import { User } from '@stump/types'
+import { z } from 'zod'
+
+export const allPermissions = [
+	'bookclub:read',
+	'bookclub:create',
+	'email:arbitrary_send',
+	'email:send',
+	'emailer:create',
+	'emailer:manage',
+	'emailer:read',
+	'file:explorer',
+	'file:upload',
+	'file:download',
+	'library:create',
+	'library:edit',
+	'library:scan',
+	'library:manage',
+	'library:delete',
+	'user:read',
+	'user:manage',
+	'server:manage',
+	'smartlist:read',
+	'notifier:read',
+	'notifier:create',
+	'notifier:delete',
+	'notifier:manage',
+] as const
+export const userPermissionSchema = z.enum(allPermissions)
+
+export const buildSchema = (
+	t: (key: string) => string,
+	existingUsers: User[],
+	editingUser?: User,
+) =>
+	z.object({
+		age_restriction: z
+			.number()
+			.optional()
+			.refine((value) => value == undefined || value >= 0, {
+				message: t('settingsScene.server/users.createOrUpdateForm.validation.ageRestrictionTooLow'),
+			}),
+		age_restriction_on_unset: z.boolean().optional(),
+		forbidden_tags: z.array(z.string()).optional(),
+		max_sessions_allowed: z
+			.number()
+			.optional()
+			.refine((value) => value == undefined || value >= 0, {
+				message: t(
+					'settingsScene.server/users.createOrUpdateForm.validation.maxSessionsAllowedTooLow',
+				),
+			}),
+		password: z
+			.string()
+			// .min(1, { message: t('authScene.form.validation.missingPassword') })
+			.optional()
+			.refine(
+				// if we are updating a user, we don't need to validate the password
+				(value) => !!editingUser || !!value,
+				() => ({ message: t('authScene.form.validation.missingPassword') }),
+			),
+		permissions: z
+			.array(userPermissionSchema)
+			.optional()
+			.default(editingUser?.permissions ?? []),
+		username: z
+			.string()
+			.min(1, { message: t('authScene.form.validation.missingUsername') })
+			.refine(
+				(value) =>
+					(!!editingUser && value === editingUser.username) ||
+					existingUsers.every((user) => user.username !== value),
+				() => ({
+					message: t(
+						'settingsScene.server/users.createOrUpdateForm.validation.usernameAlreadyExists',
+					),
+				}),
+			)
+			.default(editingUser?.username ?? ''),
+	})
+export type CreateOrUpdateUserSchema = z.infer<ReturnType<typeof buildSchema>>
+
+export const formDefaults = (editingUser?: User): CreateOrUpdateUserSchema => ({
+	age_restriction: editingUser?.age_restriction?.age,
+	age_restriction_on_unset: editingUser?.age_restriction?.restrict_on_unset,
+	max_sessions_allowed: editingUser?.max_sessions_allowed ?? undefined,
+	permissions: editingUser?.permissions ?? [],
+	username: editingUser?.username ?? '',
+})

--- a/packages/browser/src/scenes/smartList/create-or-update/form/schema.ts
+++ b/packages/browser/src/scenes/smartList/create-or-update/form/schema.ts
@@ -145,6 +145,8 @@ export const schema = z.object({
 	visibility: z.union([z.literal('PUBLIC'), z.literal('SHARED'), z.literal('PRIVATE')]),
 })
 
+// FIXME: I think this suffers from heavy recursive issues, zod has a guide for this:
+// https://github.com/colinhacks/zod?tab=readme-ov-file#recursive-types
 export type Schema = z.infer<typeof schema>
 
 // yikes

--- a/packages/browser/src/scenes/smartList/settings/UserSmartListSettingsScene.tsx
+++ b/packages/browser/src/scenes/smartList/settings/UserSmartListSettingsScene.tsx
@@ -1,5 +1,5 @@
 import { Button, Form, Heading, Input, Text, TextArea } from '@stump/components'
-import { useForm } from 'react-hook-form'
+import { useForm, useFormState } from 'react-hook-form'
 import toast from 'react-hot-toast'
 
 import { ContentContainer, SceneContainer } from '@/components/container'
@@ -27,6 +27,7 @@ export default function UserSmartListSettingsScene() {
 			name,
 		},
 	})
+	const { isSubmitting } = useFormState({ control: form.control })
 
 	const handleSubmit = async (data: BasicDetailsForm) => {
 		try {
@@ -58,7 +59,7 @@ export default function UserSmartListSettingsScene() {
 						/>
 
 						<div>
-							<Button variant="primary" disabled={form.formState.isSubmitting}>
+							<Button type="submit" variant="primary" disabled={isSubmitting}>
 								Save changes
 							</Button>
 						</div>

--- a/packages/components/src/button/Button.tsx
+++ b/packages/components/src/button/Button.tsx
@@ -26,7 +26,8 @@ export const BUTTON_VARIANTS = {
 	outline: 'bg-transparent border border-edge-subtle hover:bg-background-surface text-foreground',
 	primary:
 		'bg-brand-500 text-white hover:bg-brand-600 dark:hover:bg-brand-600 focus:ring-brand-400 data-[state=open]:bg-brand-600',
-	secondary: 'bg-inverse text-background hover:bg-inverse/90 data-[state=open]:bg-inverse/90',
+	secondary:
+		'bg-background-inverse text-foreground-on-inverse hover:bg-background-inverse/90 data-[state=open]:bg-background-inverse/90',
 	subtle: 'bg-background-surface hover:bg-background-surface-hover text-foreground-subtle',
 	'subtle-dark':
 		'bg-background text-foreground-subtle hover:bg-background-surface data-[state=open]:bg-background-surface',

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -11,7 +11,8 @@
 		"form": {
 			"validation": {
 				"missingUsername": "Username is required",
-				"missingPassword": "Password is required"
+				"missingPassword": "Password is required",
+				"usernameAlreadyExists": "Username already exists"
 			},
 			"labels": {
 				"username": "Username",
@@ -967,6 +968,32 @@
 						"upload": {
 							"label": "Upload files",
 							"description": "Allows the user to upload files to the server"
+						}
+					},
+					"emailer": {
+						"label": "Emailers",
+						"read": {
+							"label": "Access emailers",
+							"description": "Allows the user to view the configured emailers"
+						},
+						"create": {
+							"label": "Create emailers",
+							"description": "Allows the user to create new emailers"
+						},
+						"manage": {
+							"label": "Manage emailers",
+							"description": "Allows the user to manage existing emailers"
+						}
+					},
+					"email": {
+						"label": "Emailing",
+						"send": {
+							"label": "Send emails",
+							"description": "Allows the user to send emails from the server to any configured aliases"
+						},
+						"arbitrary_send": {
+							"label": "Send arbitrary emails",
+							"description": "Allows the user to send emails from the server to any email address"
 						}
 					},
 					"library": {


### PR DESCRIPTION
This PR fixes a recent regression in nightly causing the submit button for the create/update user form to not submit the form. This doesn't affect the latest build

I took this as an opportunity to refactor some of the code in that section, primarily using `useFormState` where necessary, and added a suite of tests to assert basic behavior