### PR TITLE
:rotating_light: Fix fmt after rust upgrade

### DIFF
--- a/core/src/job/worker.rs
+++ b/core/src/job/worker.rs
@@ -226,7 +226,8 @@ impl Worker {
 		config: Arc<StumpConfig>,
 		core_event_tx: broadcast::Sender<CoreEvent>,
 		job_controller_tx: mpsc::UnboundedSender<JobControllerCommand>,
-	) -> Result<(Self, WorkerCtx, async_channel::Receiver<WorkerStatusEvent>), JobError> {
+	) -> Result<(Self, WorkerCtx, async_channel::Receiver<WorkerStatusEvent>), JobError>
+	{
 		let (commands_tx, commands_rx) = async_channel::unbounded::<WorkerCommand>();
 		let (status_tx, status_rx) = async_channel::unbounded::<WorkerStatusEvent>();
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -19,6 +19,7 @@ mod utils;
 mod context;
 pub mod error;
 
+#[rustfmt::skip]
 #[allow(warnings, unused)]
 pub mod prisma;
 


### PR DESCRIPTION
Should fix the following: https://github.com/stumpapp/stump/actions/runs/11138014373/job/30952354385