### PR TITLE
:green_heart: Fix latest builds for rootless docker

### DIFF
--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -70,7 +70,7 @@ jobs:
   build-stable-docker:
     if: contains(github.event.pull_request.head.ref, 'release/v')
     name: Build docker image
-    runs-on: [self-hosted]
+    runs-on: [self-hosted-large]
     needs: [parse-semver, push-or-load]
     steps:
       - name: Checkout repository


### PR DESCRIPTION
It was brought to my attention that my version of buildah causes issues with rootless docker. Until I can update both runners to be at a version where the issue doesn't present, the release workflow will have to be set to only run on the larger runner