### PR TITLE
🚨 Run clippy pedantic

### DIFF
--- a/apps/server/src/errors.rs
+++ b/apps/server/src/errors.rs
@@ -290,7 +290,7 @@ impl From<std::io::Error> for APIError {
 }
 
 /// The response body for API errors. This is just a basic JSON response with a status code and a message.
-/// Any axum handlers which return a Result with an Error of APIError will be converted into this response.
+/// Any axum handlers which return a [`Result`] with an Error of [`APIError`] will be converted into this response.
 pub struct APIErrorResponse {
 	status: StatusCode,
 	message: String,

--- a/apps/server/src/filter/basic_filter.rs
+++ b/apps/server/src/filter/basic_filter.rs
@@ -257,7 +257,7 @@ pub struct MediaMetadataFilter {
 	pub relation_filter: MediaMetadataRelationFilter,
 }
 
-/// A user-friendly representation of a media's read_progress. This will map to
+/// A user-friendly representation of a media's `read_progress`. This will map to
 /// a query condition that will be used to filter the media.
 #[derive(Default, Debug, Clone, Deserialize, Serialize, ToSchema)]
 pub enum ReadStatus {
@@ -278,7 +278,7 @@ impl FromStr for ReadStatus {
 			"unread" => Ok(ReadStatus::Unread),
 			"reading" => Ok(ReadStatus::Reading),
 			"completed" => Ok(ReadStatus::Completed),
-			_ => Err(APIError::BadRequest(format!("invalid read status: {}", s))),
+			_ => Err(APIError::BadRequest(format!("invalid read status: {s}"))),
 		}
 	}
 }

