### PR TITLE
🐛 Fix bug in `FileExplorer` that broke clicking on books.

### DIFF
--- a/packages/browser/src/components/explorer/FileExplorerProvider.tsx
+++ b/packages/browser/src/components/explorer/FileExplorerProvider.tsx
@@ -1,4 +1,4 @@
-import { useDirectoryListing } from '@stump/client'
+import { useDirectoryListing, useSDK } from '@stump/client'
 import { DirectoryListingFile } from '@stump/sdk'
 import React, { useState } from 'react'
 import toast from 'react-hot-toast'
@@ -22,6 +22,7 @@ type Props = {
 export default function FileExplorerProvider({ rootPath }: Props) {
 	const navigate = useNavigate()
 	const isMobile = useMediaMatch('(max-width: 768px)')
+	const { sdk } = useSDK()
 
 	const [layout, setLayout] = useState<ExplorerLayout>(() => getDefaultLayout())
 
@@ -39,7 +40,7 @@ export default function FileExplorerProvider({ rootPath }: Props) {
 			setPath(entry.path)
 		} else {
 			try {
-				const entity = await getBook(entry.path)
+				const entity = await getBook(entry.path, sdk)
 				if (entity) {
 					navigate(paths.bookOverview(entity.id), {
 						state: {

--- a/packages/browser/src/components/explorer/grid/FileGridItem.tsx
+++ b/packages/browser/src/components/explorer/grid/FileGridItem.tsx
@@ -1,3 +1,4 @@
+import { useSDK } from '@stump/client'
 import { Text, ToolTip } from '@stump/components'
 import { DirectoryListingFile, Media } from '@stump/sdk'
 import React, { useEffect, useMemo, useState } from 'react'
@@ -13,6 +14,7 @@ type Props = {
 
 export default function FileGridItem({ file }: Props) {
 	const { name, path, is_directory } = file
+	const { sdk } = useSDK()
 
 	const { onSelect } = useFileExplorerContext()
 
@@ -27,7 +29,7 @@ export default function FileGridItem({ file }: Props) {
 	useEffect(() => {
 		async function tryGetMedia() {
 			// Note: This should be cached, so it should be fast
-			const maybeBook = await getBook(path)
+			const maybeBook = await getBook(path, sdk)
 			if (maybeBook) {
 				setBook(maybeBook)
 			}
@@ -36,7 +38,7 @@ export default function FileGridItem({ file }: Props) {
 		if (!is_directory) {
 			tryGetMedia()
 		}
-	}, [path, is_directory])
+	}, [path, is_directory, sdk])
 
 	return (
 		<ToolTip content={tooltipName} align="start">


### PR DESCRIPTION
I noticed an issue in the `FileExplorer` component that seems to have followed on the sdk overhaul. The function `getBook` defined here requires an `sdk: Api` parameter:

https://github.com/stumpapp/stump/blob/2409a6e04371af8ba2421154da96a0588ff1811a/packages/browser/src/components/explorer/FileThumbnail.tsx#L112-L134

However, a few calls to `getBook` didn't include the parameter, which caused them to fail. As a result, when double clicking a file in the explorer, you'd get this response:

![image](https://github.com/user-attachments/assets/db55e9e2-2061-41db-bd25-f4b5fded39a2)

The changes I made seem to fix it, but it would be good to have review by someone more familiar with React to make sure that any other changes that I may have missed are made.