--- a/apps/server/src/middleware/auth.rs
+++ b/apps/server/src/middleware/auth.rs
@@ -163,8 +163,7 @@ pub async fn auth_middleware(
 			let opds_version = request_uri
 				.split('/')
 				.nth(2)
-				.map(|v| v.replace('v', ""))
-				.unwrap_or("1.2".to_string());
+				.map_or("1.2".to_string(), |v| v.replace('v', ""));
 
 			return Err(
 				OPDSBasicAuth::new(opds_version, host_details.url()).into_response()
@@ -664,7 +663,7 @@ mod tests {
 			.get("/test")
 			.add_header(
 				HeaderName::from_str("Authorization").expect("Failed to create header"),
-				HeaderValue::from_str(&format!("Bearer {}", access_token))
+				HeaderValue::from_str(&format!("Bearer {access_token}"))
 					.expect("Failed to create header"),
 			)
 			.await;
@@ -723,7 +722,7 @@ mod tests {
 			.get("/test")
 			.add_header(
 				HeaderName::from_str("Authorization").expect("Failed to create header"),
-				HeaderValue::from_str(&format!("Bearer {}", access_token))
+				HeaderValue::from_str(&format!("Bearer {access_token}"))
 					.expect("Failed to create header"),
 			)
 			.await;

--- a/apps/server/src/routers/api/v1/auth.rs
+++ b/apps/server/src/routers/api/v1/auth.rs
@@ -55,7 +55,7 @@ pub async fn enforce_max_sessions(
 			tracing::error!(?error, "Failed to load user's existing session(s)");
 			Vec::default()
 		})
-		.to_owned();
+		.clone();
 	let existing_login_sessions_count = existing_sessions.len() as i32;
 
 	match (for_user.max_sessions_allowed, existing_login_sessions_count) {
@@ -396,7 +396,7 @@ pub async fn register(
 	let created_user = db
 		.user()
 		.create(
-			input.username.to_owned(),
+			input.username.clone(),
 			hashed_password,
 			vec![user::is_server_owner::set(is_server_owner)],
 		)

--- a/apps/server/src/routers/api/v1/book_club.rs
+++ b/apps/server/src/routers/api/v1/book_club.rs
@@ -411,8 +411,7 @@ async fn create_book_club_invitation(
 	let invalid_role = payload
 		.role
 		.as_ref()
-		.map(|role| *role == BookClubMemberRole::CREATOR)
-		.unwrap_or(false);
+		.is_some_and(|role| *role == BookClubMemberRole::CREATOR);
 
 	if invalid_role {
 		return Err(APIError::BadRequest("Cannot invite a creator".to_string()));
@@ -833,11 +832,14 @@ async fn create_book_club_schedule(
 					},
 					(Some(start_at), None) => {
 						let start_at = safe_string_to_date(start_at);
-						(start_at, start_at + Duration::days(interval_days as i64))
+						(
+							start_at,
+							start_at + Duration::days(i64::from(interval_days)),
+						)
 					},
 					(None, Some(end_at)) => {
 						let end_at = safe_string_to_date(end_at);
-						(end_at - Duration::days(interval_days as i64), end_at)
+						(end_at - Duration::days(i64::from(interval_days)), end_at)
 					},
 					(None, None) => {
 						let start_at = if let Some(last_end_at) = last_end_at {
@@ -846,7 +848,10 @@ async fn create_book_club_schedule(
 							Utc::now()
 						};
 
-						(start_at, start_at + Duration::days(interval_days as i64))
+						(
+							start_at,
+							start_at + Duration::days(i64::from(interval_days)),
+						)
 					},
 				};
 
@@ -1000,11 +1005,14 @@ async fn add_books_to_book_club_schedule(
 			},
 			(Some(start_at), None) => {
 				let start_at = safe_string_to_date(start_at);
-				(start_at, start_at + Duration::days(interval_days as i64))
+				(
+					start_at,
+					start_at + Duration::days(i64::from(interval_days)),
+				)
 			},
 			(None, Some(end_at)) => {
 				let end_at = safe_string_to_date(end_at);
-				(end_at - Duration::days(interval_days as i64), end_at)
+				(end_at - Duration::days(i64::from(interval_days)), end_at)
 			},
 			(None, None) => {
 				let start_at = if let Some(last_end_at) = last_end_at {
@@ -1013,7 +1021,10 @@ async fn add_books_to_book_club_schedule(
 					Utc::now()
 				};
 
-				(start_at, start_at + Duration::days(interval_days as i64))
+				(
+					start_at,
+					start_at + Duration::days(i64::from(interval_days)),
+				)
 			},
 		};
 

--- a/apps/server/src/routers/api/v1/emailer.rs
+++ b/apps/server/src/routers/api/v1/emailer.rs
@@ -101,7 +101,7 @@ async fn get_emailers(
 
 	// TODO: consider auto truncating?
 	if include_params.include_send_history {
-		query = query.with(emailer::send_history::fetch(vec![]))
+		query = query.with(emailer::send_history::fetch(vec![]));
 	}
 
 	let emailers = query

--- a/apps/server/src/routers/api/v1/epub.rs
+++ b/apps/server/src/routers/api/v1/epub.rs
@@ -74,10 +74,7 @@ async fn get_epub_by_id(
 	if let Some(book) = result {
 		Ok(Json(Epub::try_from(book)?))
 	} else {
-		Err(APIError::NotFound(format!(
-			"Media with id {} not found",
-			id
-		)))
+		Err(APIError::NotFound(format!("Media with id {id} not found")))
 	}
 }
 
@@ -281,10 +278,7 @@ async fn get_epub_chapter(
 	if let Some(book) = result {
 		Ok(EpubProcessor::get_chapter(book.path.as_str(), chapter)?.into())
 	} else {
-		Err(APIError::NotFound(format!(
-			"Media with id {} not found",
-			id
-		)))
+		Err(APIError::NotFound(format!("Media with id {id} not found")))
 	}
 }
 
@@ -323,9 +317,6 @@ async fn get_epub_meta(
 
 		Ok(BufferResponse::new(content_type, buffer))
 	} else {
-		Err(APIError::NotFound(format!(
-			"Media with id {} not found",
-			id
-		)))
+		Err(APIError::NotFound(format!("Media with id {id} not found")))
 	}
 }

--- a/apps/server/src/routers/api/v1/filesystem.rs
+++ b/apps/server/src/routers/api/v1/filesystem.rs
@@ -103,7 +103,7 @@ fn read_and_filter_directory(
 	let listing = std::fs::read_dir(start_path)?;
 
 	let files = listing
-		.filter_map(|res| res.ok())
+		.filter_map(Result::ok)
 		.filter_map(filter_if_hidden)
 		.map(|entry| DirectoryListingFile::from(entry.path()))
 		.collect();
@@ -193,7 +193,7 @@ mod windows_fs {
 				};
 
 				let drive_text = match volume_name {
-					Some(name) => format!("{} ({})", drive_letter, name),
+					Some(name) => format!("{drive_letter} ({name})"),
 					None => drive_letter.clone(),
 				};
 

--- a/apps/server/src/routers/api/v1/job.rs
+++ b/apps/server/src/routers/api/v1/job.rs
@@ -107,10 +107,10 @@ async fn get_jobs(
 					},
 					Pagination::Cursor(cursor_query) => {
 						if let Some(cursor) = cursor_query.cursor {
-							query = query.cursor(job::id::equals(cursor)).skip(1)
+							query = query.cursor(job::id::equals(cursor)).skip(1);
 						}
 						if let Some(limit) = cursor_query.limit {
-							query = query.take(limit)
+							query = query.take(limit);
 						}
 					},
 					_ => unreachable!(),
@@ -213,13 +213,12 @@ async fn cancel_job_by_id(
 	))
 	.map_err(|e| {
 		APIError::InternalServerError(format!(
-			"Failed to send command to job manager: {}",
-			e
+			"Failed to send command to job manager: {e}"
 		))
 	})?;
 
 	Ok(task_rx.await.map_err(|e| {
-		APIError::InternalServerError(format!("Failed to get cancel confirmation: {}", e))
+		APIError::InternalServerError(format!("Failed to get cancel confirmation: {e}"))
 	})??)
 }
 

--- a/apps/server/src/routers/api/v1/log.rs
+++ b/apps/server/src/routers/api/v1/log.rs
@@ -105,7 +105,7 @@ async fn get_logs(
 							query = query.cursor(log::id::equals(cursor)).skip(1);
 						}
 						if let Some(limit) = cursor_query.limit {
-							query = query.take(limit)
+							query = query.take(limit);
 						}
 					},
 					_ => unreachable!(),
@@ -183,8 +183,6 @@ async fn tail_log_file(
 						.json_data(line.line())
 						.map_err(|e| APIError::InternalServerError(e.to_string()))?
 				);
-			} else {
-				continue;
 			}
 		}
 	};

--- a/apps/server/src/routers/api/v1/reading_list.rs
+++ b/apps/server/src/routers/api/v1/reading_list.rs
@@ -199,7 +199,7 @@ async fn create_reading_list(
 			let reading_list = client
 				.reading_list()
 				.create(
-					input.id.to_owned(),
+					input.id.clone(),
 					user::id::equals(user_id.clone()),
 					vec![reading_list::visibility::set(
 						input.visibility.unwrap_or_default().to_string(),
@@ -216,7 +216,7 @@ async fn create_reading_list(
 				.map(|(idx, media_id)| {
 					client.reading_list_item().create(
 						idx as i32,
-						media_id.to_owned(),
+						media_id.clone(),
 						reading_list::id::equals(reading_list.id.clone()),
 						// TODO: determine if connect is still needed...
 						vec![],
@@ -269,7 +269,7 @@ async fn get_reading_list_by_id(
 		.exec()
 		.await?
 		.ok_or_else(|| {
-			APIError::NotFound(format!("Reading list with ID {} not found", id))
+			APIError::NotFound(format!("Reading list with ID {id} not found"))
 		})?;
 
 	Ok(Json(ReadingList::from(reading_list)))
@@ -309,7 +309,7 @@ async fn update_reading_list(
 		.exec()
 		.await?
 		.ok_or_else(|| {
-			APIError::NotFound(format!("Reading List with id {} not found", id))
+			APIError::NotFound(format!("Reading List with id {id} not found"))
 		})?;
 
 	if reading_list.creating_user_id != user.id {
@@ -368,7 +368,7 @@ async fn delete_reading_list_by_id(
 		.exec()
 		.await?
 		.ok_or_else(|| {
-			APIError::NotFound(format!("Reading List with id {} not found", id))
+			APIError::NotFound(format!("Reading List with id {id} not found"))
 		})?;
 
 	if reading_list.creating_user_id != user.id {

--- a/apps/server/src/routers/api/v1/smart_list.rs
+++ b/apps/server/src/routers/api/v1/smart_list.rs
@@ -261,7 +261,7 @@ async fn get_smart_list_by_id(
 		.find_first(vec![smart_list::id::equals(id.clone()), access_condition]);
 
 	if options.load_views {
-		query = query.with(smart_list::saved_views::fetch(vec![]))
+		query = query.with(smart_list::saved_views::fetch(vec![]));
 	}
 
 	let smart_list = query

--- a/apps/server/src/routers/api/v1/tag.rs
+++ b/apps/server/src/routers/api/v1/tag.rs
@@ -77,8 +77,7 @@ async fn create_tags(
 			.join(", ");
 
 		return Err(APIError::BadRequest(format!(
-			"Attempted to create tags which already exist: {}",
-			existing_names
+			"Attempted to create tags which already exist: {existing_names}"
 		)));
 	}
 

--- a/apps/server/src/routers/api/v1/user.rs
+++ b/apps/server/src/routers/api/v1/user.rs
@@ -275,7 +275,7 @@ async fn update_user(
 			))
 		},
 		Some(max_sessions_allowed) => {
-			tracing::trace!(?max_sessions_allowed, "The max sessions allowed is set")
+			tracing::trace!(?max_sessions_allowed, "The max sessions allowed is set");
 		},
 		_ => {},
 	}
@@ -333,13 +333,16 @@ async fn update_user(
 						)
 						.exec()
 						.await?;
-					tracing::trace!(?upserted_age_restriction, "Upserted age restriction")
+					tracing::trace!(
+						?upserted_age_restriction,
+						"Upserted age restriction"
+					);
 				} else if existing_age_restriction.is_some() {
 					tx.age_restriction()
 						.delete(age_restriction::user_id::equals(for_user_id.clone()))
 						.exec()
 						.await?;
-					tracing::trace!("Deleted age restriction")
+					tracing::trace!("Deleted age restriction");
 				}
 
 				update_params.push(user::permissions::set(Some(
@@ -373,15 +376,15 @@ async fn update_preferences(
 		.update(
 			user_preferences::id::equals(preferences_id),
 			vec![
-				user_preferences::locale::set(input.locale.to_owned()),
+				user_preferences::locale::set(input.locale.clone()),
 				user_preferences::preferred_layout_mode::set(
-					input.preferred_layout_mode.to_owned(),
+					input.preferred_layout_mode.clone(),
 				),
-				user_preferences::app_theme::set(input.app_theme.to_owned()),
+				user_preferences::app_theme::set(input.app_theme.clone()),
 				user_preferences::enable_gradients::set(input.enable_gradients),
 				user_preferences::app_font::set(input.app_font.to_string()),
 				user_preferences::primary_navigation_mode::set(
-					input.primary_navigation_mode.to_owned(),
+					input.primary_navigation_mode.clone(),
 				),
 				user_preferences::layout_max_width_px::set(input.layout_max_width_px),
 				user_preferences::show_query_indicator::set(input.show_query_indicator),
@@ -458,7 +461,7 @@ async fn create_user(
 			let created_user = client
 				.user()
 				.create(
-					input.username.to_owned(),
+					input.username.clone(),
 					hashed_password,
 					chain_optional_iter(
 						vec![
@@ -486,7 +489,7 @@ async fn create_user(
 					)
 					.exec()
 					.await?;
-				tracing::trace!(?_age_restriction, "Created age restriction")
+				tracing::trace!(?_age_restriction, "Created age restriction");
 			}
 
 			let _user_preferences = client
@@ -695,8 +698,7 @@ async fn update_navigation_arrangement(
 			vec![user_preferences::navigation_arrangement::set(Some(
 				serde_json::to_vec(&input).map_err(|e| {
 					APIError::InternalServerError(format!(
-						"Failed to serialize navigation arrangement: {}",
-						e
+						"Failed to serialize navigation arrangement: {e}"
 					))
 				})?,
 			))],
@@ -791,7 +793,7 @@ async fn get_user_by_id(
 		.with(user::age_restriction::fetch())
 		.exec()
 		.await?
-		.ok_or(APIError::NotFound(format!("User with id {} not found", id)))?;
+		.ok_or(APIError::NotFound(format!("User with id {id} not found")))?;
 
 	Ok(Json(User::from(fetched_user)))
 }
@@ -1014,8 +1016,7 @@ async fn get_user_preferences(
 
 	if user_preferences.is_none() {
 		return Err(APIError::NotFound(format!(
-			"User preferences with id {} not found",
-			id
+			"User preferences with id {id} not found"
 		)));
 	}
 
@@ -1185,8 +1186,7 @@ async fn upload_user_avatar(
 		.update(
 			user::id::equals(id.clone()),
 			vec![user::avatar_url::set(Some(format!(
-				"/api/v1/users/{}/avatar",
-				id
+				"/api/v1/users/{id}/avatar"
 			)))],
 		)
 		.exec()

--- a/apps/server/src/routers/opds/v1_2.rs
+++ b/apps/server/src/routers/opds/v1_2.rs
@@ -218,8 +218,7 @@ async fn keep_reading(
 		{
 			Some(session) if session.epubcfi.is_some() => session
 				.percentage_completed
-				.map(|value| value < 1.0)
-				.unwrap_or(false),
+				.is_some_and(|value| value < 1.0),
 			Some(session) if session.page.is_some() => {
 				session.page.unwrap_or(1) < m.pages
 			},
@@ -355,8 +354,7 @@ async fn get_library_by_id(
 		.build()?))
 	} else {
 		Err(APIError::NotFound(format!(
-			"Library {} not found",
-			library_id
+			"Library {library_id} not found"
 		)))
 	}
 }
@@ -519,10 +517,7 @@ async fn get_series_by_id(
 		)
 		.build()?))
 	} else {
-		Err(APIError::NotFound(format!(
-			"Series {} not found",
-			series_id
-		)))
+		Err(APIError::NotFound(format!("Series {series_id} not found")))
 	}
 }
 

--- a/apps/server/src/routers/opds/v2_0.rs
+++ b/apps/server/src/routers/opds/v2_0.rs
@@ -607,7 +607,7 @@ async fn fetch_books_and_generate_feed(
 						OPDSPaginationMetadataBuilder::default()
 							.number_of_items(books_count)
 							.items_per_page(take)
-							.current_page(pagination.page.map(|p| p as i64).unwrap_or(1))
+							.current_page(pagination.page.map_or(1, i64::from))
 							.build()?,
 					))
 					.build()?,
@@ -691,7 +691,7 @@ async fn browse_series(
 		.await?;
 	let series_count = client.series().count(series_conditions).exec().await?;
 
-	let current_page = (pagination.zero_indexed_page() + 1) as i64;
+	let current_page = i64::from(pagination.zero_indexed_page() + 1);
 	let link_finalizer = OPDSLinkFinalizer::from(host);
 
 	Ok(Json(

--- a/apps/server/src/routers/spa.rs
+++ b/apps/server/src/routers/spa.rs
@@ -35,7 +35,7 @@ pub(crate) fn mount(app_state: AppState) -> Router<AppState> {
 }
 
 pub(crate) fn relative_favicon_path() -> String {
-	format!("{}{}", ASSETS, FAVICON)
+	format!("{ASSETS}{FAVICON}")
 }
 
 // https://github.com/tokio-rs/axum/discussions/608#discussioncomment-7772294

--- a/apps/server/src/routers/sse.rs
+++ b/apps/server/src/routers/sse.rs
@@ -31,8 +31,6 @@ async fn sse_handler(
 						continue;
 					}
 				}
-			} else {
-				continue;
 			}
 		}
 	};

--- a/apps/server/src/utils/http.rs
+++ b/apps/server/src/utils/http.rs
@@ -18,12 +18,12 @@ use tracing::error;
 pub(crate) fn unexpected_error<E: std::error::Error>(err: E) -> impl IntoResponse {
 	(
 		StatusCode::INTERNAL_SERVER_ERROR,
-		format!("An unknown error occurred: {}", err),
+		format!("An unknown error occurred: {err}"),
 	)
 }
-/// [ImageResponse] is a thin wrapper struct to return an image correctly in Axum.
-/// It contains a subset of actual Content-Type's (using [ContentType] enum from
-/// stump_core), as well as the raw image data. This is mostly the same as [BufferResponse],
+/// [`ImageResponse`] is a thin wrapper struct to return an image correctly in Axum.
+/// It contains a subset of actual Content-Type's (using [`ContentType`] enum from
+/// `stump_core`), as well as the raw image data. This is mostly the same as [`BufferResponse`],
 /// but adds the Cache-Control header.
 pub struct ImageResponse {
 	pub content_type: ContentType,
@@ -84,7 +84,7 @@ impl IntoResponse for Xml {
 	}
 }
 
-/// [BufferResponse] is a wrapper struct to return a buffer of any Stump-compliant (see [ContentType])
+/// [`BufferResponse`] is a wrapper struct to return a buffer of any Stump-compliant (see [`ContentType`])
 /// Content-Type correctly in Axum.
 pub struct BufferResponse {
 	pub content_type: ContentType,
@@ -117,7 +117,7 @@ impl IntoResponse for BufferResponse {
 	}
 }
 
-/// [UnknownBufferResponse] is the same as [BufferResponse], but takes a string instead of a [ContentType].
+/// [`UnknownBufferResponse`] is the same as [`BufferResponse`], but takes a string instead of a [`ContentType`].
 /// This makes it useful for returning a buffer with a content type that Stump doesn't know about. I don't
 /// anticipate this being used much, but it's here just in case.
 pub struct UnknownBufferResponse {
@@ -144,7 +144,7 @@ impl IntoResponse for UnknownBufferResponse {
 // TODO: I think it would be cool to support some variant of a named file with
 // range request support. I'm not sure how to do that yet, but it would be cool.
 // maybe something here -> https://docs.rs/tower-http/latest/tower_http/services/fs/index.html
-/// [NamedFile] is a struct used for serving 'named' files from the server. As
+/// [`NamedFile`] is a struct used for serving 'named' files from the server. As
 /// opposed to the static files handled by Stump's SPA router, this is used for
 /// dynamic files outside of the server's static directory.
 pub struct NamedFile {
@@ -181,7 +181,7 @@ impl IntoResponse for NamedFile {
 			)
 			.header(
 				header::CONTENT_DISPOSITION,
-				format!("attachment; filename=\"{}\"", filename),
+				format!("attachment; filename=\"{filename}\""),
 			)
 			.body(body)
 			.unwrap_or_else(|e| unexpected_error(e).into_response())

--- a/apps/server/src/utils/upload.rs
+++ b/apps/server/src/utils/upload.rs
@@ -11,18 +11,12 @@ pub async fn validate_and_load_image(
 	upload: &mut Multipart,
 	max_size: Option<usize>,
 ) -> APIResult<(ContentType, Vec<u8>)> {
-	validate_and_load_upload(
-		upload,
-		max_size,
-		|content_type| content_type.is_image(),
-		Some("image"),
-	)
-	.await
+	validate_and_load_upload(upload, max_size, ContentType::is_image, Some("image")).await
 }
 
 /// An internal helper function to validate and load a generic upload.
 /// The validator will load an image from multipart form data ([Multipart]) and check that it
-/// is not larger than the max_size. Then, it will check that the `ContentType` information from
+/// is not larger than the `max_size`. Then, it will check that the `ContentType` information from
 /// the header and/or magic numbers in the first 5 bytes of the file match the expected type using
 /// the provided `is_valid_content_type` function.
 ///
@@ -76,7 +70,7 @@ async fn validate_and_load_upload(
 	}?;
 
 	tracing::trace!(?content_type, file_size, "Validated upload");
-	Ok((content_type, bytes.to_vec()))
+	Ok((content_type, bytes))
 }
 
 /// Load up to `max_size` bytes of a field (erroring if `max_size` is exceeded).
@@ -122,8 +116,7 @@ fn validation_err(expected_type_name: Option<&str>) -> APIError {
 	if let Some(type_name) = expected_type_name {
 		if !type_name.is_empty() {
 			return APIError::BadRequest(format!(
-				"Uploaded file was expected to be {}",
-				type_name
+				"Uploaded file was expected to be {type_name}"
 			));
 		}
 	}
@@ -135,8 +128,7 @@ fn validation_err(expected_type_name: Option<&str>) -> APIError {
 /// by a thing named `name` with a value that is `actual_size`.
 fn max_size_err(max_size: usize, name: &str, actual_size: usize) -> APIError {
 	APIError::BadRequest(format!(
-		"Max size of {} bytes exceeded by {} which is {} bytes",
-		max_size, name, actual_size
+		"Max size of {max_size} bytes exceeded by {name} which is {actual_size} bytes"
 	))
 }
 

--- a/core/src/config/stump_config.rs
+++ b/core/src/config/stump_config.rs
@@ -1,9 +1,9 @@
-//! Contains the [StumpConfig] struct and related functions for loading and saving configuration
+//! Contains the [`StumpConfig`] struct and related functions for loading and saving configuration
 //! values for a Stump application.
 //!
-//! Note: [StumpConfig] is constructed _before_ tracing is initializing. This is because the
+//! Note: [`StumpConfig`] is constructed _before_ tracing is initializing. This is because the
 //! configuration is used to determine the log file path and verbosity level. This means that any
-//! logging that occurs during the construction of the [StumpConfig] should be done using the
+//! logging that occurs during the construction of the [`StumpConfig`] should be done using the
 //! standard `println!` or `eprintln!` macros.
 
 use std::{env, path::PathBuf};
@@ -187,8 +187,7 @@ impl StumpConfig {
 		let config_dir = self.get_config_dir();
 		if config_dir.is_file() {
 			return Err(CoreError::InitializationError(format!(
-				"Error writing config directory: {:?} is a file",
-				config_dir
+				"Error writing config directory: {config_dir:?} is a file",
 			)));
 		}
 
@@ -226,7 +225,7 @@ impl StumpConfig {
 		std::fs::write(
 			stump_toml.as_path(),
 			toml::to_string(&self).map_err(|e| {
-				eprintln!("Failed to serialize StumpConfig to toml: {}", e);
+				eprintln!("Failed to serialize StumpConfig to toml: {e}");
 				CoreError::InitializationError(e.to_string())
 			})?,
 		)?;
@@ -278,7 +277,7 @@ fn do_validate_profile(profile: &String) -> bool {
 		return true;
 	}
 
-	eprintln!("Invalid profile value: {}", profile);
+	eprintln!("Invalid profile value: {profile}");
 	false
 }
 

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -132,7 +132,7 @@ impl Ctx {
 		Arc::new(self.clone())
 	}
 
-	/// Returns the reciever for the CoreEvent channel. See [`emit_event`]
+	/// Returns the reciever for the `CoreEvent` channel. See [`emit_event`]
 	/// for more information and an example usage.
 	pub fn get_client_receiver(&self) -> Receiver<CoreEvent> {
 		self.event_channel.0.subscribe()
@@ -142,7 +142,7 @@ impl Ctx {
 		self.event_channel.0.clone()
 	}
 
-	/// Emits a [CoreEvent] to the client event channel.
+	/// Emits a [`CoreEvent`] to the client event channel.
 	///
 	/// ## Example
 	/// ```no_run
@@ -179,7 +179,7 @@ impl Ctx {
 		let _ = self.event_channel.0.send(event);
 	}
 
-	/// Sends a [JobControllerCommand] to the job controller
+	/// Sends a [`JobControllerCommand`] to the job controller
 	pub fn send_job_controller_command(
 		&self,
 		command: JobControllerCommand,
@@ -187,7 +187,7 @@ impl Ctx {
 		self.job_controller.push_command(command)
 	}
 
-	/// Sends an EnqueueJob event to the job manager.
+	/// Sends an [`JobControllerCommand::EnqueueJob`] event to the job manager.
 	pub fn enqueue_job(
 		&self,
 		job: Box<dyn Executor>,
@@ -195,7 +195,7 @@ impl Ctx {
 		self.send_job_controller_command(JobControllerCommand::EnqueueJob(job))
 	}
 
-	/// Send a [CoreEvent] through the event channel to any clients listening
+	/// Send a [`CoreEvent`] through the event channel to any clients listening
 	pub fn send_core_event(&self, event: CoreEvent) {
 		if let Err(error) = self.event_channel.0.send(event) {
 			tracing::error!(error = ?error, "Failed to send core event");

--- a/core/src/db/client.rs
+++ b/core/src/db/client.rs
@@ -7,7 +7,7 @@ pub(crate) struct JournalModeQueryResult {
 	pub journal_mode: String,
 }
 
-/// Creates the PrismaClient. Will call `create_data_dir` as well
+/// Creates the [`prisma::PrismaClient`]. Will call `create_data_dir` as well
 pub async fn create_client(config: &StumpConfig) -> prisma::PrismaClient {
 	let config_dir = config
 		.get_config_dir()
@@ -24,12 +24,12 @@ pub async fn create_client(config: &StumpConfig) -> prisma::PrismaClient {
 	// let postfix = "?socket_timeout=15000&busy_timeout=15000&connection_limit=1";
 
 	let sqlite_url = if let Some(path) = config.db_path.clone() {
-		format!("file:{}/stump.db", &path)
+		format!("file:{path}/stump.db")
 	} else if config.profile == "release" {
-		tracing::trace!("ile:{}/stump.db", &config_dir);
-		format!("file:{}/stump.db", &config_dir)
+		tracing::trace!("file:{config_dir}/stump.db");
+		format!("file:{config_dir}/stump.db")
 	} else {
-		format!("file:{}/prisma/dev.db", &env!("CARGO_MANIFEST_DIR"))
+		format!("file:{}/prisma/dev.db", env!("CARGO_MANIFEST_DIR"))
 	};
 
 	tracing::trace!(?sqlite_url, "Creating Prisma client");

--- a/core/src/db/common.rs
+++ b/core/src/db/common.rs
@@ -97,14 +97,14 @@ impl PrismaCountTrait for PrismaClient {
 		._query_raw(raw!(format!("SELECT DISTINCT series_id as series_id, COUNT(*) as count FROM media WHERE series_id in ({}) GROUP BY series_id",
 		series_ids
 			.into_iter()
-			.map(|id| format!("\"{}\"", id))
+			.map(|id| format!("\"{id}\""))
 			.collect::<Vec<_>>()
 			.join(",")
 	).as_str())).exec().await?;
 
 		Ok(count_res
 			.iter()
-			.map(|data| (data.series_id.to_owned(), data.count))
+			.map(|data| (data.series_id.clone(), data.count))
 			.collect())
 	}
 }
@@ -139,7 +139,7 @@ impl FromStr for JournalMode {
 		match s.to_uppercase().as_str() {
 			"WAL" => Ok(Self::WAL),
 			"DELETE" => Ok(Self::DELETE),
-			_ => Err(format!("Invalid or unsupported journal mode: {}", s)),
+			_ => Err(format!("Invalid or unsupported journal mode: {s}")),
 		}
 	}
 }

--- a/core/src/db/dao/series_dao.rs
+++ b/core/src/db/dao/series_dao.rs
@@ -58,7 +58,7 @@ impl SeriesDAO {
 		let recently_added_series = self
 			.client
 			._query_raw::<Series>(raw!(
-				r#"
+				r"
 				SELECT
 					series.id AS id,
 					series.name AS name,
@@ -91,7 +91,7 @@ impl SeriesDAO {
 					series.id
 				ORDER BY
 					series.created_at DESC
-				LIMIT {} OFFSET {}"#,
+				LIMIT {} OFFSET {}",
 				PrismaValue::String(viewer_id.to_string()),
 				PrismaValue::String(viewer_id.to_string()),
 				PrismaValue::String(viewer_id.to_string()),
@@ -107,7 +107,7 @@ impl SeriesDAO {
 		let count_result = self
 		.client
 		._query_raw::<CountQueryReturn>(raw!(
-			r#"
+			r"
 			SELECT
 				COUNT(DISTINCT series.id) as count
 			FROM 
@@ -124,7 +124,7 @@ impl SeriesDAO {
 					(ar.restrict_on_unset = FALSE AND sm.age_rating IS NULL) OR sm.age_rating <= ar.age
 				)
 			ORDER BY
-				series.created_at DESC"#,
+				series.created_at DESC",
 			PrismaValue::String(viewer_id.to_string()),
 			PrismaValue::String(viewer_id.to_string())
 		))
@@ -143,7 +143,7 @@ impl SeriesDAO {
 			Ok(Pageable::with_count(
 				recently_added_series,
 				db_total.count,
-				page_params,
+				&page_params,
 			))
 		} else {
 			Err(CoreError::InternalError(

--- a/core/src/db/entity/common.rs
+++ b/core/src/db/entity/common.rs
@@ -212,7 +212,7 @@ impl FromStr for EntityVisibility {
 			"PUBLIC" => Ok(EntityVisibility::Public),
 			"SHARED" => Ok(EntityVisibility::Shared),
 			"PRIVATE" => Ok(EntityVisibility::Private),
-			_ => Err(format!("Invalid visibility: {}", s)),
+			_ => Err(format!("Invalid visibility: {s}")),
 		}
 	}
 }

--- a/core/src/db/entity/epub.rs
+++ b/core/src/db/entity/epub.rs
@@ -65,9 +65,9 @@ pub struct Epub {
 
 /// This struct is mainly used when the Stump client sends the inital request to grab information on an epub file.
 /// This will get cached on the client, which will use the metadata to make consecutive requests for various
-/// resources/chapters. This struct isn't really used after that first request, everything else is file IO using EpubDoc.
+/// resources/chapters. This struct isn't really used after that first request, everything else is file IO using [`EpubDoc`].
 impl Epub {
-	/// Creates an Epub from a media entity and an open EpubDoc
+	/// Creates an Epub from a media entity and an open [`EpubDoc`]
 	pub fn from(media: media::Data, epub: EpubDoc<BufReader<File>>) -> Epub {
 		let annotations = match media.annotations() {
 			Ok(annotations) => Some(
@@ -93,8 +93,8 @@ impl Epub {
 		}
 	}
 
-	/// Attempts to create an Epub from a media entity. Internally, this will attempt to open
-	/// an EpubDoc from the media's path. If this fails, it will return an EpubOpenError.
+	/// Attempts to create an Epub from a media entity. Internally, this will attempt to open an [`EpubDoc`]
+	/// from the media's path. If this fails, it will return a [`FileError::EpubOpenError`].
 	pub fn try_from(media: media::Data) -> Result<Epub, FileError> {
 		let epub_file = EpubDoc::new(media.path.as_str()).map_err(|e| {
 			error!("Failed to open epub {}: {}", &media.path, e);

--- a/core/src/db/entity/library/entity.rs
+++ b/core/src/db/entity/library/entity.rs
@@ -59,7 +59,7 @@ impl FromStr for LibraryPattern {
 			"SERIES_BASED" => Ok(LibraryPattern::SeriesBased),
 			"COLLECTION_BASED" => Ok(LibraryPattern::CollectionBased),
 			"" => Ok(LibraryPattern::default()),
-			_ => Err(format!("Invalid library pattern: {}", s)),
+			_ => Err(format!("Invalid library pattern: {s}")),
 		}
 	}
 }
@@ -103,7 +103,7 @@ impl FromStr for LibraryScanMode {
 			"DEFAULT" => Ok(LibraryScanMode::Default),
 			"NONE" => Ok(LibraryScanMode::None),
 			"" => Ok(LibraryScanMode::default()),
-			_ => Err(format!("Invalid library scan mode: {}", s)),
+			_ => Err(format!("Invalid library scan mode: {s}")),
 		}
 	}
 }

--- a/core/src/db/entity/log.rs
+++ b/core/src/db/entity/log.rs
@@ -8,8 +8,8 @@ use crate::prisma::log;
 
 use super::Cursor;
 
-/// Information about the Stump log file, located at STUMP_CONFIG_DIR/Stump.log, or
-/// ~/.stump/Stump.log by default. Information such as the file size, last modified date, etc.
+/// Information about the Stump log file, located at `STUMP_CONFIG_DIR/Stump.log`, or
+/// `~/.stump/Stump.log` by default. Information such as the file size, last modified date, etc.
 #[derive(Serialize, Deserialize, Type, ToSchema)]
 pub struct LogMetadata {
 	pub path: PathBuf,

--- a/core/src/db/entity/media/entity.rs
+++ b/core/src/db/entity/media/entity.rs
@@ -70,7 +70,7 @@ pub struct Media {
 	/// Whether or not the media is completed. Only None if the relation is not loaded.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub is_completed: Option<bool>,
-	/// The user assigned tags for the media. ex: ["comic", "spiderman"]. Will be `None` only if the relation is not loaded.
+	/// The user assigned tags for the media. ex: `["comic", "spiderman"]`. Will be `None` only if the relation is not loaded.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub tags: Option<Vec<Tag>>,
 	/// Bookmarks for the media. Will be `None` only if the relation is not loaded.
@@ -98,8 +98,8 @@ impl Cursor for Media {
 impl TryFrom<active_reading_session::Data> for Media {
 	type Error = CoreError;
 
-	/// Creates a [Media] instance from the loaded relation of a [media::Data] on
-	/// a [active_reading_session::Data] instance. If the relation is not loaded, it will
+	/// Creates a [Media] instance from the loaded relation of a [`media::Data`] on an
+	/// [`active_reading_session::Data`] instance. If the relation is not loaded, it will
 	/// return an error.
 	fn try_from(data: active_reading_session::Data) -> Result<Self, Self::Error> {
 		let Ok(media) = data.media() else {
@@ -135,8 +135,9 @@ impl From<media::Data> for Media {
 		};
 		let (current_page, current_epubcfi) = active_reading_session
 			.as_ref()
-			.map(|session| (session.page, session.epubcfi.clone()))
-			.unwrap_or((None, None));
+			.map_or((None, None), |session| {
+				(session.page, session.epubcfi.clone())
+			});
 
 		let finished_reading_sessions = match data.finished_user_reading_sessions() {
 			Ok(sessions) => Some(

--- a/core/src/db/entity/metadata/media_metadata.rs
+++ b/core/src/db/entity/metadata/media_metadata.rs
@@ -259,23 +259,24 @@ impl From<HashMap<String, Vec<String>>> for MediaMetadata {
 				"series" => metadata.series = Some(value.join("\n").to_string()),
 				"number" => {
 					metadata.number =
-						value.into_iter().next().and_then(|n| n.parse().ok())
+						value.into_iter().next().and_then(|n| n.parse().ok());
 				},
 				"volume" => {
 					metadata.volume =
-						value.into_iter().next().and_then(|n| n.parse().ok())
+						value.into_iter().next().and_then(|n| n.parse().ok());
 				},
 				"summary" => metadata.summary = Some(value.join("\n").to_string()),
 				"notes" => metadata.notes = Some(value.join("\n").to_string()),
 				"genre" => metadata.genre = Some(value),
 				"year" => {
-					metadata.year = value.into_iter().next().and_then(|n| n.parse().ok())
+					metadata.year = value.into_iter().next().and_then(|n| n.parse().ok());
 				},
 				"month" => {
-					metadata.month = value.into_iter().next().and_then(|n| n.parse().ok())
+					metadata.month =
+						value.into_iter().next().and_then(|n| n.parse().ok());
 				},
 				"day" => {
-					metadata.day = value.into_iter().next().and_then(|n| n.parse().ok())
+					metadata.day = value.into_iter().next().and_then(|n| n.parse().ok());
 				},
 				"pencillers" => metadata.pencillers = Some(value),
 				"inkers" => metadata.inkers = Some(value),
@@ -289,7 +290,7 @@ impl From<HashMap<String, Vec<String>>> for MediaMetadata {
 				"teams" => metadata.teams = Some(value),
 				"pagecount" => {
 					metadata.page_count =
-						value.into_iter().next().and_then(|n| n.parse().ok())
+						value.into_iter().next().and_then(|n| n.parse().ok());
 				},
 				"date" => {
 					// Note: we don't know the format of the date. It could be a year, a full date, etc.
@@ -297,7 +298,7 @@ impl From<HashMap<String, Vec<String>>> for MediaMetadata {
 					// This is a bit of a hack, but it's the best we can do without knowing the format.
 					let raw_date = value.into_iter().next().unwrap_or_default();
 
-					for format in NAIVE_DATE_FORMATS.iter() {
+					for format in &NAIVE_DATE_FORMATS {
 						if let Ok(date) = NaiveDate::parse_from_str(&raw_date, format) {
 							metadata.year = Some(date.year());
 							metadata.month = Some(date.month() as i32);
@@ -332,7 +333,7 @@ impl From<HashMap<String, Vec<String>>> for MediaMetadata {
 					match (metadata.age_rating, parsed) {
 						// if metadata.age_rating has been set, we need to take the min of the two
 						(Some(existing), Some(new)) => {
-							metadata.age_rating = Some(existing.min(new))
+							metadata.age_rating = Some(existing.min(new));
 						},
 						// if metadata.age_rating has not been set, we can just take the new value
 						(_, Some(new)) => metadata.age_rating = Some(new),
@@ -353,7 +354,7 @@ impl From<Dictionary> for MediaMetadata {
 		let map = dict
 			.into_iter()
 			.map(|(k, v)| v.to_string().map(|v| (k, v)))
-			.filter_map(|result| result.ok())
+			.filter_map(std::result::Result::ok)
 			.map(|(k, v)| (k.to_lowercase(), vec![v]))
 			.collect::<HashMap<String, Vec<String>>>();
 		Self::from(map)

--- a/core/src/db/entity/metadata/media_metadata.rs
+++ b/core/src/db/entity/metadata/media_metadata.rs
@@ -354,7 +354,7 @@ impl From<Dictionary> for MediaMetadata {
 		let map = dict
 			.into_iter()
 			.map(|(k, v)| v.to_string().map(|v| (k, v)))
-			.filter_map(std::result::Result::ok)
+			.filter_map(Result::ok)
 			.map(|(k, v)| (k.to_lowercase(), vec![v]))
 			.collect::<HashMap<String, Vec<String>>>();
 		Self::from(map)

--- a/core/src/db/entity/metadata/page_dimension.rs
+++ b/core/src/db/entity/metadata/page_dimension.rs
@@ -1,11 +1,11 @@
 //! This module defines structures for storing and retrieving page dimensions data. The
-//! two primary stuctures defined here are [PageDimension], which represents a pair of
-//! page dimensions (height, width), and [PageDimensionsEntity], which is the rust
+//! two primary stuctures defined here are [`PageDimension`], which represents a pair of
+//! page dimensions (height, width), and [`PageDimensionsEntity`], which is the rust
 //! representation of a database row in the `page_dimensions` table.
 //!
 //! In addition to defining data structures, this module includes a simple compression
-//! algorithm for storing and retrieving [Vec]<[PageDimension]s. The [dimension_vec_to_string]
-//! and [dimension_vec_from_str] methods can be used for serializing and deserializing this
+//! algorithm for storing and retrieving [Vec]<[`PageDimension`]s. The [`dimension_vec_to_string`]
+//! and [`dimension_vec_from_str`] methods can be used for serializing and deserializing this
 //! structure
 
 use serde::{Deserialize, Serialize};
@@ -29,9 +29,9 @@ pub enum PageDimensionParserError {
 	ErrorParsingInt(#[from] std::num::ParseIntError),
 }
 
-/// Represents a database [page_dimensions::Data] object.
+/// Represents a database [`page_dimensions::Data`] object.
 ///
-/// The `dimensions` member contains a [Vec]<[PageDimension]> containing the height and width
+/// The `dimensions` member contains a [Vec]<[`PageDimension`]> containing the height and width
 /// of each page for the media attached to the metadata for this entity.
 #[derive(Serialize, Deserialize, Debug, Clone, Type)]
 pub struct PageDimensionsEntity {
@@ -99,18 +99,18 @@ impl FromStr for PageDimension {
 	}
 }
 
-/// Serializes a [Vec]<[PageDimension]> as a [String].
+/// Serializes a [Vec]<[`PageDimension`]> as a [String].
 ///
-/// The serialization uses comma-separation for height and width in [PageDimension], and semicolon-separation
-/// for each [PageDimension] object. Additionally, it uses a form of deduplication that encodes a run of n > 1
-/// [PageDimension]s as `"n>height,width"`. An empty vector serializes to `""`.
+/// The serialization uses comma-separation for height and width in [`PageDimension`], and semicolon-separation
+/// for each [`PageDimension`] object. Additionally, it uses a form of deduplication that encodes a run of n > 1
+/// [`PageDimension`]s as `"n>height,width"`. An empty vector serializes to `""`.
 pub fn dimension_vec_to_string(list: Vec<PageDimension>) -> String {
 	let mut encoded_strings = Vec::new();
 	let mut run_count = 0;
 	let mut run_dimension: Option<PageDimension> = None;
 
 	// Loop over each of the items in the list to be encoded
-	for next_dim in list.into_iter() {
+	for next_dim in list {
 		match run_dimension {
 			// If there's already a run going and it matches the next, increment the counter
 			Some(ref run_dim) if *run_dim == next_dim => run_count += 1,
@@ -144,11 +144,11 @@ pub fn dimension_vec_to_string(list: Vec<PageDimension>) -> String {
 	encoded_strings.join(";")
 }
 
-/// Deserializes a [Vec]<[PageDimension]> from a [String] containing its serialized form.
+/// Deserializes a [Vec]<[`PageDimension`]> from a [String] containing its serialized form.
 ///
-/// The serialization uses comma-separation for height and width in [PageDimension], and semicolon-separation
-/// for each [PageDimension] object. Additionally, it uses a form of deduplication that encodes a run of n > 1
-/// [PageDimension]s as `"n>height,width"`. An empty vector serializes to `""`.
+/// The serialization uses comma-separation for height and width in [`PageDimension`], and semicolon-separation
+/// for each [`PageDimension`] object. Additionally, it uses a form of deduplication that encodes a run of n > 1
+/// [`PageDimension`]s as `"n>height,width"`. An empty vector serializes to `""`.
 pub fn dimension_vec_from_str(
 	s: &str,
 ) -> Result<Vec<PageDimension>, PageDimensionParserError> {

--- a/core/src/db/entity/notifier.rs
+++ b/core/src/db/entity/notifier.rs
@@ -103,7 +103,7 @@ impl FromStr for NotifierType {
 		match uppercase.as_str() {
 			"DISCORD" => Ok(NotifierType::Discord),
 			"TELEGRAM" => Ok(NotifierType::Telegram),
-			_ => Err(format!("Invalid NotifierType: {}", s)),
+			_ => Err(format!("Invalid NotifierType: {s}")),
 		}
 	}
 }

--- a/core/src/db/entity/series/entity.rs
+++ b/core/src/db/entity/series/entity.rs
@@ -48,7 +48,7 @@ pub struct Series {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[specta(optional)]
 	pub unread_media_count: Option<i64>,
-	/// The user assigned tags for the series. ex: ["comic", "family"]. Will be `None` only if the relation is not loaded.
+	/// The user assigned tags for the series. ex: `["comic", "family"]`. Will be `None` only if the relation is not loaded.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[specta(optional)]
 	pub tags: Option<Vec<Tag>>,

--- a/core/src/db/entity/smart_list/item.rs
+++ b/core/src/db/entity/smart_list/item.rs
@@ -30,7 +30,7 @@ impl FromStr for SmartListItemGrouping {
 			"by_books" => Ok(Self::ByBooks),
 			"by_series" => Ok(Self::BySeries),
 			"by_library" => Ok(Self::ByLibrary),
-			_ => Err(format!("Invalid item grouping: {}", s)),
+			_ => Err(format!("Invalid item grouping: {s}")),
 		}
 	}
 }

--- a/core/src/db/entity/smart_list/prisma_macros.rs
+++ b/core/src/db/entity/smart_list/prisma_macros.rs
@@ -30,8 +30,9 @@ impl From<media_grouped_by_library::Data> for Media {
 			.map(ActiveReadingSession::from);
 		let (current_page, current_epubcfi) = active_reading_session
 			.as_ref()
-			.map(|session| (session.page, session.epubcfi.clone()))
-			.unwrap_or((None, None));
+			.map_or((None, None), |session| {
+				(session.page, session.epubcfi.clone())
+			});
 
 		let finished_reading_sessions = data
 			.finished_user_reading_sessions
@@ -53,7 +54,7 @@ impl From<media_grouped_by_library::Data> for Media {
 			path: data.path,
 			status: FileStatus::from_str(&data.status).unwrap_or(FileStatus::Error),
 			series_id: data.series_id.unwrap_or_default(),
-			metadata: data.metadata.map(|m| MediaMetadata::from(m.to_owned())),
+			metadata: data.metadata.map(|m| MediaMetadata::from(m.clone())),
 			active_reading_session,
 			finished_reading_sessions: Some(finished_reading_sessions),
 			current_page,

--- a/core/src/db/entity/user/permissions.rs
+++ b/core/src/db/entity/user/permissions.rs
@@ -106,7 +106,7 @@ pub enum UserPermission {
 impl UserPermission {
 	/// Return a list of permissions, if any, which are inherited by self
 	///
-	/// For example, UserPermission::CreateNotifier implies UserPermission::ReadNotifier
+	/// For example, [`UserPermission::CreateNotifier`] implies [`UserPermission::ReadNotifier`]
 	// TODO: revisit these. I am mixing patterns, e.g. manage vs explicit edit+create+delete. Pick one!
 	pub fn associated(&self) -> Vec<UserPermission> {
 		match self {
@@ -202,7 +202,7 @@ impl From<&str> for UserPermission {
 			"notifier:delete" => UserPermission::DeleteNotifier,
 			"server:manage" => UserPermission::ManageServer,
 			// FIXME: Don't panic smh
-			_ => panic!("Invalid user permission: {}", s),
+			_ => panic!("Invalid user permission: {s}"),
 		}
 	}
 }
@@ -247,7 +247,7 @@ impl From<String> for PermissionSet {
 		}
 		let permissions = s
 			.split(',')
-			.map(|s| s.trim())
+			.map(str::trim)
 			.filter(|s| !s.is_empty())
 			.map(UserPermission::from)
 			.collect();
@@ -438,7 +438,7 @@ mod tests {
 
 	#[test]
 	fn test_permission_set_from_empty_string() {
-		let permission_set = PermissionSet::from("".to_string());
+		let permission_set = PermissionSet::from(String::new());
 		assert_eq!(permission_set.resolve_into_vec().len(), 0);
 	}
 

--- a/core/src/db/filter/smart_filter.rs
+++ b/core/src/db/filter/smart_filter.rs
@@ -27,10 +27,10 @@ pub enum Filter<T> {
 	/// A simple not filter, e.g. `name != "test"`
 	Not { not: T },
 	/// A filter for a string that contains a substring, e.g. `name contains "test"`. This should
-	/// not be confused with an `in` filter. See [Filter::Any] for that.
+	/// not be confused with an `in` filter. See [`Filter::Any`] for that.
 	Contains { contains: T },
 	/// A filter for a string that does not contain a substring, e.g. `name excludes "test"`. This
-	/// should not be confused with a `not in` filter. See [Filter::None] for that.
+	/// should not be confused with a `not in` filter. See [`Filter::None`] for that.
 	Excludes { excludes: T },
 	/// A filter for a vector of values, e.g. `name in ["test", "test2"]`
 	Any { any: Vec<T> },
@@ -192,7 +192,7 @@ impl FromStr for FilterJoin {
 		match s.to_lowercase().as_str() {
 			"and" => Ok(Self::And),
 			"or" => Ok(Self::Or),
-			_ => Err(format!("Invalid filter joiner: {}", s)),
+			_ => Err(format!("Invalid filter joiner: {s}")),
 		}
 	}
 }

--- a/core/src/db/query/ordering.rs
+++ b/core/src/db/query/ordering.rs
@@ -29,9 +29,9 @@ impl From<Direction> for prisma_client_rust::Direction {
 #[derive(Debug, Deserialize, Serialize, Type, ToSchema)]
 #[serde(default)]
 pub struct QueryOrder {
-	/// The field to order by. Defaults to 'name'
+	/// The field to order by. Defaults to "name"
 	pub order_by: String,
-	/// The order in which to sort, based on order_by. Defaults to 'Asc'
+	/// The order in which to sort, based on `order_by`. Defaults to [`Direction::Asc`]
 	pub direction: Direction,
 }
 

--- a/core/src/filesystem/archive.rs
+++ b/core/src/filesystem/archive.rs
@@ -26,7 +26,7 @@ pub(crate) fn zip_dir(
 	let mut buffer = Vec::new();
 	for entry in WalkDir::new(unpacked_path)
 		.into_iter()
-		.filter_map(|e| e.ok())
+		.filter_map(std::result::Result::ok)
 	{
 		let path = entry.path();
 		let name = path.strip_prefix(Path::new(prefix)).unwrap();
@@ -74,7 +74,7 @@ pub fn create_zip_archive(
 
 	trace!("Calculated extension for zip file: {}", ext);
 
-	let zip_path = destination.join(format!("{}.{}", name, ext));
+	let zip_path = destination.join(format!("{name}.{ext}"));
 
 	zip_dir(unpacked_path, &zip_path, unpacked_path)?;
 

--- a/core/src/filesystem/archive.rs
+++ b/core/src/filesystem/archive.rs
@@ -26,7 +26,7 @@ pub(crate) fn zip_dir(
 	let mut buffer = Vec::new();
 	for entry in WalkDir::new(unpacked_path)
 		.into_iter()
-		.filter_map(std::result::Result::ok)
+		.filter_map(Result::ok)
 	{
 		let path = entry.path();
 		let name = path.strip_prefix(Path::new(prefix)).unwrap();

--- a/core/src/filesystem/common.rs
+++ b/core/src/filesystem/common.rs
@@ -2,6 +2,7 @@ use globset::GlobSet;
 use std::{
 	ffi::OsStr,
 	path::{Path, PathBuf},
+	string::ToString,
 };
 use tokio::{fs, io};
 use tracing::error;
@@ -85,7 +86,7 @@ pub trait OsStrUtils {
 
 impl OsStrUtils for OsStr {
 	fn try_to_string(&self) -> Option<String> {
-		self.to_str().map(std::string::ToString::to_string)
+		self.to_str().map(ToString::to_string)
 	}
 }
 

--- a/core/src/filesystem/common.rs
+++ b/core/src/filesystem/common.rs
@@ -236,7 +236,7 @@ impl PathUtils for Path {
 
 		match read_result {
 			Ok(items) => items
-				.filter_map(std::result::Result::ok)
+				.filter_map(Result::ok)
 				.filter(|item| item.path() != self)
 				.any(|f| {
 					let path = f.path();
@@ -260,7 +260,7 @@ impl PathUtils for Path {
 
 		WalkDir::new(self)
 			.into_iter()
-			.filter_map(std::result::Result::ok)
+			.filter_map(Result::ok)
 			.filter(|item| item.path() != self)
 			.any(|f| {
 				let path = f.path();

--- a/core/src/filesystem/common.rs
+++ b/core/src/filesystem/common.rs
@@ -47,14 +47,14 @@ pub async fn get_thumbnail(
 pub async fn find_thumbnail(parent: &Path, name: &str) -> Option<PathBuf> {
 	let mut thumbnails_dir = parent.to_path_buf();
 
-	for extension in ACCEPTED_IMAGE_EXTENSIONS.iter() {
-		let path = parent.join(format!("{}.{}", name, extension));
+	for extension in &ACCEPTED_IMAGE_EXTENSIONS {
+		let path = parent.join(format!("{name}.{extension}"));
 
 		if fs::metadata(&path).await.is_ok() {
 			return Some(path);
 		}
 
-		thumbnails_dir.push(format!("{}.{}", name, extension));
+		thumbnails_dir.push(format!("{name}.{extension}"));
 	}
 
 	None
@@ -62,7 +62,7 @@ pub async fn find_thumbnail(parent: &Path, name: &str) -> Option<PathBuf> {
 
 // TODO(perf): Async-ify
 pub fn get_unknown_image(mut base_path: PathBuf) -> Option<PathBuf> {
-	for extension in ACCEPTED_IMAGE_EXTENSIONS.iter() {
+	for extension in &ACCEPTED_IMAGE_EXTENSIONS {
 		base_path.set_extension(extension);
 
 		if base_path.exists() {
@@ -85,7 +85,7 @@ pub trait OsStrUtils {
 
 impl OsStrUtils for OsStr {
 	fn try_to_string(&self) -> Option<String> {
-		self.to_str().map(|str| str.to_string())
+		self.to_str().map(std::string::ToString::to_string)
 	}
 }
 
@@ -132,21 +132,21 @@ impl PathUtils for Path {
 	fn file_parts(&self) -> FileParts {
 		let file_name = self
 			.file_name()
-			.and_then(|os_str| os_str.try_to_string())
+			.and_then(OsStrUtils::try_to_string)
 			.unwrap_or_else(|| {
 				tracing::warn!(path = ?self, "Failed to get file name");
 				String::default()
 			});
 		let file_stem = self
 			.file_stem()
-			.and_then(|os_str| os_str.try_to_string())
+			.and_then(OsStrUtils::try_to_string)
 			.unwrap_or_else(|| {
 				tracing::warn!(path = ?self, "Failed to get file stem");
 				String::default()
 			});
 		let extension = self
 			.extension()
-			.and_then(|os_str| os_str.try_to_string())
+			.and_then(OsStrUtils::try_to_string)
 			.unwrap_or_default();
 
 		FileParts {
@@ -184,7 +184,7 @@ impl PathUtils for Path {
 
 		let file_name = self
 			.file_name()
-			.and_then(|os_str| os_str.try_to_string())
+			.and_then(OsStrUtils::try_to_string)
 			.unwrap_or_else(|| {
 				tracing::warn!(path = ?self, "Failed to get file name");
 				String::default()
@@ -236,7 +236,7 @@ impl PathUtils for Path {
 
 		match read_result {
 			Ok(items) => items
-				.filter_map(|item| item.ok())
+				.filter_map(std::result::Result::ok)
 				.filter(|item| item.path() != self)
 				.any(|f| {
 					let path = f.path();
@@ -260,7 +260,7 @@ impl PathUtils for Path {
 
 		WalkDir::new(self)
 			.into_iter()
-			.filter_map(|item| item.ok())
+			.filter_map(std::result::Result::ok)
 			.filter(|item| item.path() != self)
 			.any(|f| {
 				let path = f.path();

--- a/core/src/filesystem/content_type.rs
+++ b/core/src/filesystem/content_type.rs
@@ -91,7 +91,7 @@ impl ContentType {
 		}
 	}
 
-	/// Infer the MIME type of a file using the [infer] crate. If the MIME type cannot be inferred,
+	/// Infer the MIME type of a file using the [`infer`] crate. If the MIME type cannot be inferred,
 	/// then the file extension is used to determine the content type.
 	///
 	/// ### Example
@@ -106,8 +106,8 @@ impl ContentType {
 		ContentType::from_path(path)
 	}
 
-	/// Infer the MIME type of a [Vec] of bytes using the [infer] crate. If the MIME type cannot be
-	/// inferred, then the content type is set to [ContentType::UNKNOWN].
+	/// Infer the MIME type of a [`Vec`] of bytes using the [`infer`] crate. If the MIME type cannot be
+	/// inferred, then the content type is set to [`ContentType::UNKNOWN`].
 	///
 	/// ### Example
 	/// ```no_run
@@ -123,7 +123,7 @@ impl ContentType {
 			.unwrap_or_default()
 	}
 
-	/// Infer the MIME type of a [Vec] of bytes using the [infer] crate. If the MIME type cannot be
+	/// Infer the MIME type of a [`Vec`] of bytes using the [`infer`] crate. If the MIME type cannot be
 	/// inferred, then the extension is used to determine the content type.
 	///
 	/// ### Example

--- a/core/src/filesystem/image/generic.rs
+++ b/core/src/filesystem/image/generic.rs
@@ -20,7 +20,7 @@ impl ImageProcessor for GenericImageProcessor {
 		if let Some(resize_options) = options.resize_options {
 			let (current_width, current_height) = image.dimensions();
 			let (height, width) =
-				resized_dimensions(current_height, current_width, resize_options);
+				resized_dimensions(current_height, current_width, &resize_options);
 			image = image.resize_exact(width, height, imageops::FilterType::Triangle);
 		}
 

--- a/core/src/filesystem/image/process.rs
+++ b/core/src/filesystem/image/process.rs
@@ -200,7 +200,7 @@ pub trait ImageProcessor {
 pub fn resized_dimensions(
 	current_height: u32,
 	current_width: u32,
-	size_options: ImageResizeOptions,
+	size_options: &ImageResizeOptions,
 ) -> (u32, u32) {
 	match size_options.mode {
 		ImageResizeMode::Scaled => (
@@ -243,7 +243,7 @@ mod tests {
 	#[test]
 	fn test_resized_dimensions_scaled() {
 		let (height, width) =
-			resized_dimensions(100, 100, ImageResizeOptions::scaled(0.75, 0.5));
+			resized_dimensions(100, 100, &ImageResizeOptions::scaled(0.75, 0.5));
 		assert_eq!(height, 75);
 		assert_eq!(width, 50);
 	}
@@ -251,7 +251,7 @@ mod tests {
 	#[test]
 	fn test_resized_dimensions_sized() {
 		let (height, width) =
-			resized_dimensions(100, 100, ImageResizeOptions::sized(50.0, 50.0));
+			resized_dimensions(100, 100, &ImageResizeOptions::sized(50.0, 50.0));
 		assert_eq!(height, 50);
 		assert_eq!(width, 50);
 	}

--- a/core/src/filesystem/image/thumbnail/generate.rs
+++ b/core/src/filesystem/image/thumbnail/generate.rs
@@ -44,14 +44,14 @@ pub type DidGenerate = bool;
 pub type GenerateOutput = (Vec<u8>, PathBuf, DidGenerate);
 
 /// The main function for generating a thumbnail for a book. This should be called from within the
-/// scope of a blocking task in the [generate_book_thumbnail] function.
+/// scope of a blocking task in the [`generate_book_thumbnail`] function.
 fn do_generate_book_thumbnail(
 	book_path: &str,
 	file_name: &str,
-	config: StumpConfig,
+	config: &StumpConfig,
 	options: ImageProcessorOptions,
 ) -> Result<GenerateOutput, FileError> {
-	let (_, page_data) = get_page(book_path, options.page.unwrap_or(1), &config)?;
+	let (_, page_data) = get_page(book_path, options.page.unwrap_or(1), config)?;
 	let ext = options.format.extension();
 
 	let thumbnail_path = config
@@ -113,14 +113,14 @@ pub async fn generate_book_thumbnail(
 		let file_name = file_name.clone();
 
 		move || {
-			let _send_result = tx.send(do_generate_book_thumbnail(
+			let send_result = tx.send(do_generate_book_thumbnail(
 				&book_path,
 				&file_name,
-				core_config,
+				&core_config,
 				image_options,
 			));
 			tracing::trace!(
-				is_err = _send_result.is_err(),
+				is_err = send_result.is_err(),
 				"Sending generate result to channel"
 			);
 		}

--- a/core/src/filesystem/image/thumbnail/generation_job.rs
+++ b/core/src/filesystem/image/thumbnail/generation_job.rs
@@ -212,7 +212,7 @@ impl JobExt for ThumbnailGenerationJob {
 						ctx.report_progress(JobProgress::subtask_position(
 							position as i32,
 							task_count,
-						))
+						));
 					},
 				)
 				.await;
@@ -290,7 +290,7 @@ pub async fn safely_generate_batch(
 						"Failed to generate thumbnail: {:?}",
 						error.to_string()
 					))
-					.with_ctx(format!("Media path: {}", path)),
+					.with_ctx(format!("Media path: {path}")),
 				);
 			},
 		}

--- a/core/src/filesystem/image/thumbnail/utils.rs
+++ b/core/src/filesystem/image/thumbnail/utils.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::{config::StumpConfig, filesystem::FileError};
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
@@ -11,7 +11,7 @@ pub async fn place_thumbnail(
 	bytes: &[u8],
 	config: &StumpConfig,
 ) -> Result<PathBuf, FileError> {
-	let thumbnail_path = config.get_thumbnails_dir().join(format!("{}.{}", id, ext));
+	let thumbnail_path = config.get_thumbnails_dir().join(format!("{id}.{ext}"));
 	fs::write(&thumbnail_path, bytes).await?;
 	Ok(thumbnail_path)
 }
@@ -20,10 +20,10 @@ pub const THUMBNAIL_CHUNK_SIZE: usize = 500;
 
 // TODO(perf): Async-ify
 /// Deletes thumbnails and returns the number deleted if successful, returns
-/// [FileError] otherwise.
+/// [`FileError`] otherwise.
 pub fn remove_thumbnails(
 	id_list: &[String],
-	thumbnails_dir: PathBuf,
+	thumbnails_dir: &Path,
 ) -> Result<u64, FileError> {
 	let found_thumbnails = thumbnails_dir
 		.read_dir()

--- a/core/src/filesystem/image/webp.rs
+++ b/core/src/filesystem/image/webp.rs
@@ -44,7 +44,7 @@ impl WebpProcessor {
 	) -> DynamicImage {
 		let (current_width, current_height) = image.dimensions();
 		let (height, width) =
-			resized_dimensions(current_height, current_width, resize_options);
+			resized_dimensions(current_height, current_width, &resize_options);
 
 		DynamicImage::ImageRgba8(imageops::resize(
 			&image,
@@ -84,7 +84,7 @@ mod tests {
 			&webp_bytes,
 			image::ImageFormat::WebP
 		)
-		.is_ok())
+		.is_ok());
 	}
 
 	#[test]
@@ -106,7 +106,7 @@ mod tests {
 			&webp_bytes,
 			image::ImageFormat::WebP
 		)
-		.is_ok())
+		.is_ok());
 	}
 
 	#[test]
@@ -173,7 +173,7 @@ mod tests {
 			&webp_bytes,
 			image::ImageFormat::WebP
 		)
-		.is_ok())
+		.is_ok());
 	}
 
 	#[test]

--- a/core/src/filesystem/media/analyze_media_job/mod.rs
+++ b/core/src/filesystem/media/analyze_media_job/mod.rs
@@ -35,7 +35,7 @@ pub enum AnalyzeMediaTask {
 	UpdatePageCount(MediaID),
 	/// Analyze and store dimensions for each page of a media item specified by an ID.
 	AnalyzePageDimensions(MediaID),
-	/// Performs both [UpdatePageCount] and then [AnalyzePageDimensions] in sequence for
+	/// Performs both [`UpdatePageCount`] and then [`AnalyzePageDimensions`] in sequence for
 	/// the media item specified by an ID.
 	FullAnalysis(MediaID),
 }
@@ -66,14 +66,14 @@ pub struct AnalyzeMediaJob {
 }
 
 impl AnalyzeMediaJob {
-	/// Create a new [AnalyzeMediaJob] for the media specified by `media_id`.
+	/// Create a new [`AnalyzeMediaJob`] for the media specified by `media_id`.
 	pub fn analyze_media_item(media_id: String) -> Box<WrappedJob<AnalyzeMediaJob>> {
 		WrappedJob::new(Self {
 			variant: AnalyzeMediaJobVariant::AnalyzeSingleItem(media_id),
 		})
 	}
 
-	/// Create a new [AnalyzeMediaJob] for the `group_ids`s specified.
+	/// Create a new [`AnalyzeMediaJob`] for the `group_ids`s specified.
 	pub fn analyze_media_group(
 		group_ids: Vec<String>,
 	) -> Box<WrappedJob<AnalyzeMediaJob>> {
@@ -82,14 +82,14 @@ impl AnalyzeMediaJob {
 		})
 	}
 
-	/// Create a new [AnalyzeMediaJob] for the library specified by `library_id`.
+	/// Create a new [`AnalyzeMediaJob`] for the library specified by `library_id`.
 	pub fn analyze_library(library_id: String) -> Box<WrappedJob<AnalyzeMediaJob>> {
 		WrappedJob::new(Self {
 			variant: AnalyzeMediaJobVariant::AnalyzeLibrary(library_id),
 		})
 	}
 
-	/// Create a new [AnalyzeMediaJob] for the series specified by `series_id`.
+	/// Create a new [`AnalyzeMediaJob`] for the series specified by `series_id`.
 	pub fn analyze_series(series_id: String) -> Box<WrappedJob<AnalyzeMediaJob>> {
 		WrappedJob::new(Self {
 			variant: AnalyzeMediaJobVariant::AnalyzeSeries(series_id),
@@ -107,16 +107,16 @@ impl JobExt for AnalyzeMediaJob {
 	fn description(&self) -> Option<String> {
 		match &self.variant {
 			AnalyzeMediaJobVariant::AnalyzeSingleItem(id) => {
-				Some(format!("Analyze media item with id: {}", id))
+				Some(format!("Analyze media item with id: {id}"))
 			},
 			AnalyzeMediaJobVariant::AnalyzeLibrary(id) => {
-				Some(format!("Analyze library with id: {}", id))
+				Some(format!("Analyze library with id: {id}"))
 			},
 			AnalyzeMediaJobVariant::AnalyzeSeries(id) => {
-				Some(format!("Analyze series with id: {}", id))
+				Some(format!("Analyze series with id: {id}"))
 			},
 			AnalyzeMediaJobVariant::AnalyzeMediaGroup(ids) => {
-				Some(format!("Analyze media group with ids: {:?}", ids))
+				Some(format!("Analyze media group with ids: {ids:?}"))
 			},
 		}
 	}
@@ -191,17 +191,17 @@ impl JobExt for AnalyzeMediaJob {
 
 		match task {
 			AnalyzeMediaTask::UpdatePageCount(id) => {
-				task_page_count::execute(id, ctx, &mut output).await?
+				task_page_count::execute(id, ctx, &mut output).await?;
 			},
 			AnalyzeMediaTask::AnalyzePageDimensions(id) => {
-				task_analyze_dimensions::execute(id, ctx, &mut output).await?
+				task_analyze_dimensions::execute(id, ctx, &mut output).await?;
 			},
 			AnalyzeMediaTask::FullAnalysis(id) => {
 				// TODO This is suboptimal because it buffers the file twice, this should be improved later.
 				// First page count needs to be updated
 				task_page_count::execute(id.clone(), ctx, &mut output).await?;
 				// Then we can do the dimensions analysis
-				task_analyze_dimensions::execute(id, ctx, &mut output).await?
+				task_analyze_dimensions::execute(id, ctx, &mut output).await?;
 			},
 		}
 

--- a/core/src/filesystem/media/analyze_media_job/task_analyze_dimensions.rs
+++ b/core/src/filesystem/media/analyze_media_job/task_analyze_dimensions.rs
@@ -10,14 +10,14 @@ use crate::{
 	prisma::{media_metadata, page_dimensions},
 };
 
-/// The logic for [super::AnalyzeMediaTask::AnalyzePageDimensions].
+/// The logic for [`super::AnalyzeMediaTask::AnalyzePageDimensions`].
 ///
 /// Reads each page of the media item and determines its dimensions then writes them to
 /// the database.
 ///
 /// # Arguments
 /// * `id` - The id for the media item being analyzed
-/// * `ctx` - A reference to the [WorkerCtx] for the job
+/// * `ctx` - A reference to the [`WorkerCtx`] for the job
 /// * `output` - A mutable reference to the job output
 pub(crate) async fn execute(
 	id: String,
@@ -56,7 +56,7 @@ pub(crate) async fn execute(
 		let (height, width) =
 			image::load_from_memory_with_format(&page_data, image_format)
 				.map_err(|e| {
-					JobError::TaskFailed(format!("Error loading image data: {}", e))
+					JobError::TaskFailed(format!("Error loading image data: {e}"))
 				})?
 				.dimensions();
 

--- a/core/src/filesystem/media/analyze_media_job/task_page_count.rs
+++ b/core/src/filesystem/media/analyze_media_job/task_page_count.rs
@@ -7,16 +7,16 @@ use crate::{
 	prisma::{media, media_metadata},
 };
 
-/// The logic for [super::AnalyzeMediaTask::UpdatePageCount].
+/// The logic for [`super::AnalyzeMediaTask::UpdatePageCount`].
 ///
-/// Determines the page count for media using media processor [get_page_count] function, then
+/// Determines the page count for media using media processor [`get_page_count_async`] function, then
 /// performs one of:
 /// 1. Updating metadata if it already exists and does not match the determined page count, or
 /// 2. Creating metadata if it doesn't exist and writes the determined page count.
 ///
 /// # Arguments
 /// * `id` - The id for the media item being analyzed
-/// * `ctx` - A reference to the [WorkerCtx] for the job
+/// * `ctx` - A reference to the [`WorkerCtx`] for the job
 /// * `output` - A mutable reference to the job output
 pub(crate) async fn execute(
 	id: String,

--- a/core/src/filesystem/media/analyze_media_job/utils.rs
+++ b/core/src/filesystem/media/analyze_media_job/utils.rs
@@ -5,7 +5,7 @@ use crate::{
 	prisma::{media, media_metadata},
 };
 
-/// A utility function for fetching media by its [MediaID] with metadata (but not page dimensions) loaded.
+/// A utility function for fetching media by its [`MediaID`] with metadata (but not page dimensions) loaded.
 pub async fn fetch_media_with_metadata(
 	id: &MediaID,
 	ctx: &WorkerCtx,
@@ -19,14 +19,14 @@ pub async fn fetch_media_with_metadata(
 		.await
 		.map_err(|e: prisma_client_rust::QueryError| JobError::TaskFailed(e.to_string()))?
 		.ok_or_else(|| {
-			JobError::TaskFailed(format!("Unable to find media item with id: {}", id))
+			JobError::TaskFailed(format!("Unable to find media item with id: {id}"))
 		})?
 		.into();
 
 	Ok(media_item)
 }
 
-/// A utility function for fetching media by its [MediaID] with metadata and page dimensions loaded.
+/// A utility function for fetching media by its [`MediaID`] with metadata and page dimensions loaded.
 pub async fn fetch_media_with_dimensions(
 	id: &MediaID,
 	ctx: &WorkerCtx,
@@ -40,7 +40,7 @@ pub async fn fetch_media_with_dimensions(
 		.await
 		.map_err(|e: prisma_client_rust::QueryError| JobError::TaskFailed(e.to_string()))?
 		.ok_or_else(|| {
-			JobError::TaskFailed(format!("Unable to find media item with id: {}", id))
+			JobError::TaskFailed(format!("Unable to find media item with id: {id}"))
 		})?
 		.into();
 

--- a/core/src/filesystem/media/builder.rs
+++ b/core/src/filesystem/media/builder.rs
@@ -68,10 +68,8 @@ impl MediaBuilder {
 
 		let pages = processed_entry.pages;
 		if let Some(ref mut metadata) = processed_entry.metadata {
-			let conflicting_page_counts = metadata
-				.page_count
-				.map(|count| count != pages)
-				.unwrap_or(false);
+			let conflicting_page_counts =
+				metadata.page_count.is_some_and(|count| count != pages);
 			if conflicting_page_counts {
 				tracing::warn!(
 					?pages,

--- a/core/src/filesystem/media/format/epub.rs
+++ b/core/src/filesystem/media/format/epub.rs
@@ -138,16 +138,15 @@ impl FileProcessor for EpubProcessor {
 				));
 			}
 
-			let content_type = match epub_file.get_current_mime() {
-				Some(mime) => ContentType::from(mime.as_str()),
-				None => {
-					tracing::error!(
-						chapter_path = ?path,
-						"Failed to get explicit resource mime for chapter. Returning XHTML",
-					);
+			let content_type = if let Some(mime) = epub_file.get_current_mime() {
+				ContentType::from(mime.as_str())
+			} else {
+				tracing::error!(
+					chapter_path = ?path,
+					"Failed to get explicit resource mime for chapter. Returning XHTML",
+				);
 
-					ContentType::XHTML
-				},
+				ContentType::XHTML
 			};
 
 			content_types.insert(chapter, content_type);
@@ -247,16 +246,15 @@ impl EpubProcessor {
 			FileError::EpubReadError(e.to_string())
 		})?;
 
-		let content_type = match epub_file.get_current_mime() {
-			Some(mime) => ContentType::from(mime.as_str()),
-			None => {
-				tracing::error!(
-					chapter_path = ?path,
-					"Failed to get explicit resource mime for chapter. Returning XHTML",
-				);
+		let content_type = if let Some(mime) = epub_file.get_current_mime() {
+			ContentType::from(mime.as_str())
+		} else {
+			tracing::error!(
+				chapter_path = ?path,
+				"Failed to get explicit resource mime for chapter. Returning XHTML",
+			);
 
-				ContentType::XHTML
-			},
+			ContentType::XHTML
 		};
 
 		Ok((content_type, content))
@@ -295,18 +293,18 @@ impl EpubProcessor {
 		// Note: If the resource does not have an entry in the `resources` map, then loading the content
 		// type will fail. This seems to only happen when loading the root file (e.g. container.xml,
 		// package.opf, etc.).
-		let content_type =
-			match epub_file.get_resource_mime_by_path(adjusted_path.as_path()) {
-				Some(mime) => ContentType::from(mime.as_str()),
-				None => {
-					tracing::warn!(
-						?adjusted_path,
-						"Failed to get explicit definition of resource mime",
-					);
+		let content_type = if let Some(mime) =
+			epub_file.get_resource_mime_by_path(adjusted_path.as_path())
+		{
+			ContentType::from(mime.as_str())
+		} else {
+			tracing::warn!(
+				?adjusted_path,
+				"Failed to get explicit definition of resource mime",
+			);
 
-					ContentType::from_path(adjusted_path.as_path())
-				},
-			};
+			ContentType::from_path(adjusted_path.as_path())
+		};
 
 		Ok((content_type, contents))
 	}

--- a/core/src/filesystem/media/format/pdf.rs
+++ b/core/src/filesystem/media/format/pdf.rs
@@ -187,8 +187,7 @@ impl FileConverter for PdfProcessor {
 
 		let output_format = format
 			.clone()
-			.map(image::ImageFormat::from)
-			.unwrap_or(image::ImageFormat::Png);
+			.map_or(image::ImageFormat::Png, image::ImageFormat::from);
 		let converted_pages = iter
 			.enumerate()
 			.map(|(idx, page)| {
@@ -235,11 +234,10 @@ impl FileConverter for PdfProcessor {
 		// write each image to the folder
 		for image_buf in converted_pages {
 			// write the image to file with proper extension
-			let output_extension =
-				format.as_ref().map(|f| f.extension()).unwrap_or("png");
+			let output_extension = format.as_ref().map_or("png", |f| f.extension());
 
 			let image_path =
-				unpacked_path.join(format!("{}.{}", file_name, output_extension));
+				unpacked_path.join(format!("{file_name}.{output_extension}"));
 
 			// NOTE: This isn't bubbling up because I don't think at this point it should
 			// kill the whole conversion process.

--- a/core/src/filesystem/media/format/rar.rs
+++ b/core/src/filesystem/media/format/rar.rs
@@ -154,7 +154,7 @@ impl FileProcessor for RarProcessor {
 
 		let metadata = if let Some(buf) = metadata_buf {
 			let content_str = std::str::from_utf8(&buf)?;
-			metadata_from_buf(content_str.to_string())
+			metadata_from_buf(content_str)
 		} else {
 			None
 		};
@@ -176,7 +176,7 @@ impl FileProcessor for RarProcessor {
 
 		let sorted_entries = archive
 			.into_iter()
-			.filter_map(|entry| entry.ok())
+			.filter_map(std::result::Result::ok)
 			.filter(|entry| entry.filename.is_img() && !entry.filename.is_hidden_file())
 			.sorted_by(|a, b| alphanumeric_sort::compare_path(&a.filename, &b.filename))
 			.collect::<Vec<_>>();
@@ -195,9 +195,10 @@ impl FileProcessor for RarProcessor {
 				let (data, _) = header.read()?;
 				bytes = Some(data);
 				break;
-			} else {
-				archive = header.skip()?;
 			}
+
+			// Otherwise, skip
+			archive = header.skip()?;
 		}
 
 		let Some(bytes) = bytes else {
@@ -221,7 +222,7 @@ impl FileProcessor for RarProcessor {
 
 		let page_count = archive
 			.into_iter()
-			.filter_map(|entry| entry.ok())
+			.filter_map(std::result::Result::ok)
 			.filter(|entry| entry.filename.is_img() && !entry.filename.is_hidden_file())
 			.count();
 
@@ -236,7 +237,7 @@ impl FileProcessor for RarProcessor {
 
 		let sorted_entries = archive
 			.into_iter()
-			.filter_map(|entry| entry.ok())
+			.filter_map(std::result::Result::ok)
 			.filter(|entry| entry.filename.is_img())
 			.sorted_by(|a, b| alphanumeric_sort::compare_path(&a.filename, &b.filename))
 			.collect::<Vec<_>>();
@@ -358,7 +359,7 @@ mod tests {
 		// Assert that the operation succeeded
 		assert!(processed_file.is_ok());
 		// And that the original file was deleted
-		assert!(!Path::new(&temp_rar_file_path).exists())
+		assert!(!Path::new(&temp_rar_file_path).exists());
 	}
 
 	#[test]
@@ -379,7 +380,7 @@ mod tests {
 		// Assert that operation succeeded
 		assert!(zip_result.is_ok());
 		// And that the original file was deleted
-		assert!(!Path::new(&temp_rar_file_path).exists())
+		assert!(!Path::new(&temp_rar_file_path).exists());
 	}
 
 	#[test]

--- a/core/src/filesystem/media/format/rar.rs
+++ b/core/src/filesystem/media/format/rar.rs
@@ -176,7 +176,7 @@ impl FileProcessor for RarProcessor {
 
 		let sorted_entries = archive
 			.into_iter()
-			.filter_map(std::result::Result::ok)
+			.filter_map(Result::ok)
 			.filter(|entry| entry.filename.is_img() && !entry.filename.is_hidden_file())
 			.sorted_by(|a, b| alphanumeric_sort::compare_path(&a.filename, &b.filename))
 			.collect::<Vec<_>>();
@@ -222,7 +222,7 @@ impl FileProcessor for RarProcessor {
 
 		let page_count = archive
 			.into_iter()
-			.filter_map(std::result::Result::ok)
+			.filter_map(Result::ok)
 			.filter(|entry| entry.filename.is_img() && !entry.filename.is_hidden_file())
 			.count();
 
@@ -237,7 +237,7 @@ impl FileProcessor for RarProcessor {
 
 		let sorted_entries = archive
 			.into_iter()
-			.filter_map(std::result::Result::ok)
+			.filter_map(Result::ok)
 			.filter(|entry| entry.filename.is_img())
 			.sorted_by(|a, b| alphanumeric_sort::compare_path(&a.filename, &b.filename))
 			.collect::<Vec<_>>();

--- a/core/src/filesystem/media/format/zip.rs
+++ b/core/src/filesystem/media/format/zip.rs
@@ -101,7 +101,7 @@ impl FileProcessor for ZipProcessor {
 				file.read_to_end(&mut contents)?;
 				let contents = String::from_utf8_lossy(&contents).to_string();
 				trace!(contents_len = contents.len(), "Read ComicInfo.xml");
-				metadata = metadata_from_buf(contents);
+				metadata = metadata_from_buf(&contents);
 			} else if content_type.is_image() {
 				pages += 1;
 			}

--- a/core/src/filesystem/media/process.rs
+++ b/core/src/filesystem/media/process.rs
@@ -20,8 +20,8 @@ use crate::{
 
 use super::{rar::RarProcessor, zip::ZipProcessor};
 
-/// A struct representing the options for processing a file. This is a subset of [LibraryConfig]
-/// and is used to pass options to the [FileProcessor] implementations.
+/// A struct representing the options for processing a file. This is a subset of [`LibraryConfig`]
+/// and is used to pass options to the [`FileProcessor`] implementations.
 #[derive(Debug, Default)]
 pub struct FileProcessorOptions {
 	/// Whether to convert RAR files to ZIP files after processing
@@ -135,7 +135,7 @@ pub struct ProcessedFile {
 }
 
 /// A function to process a file in a blocking manner. This will call the appropriate
-/// [FileProcessor::process] implementation based on the file's mime type, or return an
+/// [`FileProcessor::process`] implementation based on the file's mime type, or return an
 /// error if the file type is not supported.
 pub fn process(
 	path: &Path,
@@ -198,7 +198,7 @@ pub async fn process_async(
 }
 
 /// A function to extract the bytes of a page from a file in a blocking manner. This will call the
-/// appropriate [FileProcessor::get_page] implementation based on the file's mime type, or return an
+/// appropriate [`FileProcessor::get_page`] implementation based on the file's mime type, or return an
 /// error if the file type is not supported.
 pub fn get_page(
 	path: &str,
@@ -258,7 +258,7 @@ pub async fn get_page_async(
 	Ok(page_result)
 }
 
-/// Get the number of pages in a file. This will call the appropriate [FileProcessor::get_page_count]
+/// Get the number of pages in a file. This will call the appropriate [`FileProcessor::get_page_count`]
 /// implementation based on the file's mime type, or return an error if the file type is not supported.
 pub fn get_page_count(path: &str, config: &StumpConfig) -> Result<i32, FileError> {
 	let mime = ContentType::from_file(path).mime_type();
@@ -314,7 +314,7 @@ pub async fn get_page_count_async(
 }
 
 /// Get the content types of a list of pages of a file. This will call the appropriate
-/// [FileProcessor::get_page_content_types] implementation based on the file's mime type, or return an
+/// [`FileProcessor::get_page_content_types`] implementation based on the file's mime type, or return an
 /// error if the file type is not supported.
 pub fn get_content_types_for_pages(
 	path: &str,

--- a/core/src/filesystem/media/utils.rs
+++ b/core/src/filesystem/media/utils.rs
@@ -9,7 +9,7 @@ pub fn is_accepted_cover_name(name: &str) -> bool {
 		.any(|&cover_name| name.eq_ignore_ascii_case(cover_name))
 }
 
-pub(crate) fn metadata_from_buf(contents: String) -> Option<MediaMetadata> {
+pub(crate) fn metadata_from_buf(contents: &str) -> Option<MediaMetadata> {
 	let adjusted = contents.trim();
 	// let adjusted = adjusted.trim_start_matches("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
 
@@ -20,7 +20,7 @@ pub(crate) fn metadata_from_buf(contents: String) -> Option<MediaMetadata> {
 	match serde_xml_rs::from_str(adjusted) {
 		Ok(meta) => Some(meta),
 		Err(err) => {
-			println!("Failed to parse metadata from buf: {}", err);
+			println!("Failed to parse metadata from buf: {err}");
 			error!(error = ?err, content = adjusted, "Failed to parse metadata from buf");
 			None
 		},
@@ -73,7 +73,7 @@ mod tests {
 	#[test]
 	fn test_should_parse_incomplete_metadata() {
 		let contents = "<?xml version=\"1.0\"?>\n<ComicInfo xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n  <Series>Delete</Series>\n  <Number>1</Number>\n  <Volume>2016</Volume>\n  <Summary>In the near future, where science can implant or remove human memories and the government uses brain scan technology in criminal investigations, a mute girl witnesses a multiple murder and must turn to a handyman for protection from the police and an army of killers. From the Harley Quinn team of writers Jimmy Palmiotti and Justin Grey and artist John Timms, with covers by Amanda Conner.\n\n\nNote: The digital edition (3/2/2016) for this issue was released before the print edition.</Summary>\n  <Notes>Tagged with ComicTagger 1.3.0-alpha.0 using info from Comic Vine on 2021-12-01 20:34:52.  [Issue ID 517895]</Notes>\n  <Year>2016</Year>\n  <Month>03</Month>\n  <Day>31</Day>\n  <Writer>Jimmy Palmiotti, Justin Gray</Writer>\n  <Penciller>John Timms, John Timms</Penciller>\n  <Inker>John Timms, John Timms</Inker>\n  <Colorist>David Curiel, Paul Mounts</Colorist>\n  <Letterer>Bill Tortolini</Letterer>\n  <CoverArtist>Amanda Conner, Paul Mounts</CoverArtist>\n  <Editor>Alex Wald, Joanne Starer</Editor>\n  <Publisher>1First Comics</Publisher>\n  <Web>https://comicvine.gamespot.com/delete-1/4000-517895/</Web>\n  <PageCount>27</PageCount>\n  <ScanInformation>(digital) (Son of Ultron-Empire)</ScanInformation>\n  <Pages>\n    <Page Image=\"0\" ImageSize=\"907332\" Type=\"FrontCover\" />\n    <Page Image=\"1\" ImageSize=\"431378\" />\n    <Page Image=\"2\" ImageSize=\"776720\" />\n    <Page Image=\"3\" ImageSize=\"524902\" />\n    <Page Image=\"4\" ImageSize=\"753942\" />\n    <Page Image=\"5\" ImageSize=\"607990\" />\n    <Page Image=\"6\" ImageSize=\"438880\" />\n    <Page Image=\"7\" ImageSize=\"504806\" />\n    <Page Image=\"8\" ImageSize=\"532746\" />\n    <Page Image=\"9\" ImageSize=\"542816\" />\n    <Page Image=\"10\" ImageSize=\"571650\" />\n    <Page Image=\"11\" ImageSize=\"626656\" />\n    <Page Image=\"12\" ImageSize=\"605810\" />\n    <Page Image=\"13\" ImageSize=\"585234\" />\n    <Page Image=\"14\" ImageSize=\"553270\" />\n    <Page Image=\"15\" ImageSize=\"440568\" />\n    <Page Image=\"16\" ImageSize=\"483816\" />\n    <Page Image=\"17\" ImageSize=\"492922\" />\n    <Page Image=\"18\" ImageSize=\"470748\" />\n    <Page Image=\"19\" ImageSize=\"644256\" />\n    <Page Image=\"20\" ImageSize=\"584142\" />\n    <Page Image=\"21\" ImageSize=\"425322\" />\n    <Page Image=\"22\" ImageSize=\"565166\" />\n    <Page Image=\"23\" ImageSize=\"582706\" />\n    <Page Image=\"24\" ImageSize=\"507370\" />\n    <Page Image=\"25\" ImageSize=\"489280\" />\n    <Page Image=\"26\" ImageSize=\"519906\" />\n  </Pages>\n</ComicInfo>";
-		let metadata = metadata_from_buf(contents.to_string()).unwrap();
+		let metadata = metadata_from_buf(contents).unwrap();
 
 		assert_eq!(metadata.series, Some("Delete".to_string()));
 		assert_eq!(metadata.number, Some(1f64));
@@ -83,12 +83,12 @@ mod tests {
 	#[test]
 	fn test_malformed_media_xml() {
 		// An empty string
-		let contents = String::from("");
+		let contents = "";
 		let metadata = metadata_from_buf(contents);
 		assert!(metadata.is_none());
 
 		// Something JSON-ish instead of xml
-		let contents = String::from("metadata: { contents: oops }");
+		let contents = "metadata: { contents: oops }";
 		let metadata = metadata_from_buf(contents);
 		assert!(metadata.is_none());
 	}

--- a/core/src/filesystem/scanner/library_scan_job.rs
+++ b/core/src/filesystem/scanner/library_scan_job.rs
@@ -272,7 +272,7 @@ impl JobExt for LibraryScanJob {
 
 				// Task count: build each series + 1 for insertion step, +1 for update tx on missing series
 				let total_subtask_count = (series_to_create.len() + 1)
-					+ if !missing_series.is_empty() { 1 } else { 0 };
+					+ usize::from(!missing_series.is_empty());
 				let mut current_subtask_index = 0;
 				ctx.report_progress(JobProgress::subtask_position(
 					current_subtask_index,
@@ -387,9 +387,10 @@ impl JobExt for LibraryScanJob {
 			},
 			LibraryScanTask::WalkSeries(path_buf) => {
 				tracing::debug!("Executing the walk series task for library scan");
-				ctx.report_progress(JobProgress::msg(
-					format!("Scanning series at {}", path_buf.display()).as_str(),
-				));
+				ctx.report_progress(JobProgress::msg(&format!(
+					"Scanning series at {}",
+					path_buf.display()
+				)));
 
 				// If the library is collection-priority, any child directories are 'ignored' and their
 				// files are part of / folded into the top-most folder (series).
@@ -470,8 +471,8 @@ impl JobExt for LibraryScanJob {
 					logs.extend(new_logs);
 					return Ok(JobTaskOutput {
 						output,
-						logs,
 						subtasks,
+						logs,
 					});
 				}
 
@@ -590,8 +591,8 @@ impl JobExt for LibraryScanJob {
 
 		Ok(JobTaskOutput {
 			output,
-			logs,
 			subtasks,
+			logs,
 		})
 	}
 }
@@ -636,8 +637,7 @@ pub async fn handle_missing_library(
 		.await
 		.map_err(|e| {
 			JobError::InitFailed(format!(
-				"A critical error occurred while handling missing library: {}",
-				e
+				"A critical error occurred while handling missing library: {e}"
 			))
 		})?;
 	tracing::trace!(

--- a/core/src/filesystem/scanner/utils.rs
+++ b/core/src/filesystem/scanner/utils.rs
@@ -390,7 +390,7 @@ pub(crate) async fn safely_build_series(
 						"Failed to build series: {:?}",
 						error.to_string()
 					))
-					.with_ctx(format!("Path: {:?}", path)),
+					.with_ctx(format!("Path: {path:?}")),
 				);
 			},
 		}
@@ -536,7 +536,7 @@ pub(crate) async fn safely_build_and_insert_media(
 						"Failed to build book: {:?}",
 						error.to_string()
 					))
-					.with_ctx(format!("Path: {:?}", path)),
+					.with_ctx(format!("Path: {path:?}")),
 				);
 			},
 		}
@@ -705,7 +705,7 @@ pub(crate) async fn visit_and_update_media(
 						"Failed to build book: {:?}",
 						error.to_string()
 					))
-					.with_ctx(format!("Path: {:?}", path)),
+					.with_ctx(format!("Path: {path:?}")),
 				);
 			},
 		}

--- a/core/src/filesystem/scanner/walk.rs
+++ b/core/src/filesystem/scanner/walk.rs
@@ -86,7 +86,7 @@ pub async fn walk_library(path: &str, ctx: WalkerCtx) -> CoreResult<WalkedLibrar
 		.min_depth(0)
 		.into_iter()
 		.filter_entry(|e| e.path().is_dir())
-		.filter_map(std::result::Result::ok)
+		.filter_map(Result::ok)
 		.par_bridge()
 		.partition_map::<Vec<DirEntry>, Vec<DirEntry>, _, _, _>(|entry| {
 			let entry_path = entry.path();
@@ -250,7 +250,7 @@ pub async fn walk_series(path: &Path, ctx: WalkerCtx) -> CoreResult<WalkedSeries
 	let walk_start = std::time::Instant::now();
 	let (valid_entries, ignored_entries) = walker
 		.into_iter()
-		.filter_map(std::result::Result::ok)
+		.filter_map(Result::ok)
 		.filter_map(|e| e.path().is_file().then_some(e))
 		.par_bridge()
 		.partition_map::<Vec<DirEntry>, Vec<DirEntry>, _, _, _>(|entry| {

--- a/core/src/filesystem/scanner/walk.rs
+++ b/core/src/filesystem/scanner/walk.rs
@@ -34,7 +34,7 @@ pub struct WalkedLibrary {
 	pub ignored_directories: u64,
 	/// The paths for series that need to be created
 	pub series_to_create: Vec<PathBuf>,
-	/// The paths for series that need to be visited. This differs from [WalkedSeries::media_to_visit] because
+	/// The paths for series that need to be visited. This differs from [`WalkedSeries::media_to_visit`] because
 	/// All series will always be visited in order to determine what media need to be reconciled in the series walk
 	pub series_to_visit: Vec<PathBuf>,
 	/// The paths for series that are missing from the filesystem
@@ -86,7 +86,7 @@ pub async fn walk_library(path: &str, ctx: WalkerCtx) -> CoreResult<WalkedLibrar
 		.min_depth(0)
 		.into_iter()
 		.filter_entry(|e| e.path().is_dir())
-		.filter_map(|e| e.ok())
+		.filter_map(std::result::Result::ok)
 		.par_bridge()
 		.partition_map::<Vec<DirEntry>, Vec<DirEntry>, _, _, _>(|entry| {
 			let entry_path = entry.path();
@@ -143,7 +143,7 @@ pub async fn walk_library(path: &str, ctx: WalkerCtx) -> CoreResult<WalkedLibrar
 		} else {
 			let existing_series_map = existing_records
 				.into_iter()
-				.map(|s| (s.path.clone(), s.to_owned()))
+				.map(|s| (s.path.clone(), s.clone()))
 				.collect::<HashMap<String, _>>();
 
 			let missing_series = existing_series_map
@@ -250,7 +250,7 @@ pub async fn walk_series(path: &Path, ctx: WalkerCtx) -> CoreResult<WalkedSeries
 	let walk_start = std::time::Instant::now();
 	let (valid_entries, ignored_entries) = walker
 		.into_iter()
-		.filter_map(|e| e.ok())
+		.filter_map(std::result::Result::ok)
 		.filter_map(|e| e.path().is_file().then_some(e))
 		.par_bridge()
 		.partition_map::<Vec<DirEntry>, Vec<DirEntry>, _, _, _>(|entry| {
@@ -294,7 +294,7 @@ pub async fn walk_series(path: &Path, ctx: WalkerCtx) -> CoreResult<WalkedSeries
 
 	let existing_media_map = existing_media
 		.into_iter()
-		.map(|m| (m.path.clone(), m.to_owned()))
+		.map(|m| (m.path.clone(), m.clone()))
 		.collect::<HashMap<String, _>>();
 
 	let (media_to_create, media_to_visit) = valid_entries
@@ -317,7 +317,7 @@ pub async fn walk_series(path: &Path, ctx: WalkerCtx) -> CoreResult<WalkedSeries
 								error = ?err,
 								path = ?entry_path,
 								"Failed to determine if entry has been modified since last scan"
-							)
+							);
 						})
 						.unwrap_or(false)
 				} else {

--- a/core/src/job/controller.rs
+++ b/core/src/job/controller.rs
@@ -70,7 +70,7 @@ impl JobController {
 		self.manager.clone().initialize().await
 	}
 
-	/// Starts the watcher loop for the [JobController]. This function will listen for incoming
+	/// Starts the watcher loop for the [`JobController`]. This function will listen for incoming
 	/// commands and execute them.
 	pub fn watch(
 		self: Arc<Self>,
@@ -108,7 +108,7 @@ impl JobController {
 									Ok(()),
 									"Successfully issued pause request",
 									"Error while sending pause confirmation",
-								)
+								);
 							},
 						);
 					},
@@ -121,7 +121,7 @@ impl JobController {
 									Ok(()),
 									"Successfully issued resume request",
 									"Error while sending resume confirmation",
-								)
+								);
 							},
 						);
 					},
@@ -135,7 +135,7 @@ impl JobController {
 								);
 							},
 							|_| tracing::trace!("Shutdown confirmation sent"),
-						)
+						);
 					},
 				}
 			}
@@ -151,8 +151,8 @@ impl JobController {
 	}
 }
 
-/// A helper function to send a [JobManagerResult] back along a job's [oneshot::Sender]
-/// and log a [tracing::trace!] `msg`. If sending fails then `err_msg`is logged as an
+/// A helper function to send a [`JobManagerResult`] back along a job's [`oneshot::Sender`]
+/// and log a [`tracing::trace!`] `msg`. If sending fails then `err_msg`is logged as an
 /// error instead.
 fn acknowledge_command_trace(
 	ack: oneshot::Sender<JobManagerResult<()>>,
@@ -165,11 +165,11 @@ fn acknowledge_command_trace(
 			tracing::error!(?error, err_msg);
 		},
 		|_| tracing::trace!(msg),
-	)
+	);
 }
 
-/// A helper function to send a [JobManagerResult] back along a job's [oneshot::Sender]
-/// and log a [tracing::info!] `msg`. If sending fails then `err_msg`is logged as an
+/// A helper function to send a [`JobManagerResult`] back along a job's [`oneshot::Sender`]
+/// and log a [`tracing::info!`] `msg`. If sending fails then `err_msg`is logged as an
 /// error instead.
 fn acknowledge_command_info(
 	ack: oneshot::Sender<JobManagerResult<()>>,
@@ -182,5 +182,5 @@ fn acknowledge_command_info(
 			tracing::error!(?error, err_msg);
 		},
 		|_| tracing::info!(msg),
-	)
+	);
 }

--- a/core/src/job/manager.rs
+++ b/core/src/job/manager.rs
@@ -19,17 +19,17 @@ use crate::{
 
 pub type JobManagerResult<T> = Result<T, JobManagerError>;
 
-/// A helper struct that holds the job queue and a list of workers for the job manager
+/// A helper struct that holds the job queue and a list of [`Worker`]s.
 pub struct JobManager {
 	/// Queue of jobs waiting to be run in a worker thread
 	queue: RwLock<VecDeque<Box<dyn Executor>>>,
 	/// Worker threads with a running job
 	workers: RwLock<HashMap<String, Arc<Worker>>>,
-	/// A channel to send shutdown signals to the parent job manager
+	/// A channel to send shutdown signals to the parent [`JobManager`]
 	job_controller_tx: mpsc::UnboundedSender<JobControllerCommand>,
 	/// A channel to emit core events
 	core_event_tx: broadcast::Sender<CoreEvent>,
-	/// A pointer to the PrismaClient
+	/// A pointer to the [`PrismaClient`]
 	client: Arc<PrismaClient>,
 	/// A pointer to the core config
 	config: Arc<StumpConfig>,
@@ -156,12 +156,12 @@ impl JobManager {
 				.send(JobControllerCommand::EnqueueJob(next))
 				.map_or_else(
 					|error| {
-						tracing::error!(?error, "Failed to send event to job manager")
+						tracing::error!(?error, "Failed to send event to job manager");
 					},
 					|_| tracing::trace!("Sent event to job manager to enqueue next job"),
 				);
 		} else {
-			tracing::trace!("No jobs in queue to auto enqueue")
+			tracing::trace!("No jobs in queue to auto enqueue");
 		}
 	}
 

--- a/core/src/job/mod.rs
+++ b/core/src/job/mod.rs
@@ -135,7 +135,7 @@ pub enum JobRetryPolicy {
 /// A trait to extend the output type for a job with a common interface. Job output starts
 /// in an 'empty' state (Default) and is frequently updated during execution.
 ///
-/// The state is also serialized and stored in the DB, so it must implement [Serialize] and [de::DeserializeOwned].
+/// The state is also serialized and stored in the DB, so it must implement [Serialize] and [`de::DeserializeOwned`].
 pub trait JobOutputExt: Serialize + de::DeserializeOwned + Debug {
 	/// Update the state with new data. By default, the implementation is a full replacement
 	fn update(&mut self, updated: Self) {
@@ -164,7 +164,7 @@ pub struct JobExecuteLog {
 }
 
 impl JobExecuteLog {
-	/// Construct a [JobExecuteLog] with the given msg and level
+	/// Construct a [`JobExecuteLog`] with the given msg and level
 	pub fn new(msg: String, level: LogLevel) -> Self {
 		Self {
 			msg,
@@ -174,7 +174,7 @@ impl JobExecuteLog {
 		}
 	}
 
-	/// Construct a [JobExecuteLog] with the given msg and [LogLevel::Error]
+	/// Construct a [`JobExecuteLog`] with the given msg and [`LogLevel::Error`]
 	pub fn error(msg: String) -> Self {
 		Self {
 			msg,
@@ -184,7 +184,7 @@ impl JobExecuteLog {
 		}
 	}
 
-	/// Construct a [JobExecuteLog] with the given msg and [LogLevel::Warn]
+	/// Construct a [`JobExecuteLog`] with the given msg and [`LogLevel::Warn`]
 	pub fn warn(msg: &str) -> Self {
 		Self {
 			msg: msg.to_string(),
@@ -194,7 +194,7 @@ impl JobExecuteLog {
 		}
 	}
 
-	/// Construct a new [JobExecuteLog] with the given context string
+	/// Construct a new [`JobExecuteLog`] with the given context string
 	pub fn with_ctx(self, ctx: String) -> Self {
 		Self {
 			context: Some(ctx),
@@ -414,7 +414,7 @@ pub struct WrappedJob<J: JobExt> {
 }
 
 impl<J: JobExt> WrappedJob<J> {
-	/// Create a new [WrappedJob] with the given job, wrapping itself in a Box
+	/// Create a new [`WrappedJob`] with the given job, wrapping itself in a Box
 	pub fn new(job: J) -> Box<Self> {
 		Box::new(Self {
 			id: Uuid::new_v4(),
@@ -431,7 +431,7 @@ impl<J: JobExt> WrappedJob<J> {
 }
 
 /// The output of a job's execution. To avoid the need for a generic type, the output data is serialized
-/// _prior_ to being returned from the [Executor::execute] function.
+/// _prior_ to being returned from the [`Executor::execute`] function.
 pub struct ExecutorOutput {
 	pub output: Option<serde_json::Value>,
 	pub logs: Vec<JobExecuteLog>,
@@ -597,7 +597,7 @@ impl<J: JobExt> Executor for WrappedJob<J> {
 	}
 
 	fn description(&self) -> Option<String> {
-		self.inner_job.as_ref().and_then(|job| job.description())
+		self.inner_job.as_ref().and_then(JobExt::description)
 	}
 
 	fn should_requeue(&self) -> bool {
@@ -731,10 +731,7 @@ impl<J: JobExt> Executor for WrappedJob<J> {
 				Ok(r) => r,
 				Err(e) => {
 					tracing::error!(?e, "Task handler failed");
-					logs.push(JobExecuteLog::error(format!(
-						"Critical task error: {}",
-						e
-					)));
+					logs.push(JobExecuteLog::error(format!("Critical task error: {e}")));
 					return Ok(ExecutorOutput {
 						output: working_output.into_json(),
 						logs,
@@ -770,8 +767,7 @@ impl<J: JobExt> Executor for WrappedJob<J> {
 				tasks = new_tasks;
 				ctx.report_progress(JobProgress::task_position_msg(
 					format!(
-						"{} subtask(s) discovered. Reordering the task queue",
-						subtask_count
+						"{subtask_count} subtask(s) discovered. Reordering the task queue",
 					)
 					.as_str(),
 					completed_tasks as i32,

--- a/core/src/job/progress.rs
+++ b/core/src/job/progress.rs
@@ -41,7 +41,7 @@ pub struct JobProgress {
 }
 
 impl JobProgress {
-	/// Constructs a new JobProgress with the given message
+	/// Constructs a new [`JobProgress`] with the given message
 	pub fn msg(msg: &str) -> Self {
 		Self {
 			message: Some(msg.to_string()),
@@ -49,7 +49,7 @@ impl JobProgress {
 		}
 	}
 
-	/// Constructs a new JobProgress with the given status
+	/// Constructs a new [`JobProgress`] with the given status
 	pub fn status(status: JobStatus) -> Self {
 		Self {
 			status: Some(status),
@@ -57,7 +57,7 @@ impl JobProgress {
 		}
 	}
 
-	/// Constructs a new JobProgress with the given status and msg
+	/// Constructs a new [`JobProgress`] with the given status and msg
 	pub fn status_msg(status: JobStatus, msg: &str) -> Self {
 		Self {
 			status: Some(status),
@@ -66,12 +66,12 @@ impl JobProgress {
 		}
 	}
 
-	/// Constructs a new JobProgress with the status set to `JobStatus::Completed` and the message set to "Job finished"
+	/// Constructs a new [`JobProgress`] with the status set to `JobStatus::Completed` and the message set to "Job finished"
 	pub fn finished() -> Self {
 		Self::status_msg(JobStatus::Completed, "Job finished")
 	}
 
-	/// Constructs a new JobProgress with the given queue position and size
+	/// Constructs a new [`JobProgress`] with the given queue position and size
 	pub fn task_position(index: i32, size: i32) -> Self {
 		Self {
 			completed_tasks: Some(index),

--- a/core/src/job/scheduler.rs
+++ b/core/src/job/scheduler.rs
@@ -79,7 +79,7 @@ impl JobScheduler {
 							vec![]
 						});
 
-					for library in libraries_to_scan.iter() {
+					for library in &libraries_to_scan {
 						let library_path = library.path.clone();
 						// TODO: optimize query with select!/include!
 						let options = library.config().ok().take();

--- a/core/src/job/task.rs
+++ b/core/src/job/task.rs
@@ -53,11 +53,7 @@ pub(crate) async fn job_task_handler<J: JobExt>(
 						} = result?;
 
 						return Ok(JobTaskHandlerOutput {
-							output: JobTaskOutput {
-								output,
-								logs,
-								subtasks,
-							},
+							output: JobTaskOutput { output, subtasks, logs },
 							returned_ctx: worker_ctx,
 						});
 					}

--- a/core/src/job/worker.rs
+++ b/core/src/job/worker.rs
@@ -69,13 +69,13 @@ pub struct WorkerCtx {
 	pub commands_rx: async_channel::Receiver<WorkerCommand>,
 	/// A sender for the worker to send commands to the job manager
 	pub job_controller_tx: mpsc::UnboundedSender<JobControllerCommand>,
-	/// A sender for the [WorkerCtx] to send status events to the loop which
+	/// A sender for the [`WorkerCtx`] to send status events to the loop which
 	/// is managing the corresponding worker
 	pub status_tx: async_channel::Sender<WorkerStatusEvent>,
 }
 
 impl WorkerCtx {
-	/// Emit a [CoreEvent] to any clients listening to the server that a job has started
+	/// Emit a [`CoreEvent`] to any clients listening to the server that a job has started
 	pub fn report_started(&self) {
 		let send_result = self
 			.core_event_tx
@@ -85,7 +85,7 @@ impl WorkerCtx {
 		}
 	}
 
-	/// Emit a [CoreEvent] to any clients listening to the server
+	/// Emit a [`CoreEvent`] to any clients listening to the server
 	pub fn report_progress(&self, payload: JobProgress) {
 		let send_result = self.core_event_tx.send(CoreEvent::JobUpdate(JobUpdate {
 			id: self.job_id.clone(),
@@ -96,7 +96,7 @@ impl WorkerCtx {
 		}
 	}
 
-	/// Send a command to the [super::JobManager]
+	/// Send a command to the [`super::JobManager`]
 	pub fn send_manager_command(&self, command: JobControllerCommand) {
 		self.job_controller_tx.send(command).map_or_else(
 			|error| {
@@ -119,7 +119,7 @@ impl WorkerCtx {
 		);
 	}
 
-	/// Send a batch of [WorkerSend] to the appropriate handlers
+	/// Send a batch of [`WorkerSend`] to the appropriate handlers
 	///
 	/// Note that this isn't _really_ batching on the send side, rather just providing
 	/// a convenient interface for providing multiple send operations at once.
@@ -220,7 +220,7 @@ pub struct Worker {
 
 impl Worker {
 	/// Create a new worker instance and its context
-	async fn new(
+	fn new(
 		job_id: &str,
 		db: Arc<PrismaClient>,
 		config: Arc<StumpConfig>,
@@ -264,8 +264,7 @@ impl Worker {
 			config,
 			core_event_tx,
 			job_controller_tx,
-		)
-		.await?;
+		)?;
 		let worker = worker.arced();
 
 		handle_job_start(&worker_ctx.db, job_id.clone()).await?;
@@ -336,7 +335,7 @@ impl Worker {
 				|_| {
 					tracing::trace!("Received cancel confirmation");
 				},
-			)
+			);
 		} else {
 			tracing::error!("Failed to send cancel signal to worker");
 		}
@@ -407,7 +406,7 @@ impl WorkerManager {
 									tracing::error!(?error, "Job failed with critical error");
 									finalizer_ctx.report_progress(JobProgress::status_msg(
 										JobStatus::Failed,
-										&format!("Job failed: {}", error),
+										&format!("Job failed: {error}"),
 									));
 
 									let result = returned_executor
@@ -442,7 +441,7 @@ impl WorkerManager {
 							tracing::error!(?join_error, ?elapsed, "Error while joining job worker thread");
 							finalizer_ctx.report_progress(JobProgress::status_msg(
 								JobStatus::Failed,
-								&format!("Job failed: {}", join_error),
+								&format!("Job failed: {join_error}"),
 							));
 							let _ = handle_failure_status(job_id.clone(), JobStatus::Failed, &finalizer_ctx.db, elapsed).await;
 						}
@@ -468,7 +467,7 @@ impl WorkerManager {
 								},
 							);
 						},
-						_=> {
+						_ => {
 							tracing::warn!(?status_event, "Ignoring status event. Most likely a status change to the same status");
 						}
 					}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -42,15 +42,15 @@ type JournalModeChanged = bool;
 /// A type alias strictly for explicitness in the return type of `init_encryption`.
 type EncryptionKeySet = bool;
 
-/// The [StumpCore] struct is the main entry point for any server-side Stump
-/// applications. It is responsible for managing incoming tasks ([InternalCoreTask]),
-/// outgoing events ([CoreEvent](event::CoreEvent)), and providing access to the database
-/// via the core's [Ctx].
+/// The [`StumpCore`] struct is the main entry point for any server-side Stump
+/// applications. It is responsible for managing incoming tasks ([`InternalCoreTask`]),
+/// outgoing events ([`CoreEvent`](event::CoreEvent)), and providing access to the database
+/// via the core's [`Ctx`].
 ///
-/// [StumpCore] expects the consuming application to determine its configuration prior to startup.
-/// [config::bootstrap_config_dir] enables consumers to fetch the configuration directory automatically,
-/// and [StumpCore::init_config](#method.init_config) will load any Stump.toml in the config directory
-/// or environment variables to return a [StumpConfig] struct.
+/// [`StumpCore`] expects the consuming application to determine its configuration prior to startup.
+/// [`config::bootstrap_config_dir`] enables consumers to fetch the configuration directory automatically,
+/// and [`StumpCore::init_config`](#method.init_config) will load any Stump.toml in the config directory
+/// or environment variables to return a [`StumpConfig`] struct.
 ///
 /// ## Example:
 /// ```no_run
@@ -69,7 +69,7 @@ pub struct StumpCore {
 }
 
 impl StumpCore {
-	/// Creates a new instance of [StumpCore] and returns it wrapped in an [std::sync::Arc].
+	/// Creates a new instance of [`StumpCore`] and returns it wrapped in an [`std::sync::Arc`].
 	pub async fn new(config: StumpConfig) -> StumpCore {
 		let core_ctx = Ctx::new(config).await;
 		StumpCore { ctx: core_ctx }
@@ -78,7 +78,7 @@ impl StumpCore {
 	/// A three-step configuration initialization function.
 	///
 	/// 1. Loads configuration variables from Stump.toml, located at the input
-	///    config_dir, if such a file exists.
+	///    `config_dir`, if such a file exists.
 	///
 	/// 2. Overrides variables with those set in the environment.
 	///
@@ -202,16 +202,16 @@ impl StumpCore {
 		} else {
 			let journal_mode = client.get_journal_mode().await?;
 
-			if journal_mode != JournalMode::WAL {
+			if journal_mode == JournalMode::WAL {
+				tracing::trace!("Journal mode is already set to WAL, skipping");
+			} else {
 				tracing::trace!("Journal mode is not set to WAL!");
 				let updated_journal_mode =
 					client.set_journal_mode(JournalMode::WAL).await?;
 				tracing::debug!(
 					"Initial journal mode has been set to {:?}",
 					updated_journal_mode
-				)
-			} else {
-				tracing::trace!("Journal mode is already set to WAL, skipping");
+				);
 			}
 
 			let _affected_rows = client

--- a/core/src/opds/v1_2/author.rs
+++ b/core/src/opds/v1_2/author.rs
@@ -1,4 +1,4 @@
-//! This module defines [StumpAuthor] struct for representing the `atom:author` of an OPDS feed entry
+//! This module defines [`StumpAuthor`] struct for representing the `atom:author` of an OPDS feed entry
 //! as specified at https://specs.opds.io/opds-1.2#51-metadata
 
 use xml::EventWriter;
@@ -28,7 +28,7 @@ impl StumpAuthor {
 		StumpAuthor { name, uri }
 	}
 
-	/// Writes the [StumpAuthor] instance as XML.
+	/// Writes the [`StumpAuthor`] instance as XML.
 	///
 	/// ## Example
 	/// ```no_run

--- a/core/src/opds/v1_2/entry.rs
+++ b/core/src/opds/v1_2/entry.rs
@@ -1,4 +1,4 @@
-//! This module defines the [OpdsEntry] struct for representing an OPDS catalogue entry
+//! This module defines the [`OpdsEntry`] struct for representing an OPDS catalogue entry
 //! as specified at https://specs.opds.io/opds-1.2#5-opds-catalog-entry-documents
 
 use std::collections::HashMap;
@@ -170,8 +170,9 @@ impl From<media::Data> for OpdsEntry {
 			.ok()
 			.and_then(|sessions| sessions.first().cloned());
 		let (current_page, last_read_at) = active_reading_session
-			.map(|session| (session.page, Some(session.updated_at)))
-			.unwrap_or((None, None));
+			.map_or((None, None), |session| {
+				(session.page, Some(session.updated_at))
+			});
 
 		let target_pages = if let Some(page) = current_page {
 			vec![1, page]
@@ -204,9 +205,9 @@ impl From<media::Data> for OpdsEntry {
 				.to_owned(),
 			Some(page) => {
 				tracing::warn!(current_page=?page, book_pages=?value.pages, "Current page is out of bounds!");
-				thumbnail_link_type.to_owned()
+				thumbnail_link_type
 			},
-			_ => thumbnail_link_type.to_owned(),
+			_ => thumbnail_link_type,
 		};
 
 		let thumbnail_opds_link_type = OpdsLinkType::try_from(thumbnail_link_type)
@@ -225,17 +226,17 @@ impl From<media::Data> for OpdsEntry {
 			OpdsLink::new(
 				thumbnail_opds_link_type,
 				OpdsLinkRel::Thumbnail,
-				format!("{}/thumbnail", base_url),
+				format!("{base_url}/thumbnail"),
 			),
 			OpdsLink::new(
 				thumbnail_opds_link_type,
 				OpdsLinkRel::Image,
-				format!("{}/pages/1", base_url),
+				format!("{base_url}/pages/1"),
 			),
 			OpdsLink::new(
 				entry_file_acquisition_link_type,
 				OpdsLinkRel::Acquisition,
-				format!("{}/file/{}", base_url, file_name_encoded),
+				format!("{base_url}/file/{file_name_encoded}"),
 			),
 		];
 

--- a/core/src/opds/v1_2/feed.rs
+++ b/core/src/opds/v1_2/feed.rs
@@ -1,4 +1,4 @@
-//! This module defines a struct,[OpdsFeed], for representing an OPDS catalogue feed document
+//! This module defines a struct,[`OpdsFeed`], for representing an OPDS catalogue feed document
 //! as specified at https://specs.opds.io/opds-1.2#2-opds-catalog-feed-documents
 
 use crate::{
@@ -117,7 +117,7 @@ impl From<library::Data> for OpdsFeed {
 			OpdsLink::new(
 				OpdsLinkType::Navigation,
 				OpdsLinkRel::ItSelf,
-				format!("/opds/v1.2/libraries/{}", id),
+				format!("/opds/v1.2/libraries/{id}"),
 			),
 			OpdsLink::new(
 				OpdsLinkType::Navigation,
@@ -248,7 +248,7 @@ where
 			OpdsLink {
 				link_type: OpdsLinkType::Navigation,
 				rel: OpdsLinkRel::ItSelf,
-				href: format!("/opds/v1.2/{}", href_postfix),
+				href: format!("/opds/v1.2/{href_postfix}"),
 			},
 			OpdsLink {
 				link_type: OpdsLinkType::Navigation,
@@ -273,7 +273,7 @@ where
 			links.push(OpdsLink {
 				link_type: OpdsLinkType::Navigation,
 				rel: OpdsLinkRel::Next,
-				href: format!("/opds/v1.2/{}?page={}", href_postfix, page + 1),
+				href: format!("/opds/v1.2/{href_postfix}?page={}", page + 1),
 			});
 		}
 

--- a/core/src/opds/v1_2/link.rs
+++ b/core/src/opds/v1_2/link.rs
@@ -1,7 +1,7 @@
-//! This module defines the [OpdsLink] struct for representing an OPDS `atom:link` element as
+//! This module defines the [`OpdsLink`] struct for representing an OPDS `atom:link` element as
 //! specified at https://specs.opds.io/opds-1.2#the-atomlink-element
 //!
-//! It also defines the [OpdsStreamLink] struct for representing an OPDS page steaming extension
+//! It also defines the [`OpdsStreamLink`] struct for representing an OPDS page steaming extension
 //! link element as specified at https://github.com/anansi-project/opds-pse/blob/master/v1.2.md
 
 use xml::{writer::XmlEvent, EventWriter};
@@ -47,7 +47,7 @@ impl TryFrom<ContentType> for OpdsLinkType {
 			ContentType::JPEG => Ok(OpdsLinkType::ImageJpeg),
 			ContentType::PNG => Ok(OpdsLinkType::ImagePng),
 			ContentType::GIF => Ok(OpdsLinkType::ImageGif),
-			_ => Err(format!("Unsupported content type: {}", content_type)),
+			_ => Err(format!("Unsupported content type: {content_type}")),
 		}
 	}
 }

--- a/core/src/opds/v1_2/opensearch.rs
+++ b/core/src/opds/v1_2/opensearch.rs
@@ -1,4 +1,4 @@
-//! This module defines the [OpdsOpenSearch] struct for representing OpenSearch SearchDescription
+//! This module defines the [`OpdsOpenSearch`] struct for representing OpenSearch SearchDescription
 //! data as specified at https://developer.mozilla.org/en-US/docs/Web/OpenSearch
 
 use xml::{writer::XmlEvent, EventWriter};

--- a/core/src/opds/v2_0/group.rs
+++ b/core/src/opds/v2_0/group.rs
@@ -42,14 +42,12 @@ impl OPDSFeedGroupBuilder {
 		let navigation_empty = self
 			.navigation
 			.as_ref()
-			.map(|nav| nav.is_empty())
-			.unwrap_or(true);
+			.map_or(true, std::vec::Vec::is_empty);
 
 		let publications_empty = self
 			.publications
 			.as_ref()
-			.map(|pubs| pubs.is_empty())
-			.unwrap_or(true);
+			.map_or(true, std::vec::Vec::is_empty);
 
 		if navigation_empty && publications_empty {
 			return Err(OPDSV2Error::FeedValidationFailed(
@@ -123,6 +121,6 @@ mod tests {
 
 		assert!(error.to_string().contains(
 			"OPDSFeedGroup missing at least one navigation link or publication"
-		))
+		));
 	}
 }

--- a/core/src/opds/v2_0/properties.rs
+++ b/core/src/opds/v2_0/properties.rs
@@ -9,7 +9,7 @@ use serde_with::skip_serializing_none;
 use super::link::OPDSLinkType;
 
 /// A struct for representing dynamic properties of an OPDS feed or collection. This is just
-/// a wrapper around a serde_json::Value, which can be used to store any arbitrary JSON data
+/// a wrapper around a [`serde_json::Value`], which can be used to store any arbitrary JSON data
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OPDSDynamicProperties(pub serde_json::Value);
 
@@ -28,7 +28,7 @@ pub struct OPDSProperties {
 }
 
 impl OPDSProperties {
-	/// Create a new OPDSProperties object with the given authentication URL
+	/// Create a new [`OPDSProperties`] object with the given authentication URL
 	pub fn with_auth(self, url: String) -> Self {
 		Self {
 			authenticate: Some(OPDSAuthenticateProperties::new(url)),

--- a/core/src/opds/v2_0/publication.rs
+++ b/core/src/opds/v2_0/publication.rs
@@ -105,7 +105,7 @@ impl OPDSPublication {
 				let links = OPDSPublication::links_for_book(&book, &finalizer)?;
 				let images = OPDSPublication::images_for_book(&book, &finalizer).await?;
 
-				let position = positions.get(&book.id).cloned();
+				let position = positions.get(&book.id).copied();
 
 				let metadata = book
 					.metadata
@@ -159,7 +159,7 @@ impl OPDSPublication {
 		let positions = client
 			.book_positions_in_series(vec![book.id.clone()], series.id.clone())
 			.await?;
-		let position = positions.get(&book.id).cloned();
+		let position = positions.get(&book.id).copied();
 
 		let metadata = book
 			.metadata
@@ -370,7 +370,7 @@ mod tests {
 
 		mock.expect(
 			client._query_raw(book_positions_in_series_raw_query(
-				vec!["1".to_string(), "2".to_string()],
+				&["1".to_string(), "2".to_string()],
 				"1".to_string(),
 			)),
 			vec![
@@ -406,7 +406,7 @@ mod tests {
 
 		mock.expect(
 			client._query_raw(book_positions_in_series_raw_query(
-				vec!["1".to_string()],
+				&["1".to_string()],
 				"1".to_string(),
 			)),
 			vec![EntityPosition {
@@ -421,7 +421,7 @@ mod tests {
 				.page_dimensions()
 				// When metadata is not set, the metadata ID is an empty string. This will never load, but for
 				// the sake of the test it should be acceptable
-				.find_first(vec![page_dimensions::metadata_id::equals("".to_string())]),
+				.find_first(vec![page_dimensions::metadata_id::equals(String::new())]),
 			Some(page_dimensions::Data {
 				id: "1".to_string(),
 				metadata_id: "1".to_string(),

--- a/core/src/opds/v2_0/utils.rs
+++ b/core/src/opds/v2_0/utils.rs
@@ -45,7 +45,7 @@ impl OPDSV2PrismaExt for PrismaClient {
 		series_id: String,
 	) -> CoreResult<HashMap<String, i64>> {
 		let ranked: Vec<EntityPosition> = self
-			._query_raw(book_positions_in_series_raw_query(book_ids, series_id))
+			._query_raw(book_positions_in_series_raw_query(&book_ids, series_id))
 			.exec()
 			.await?;
 
@@ -58,7 +58,7 @@ impl OPDSV2PrismaExt for PrismaClient {
 // I have tried RANK() OVER (ORDER BY CASE WHEN md.number IS NOT NULL THEN md.number ELSE m.name END ASC) AS position
 // but it doesn't work as expected. We need to figure out how to do this properly.
 pub(crate) fn book_positions_in_series_raw_query(
-	book_ids: Vec<String>,
+	book_ids: &[String],
 	series_id: String,
 ) -> Raw {
 	raw!(
@@ -76,7 +76,7 @@ pub(crate) fn book_positions_in_series_raw_query(
 			// Note: Prisma (SQLite) doesn't support PrismaValue::List, so we need to manually format this
 			book_ids
 				.iter()
-				.map(|id| format!("'{}'", id))
+				.map(|id| format!("'{id}'"))
 				.collect::<Vec<_>>()
 				.join(",")
 		),

--- a/packages/types/generated.ts
+++ b/packages/types/generated.ts
@@ -18,8 +18,8 @@ export type AccessRole = "Reader" | "Writer" | "CoCreator"
 export type Log = { id: number; level: LogLevel; message: string; context: string | null; timestamp: string; job_id?: string | null }
 
 /**
- * Information about the Stump log file, located at STUMP_CONFIG_DIR/Stump.log, or
- * ~/.stump/Stump.log by default. Information such as the file size, last modified date, etc.
+ * Information about the Stump log file, located at `STUMP_CONFIG_DIR/Stump.log`, or
+ * `~/.stump/Stump.log` by default. Information such as the file size, last modified date, etc.
  */
 export type LogMetadata = { path: string; size: BigInt; modified: string }
 
@@ -166,9 +166,9 @@ export type ProgressUpdateReturn = ActiveReadingSession | FinishedReadingSession
 export type PageDimension = { height: number; width: number }
 
 /**
- * Represents a database [page_dimensions::Data] object.
+ * Represents a database [`page_dimensions::Data`] object.
  * 
- * The `dimensions` member contains a [Vec]<[PageDimension]> containing the height and width
+ * The `dimensions` member contains a [Vec]<[`PageDimension`]> containing the height and width
  * of each page for the media attached to the metadata for this entity.
  */
 export type PageDimensionsEntity = { id: string; dimensions: PageDimension[]; metadata_id: string }


### PR DESCRIPTION
This is a housekeeping PR. I went into the roots of the core and server crates, enabled clippy::pedantic, and fixed anything that seemed sensible to fix. I think the result is nice, lots of little readability and consistency fixes. Plus it was relaxing.

There were even a few instances where parameters in functions could become references, which could theoretically improve performance but won't because it was like 4 string manipulation functions.

Passes tests and runs fine for me after as well.