### PR TITLE
:rotating_light: Wrap large enum variants in `Box`

### DIFF
--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -25,7 +25,7 @@ pub enum CoreError {
 	#[error("{0}")]
 	EmailerError(#[from] email::EmailError),
 	#[error("Query error: {0}")]
-	QueryError(#[from] prisma_client_rust::queries::QueryError),
+	QueryError(#[from] Box<prisma_client_rust::QueryError>),
 	#[error("Invalid query error: {0}")]
 	InvalidQuery(String),
 	#[error("Invalid usage of query result, failed to load relation: {0}")]
@@ -56,4 +56,10 @@ pub enum CoreError {
 	SerdeFailure(#[from] serde_json::Error),
 	#[error("An unknown error ocurred: {0}")]
 	Unknown(String),
+}
+
+impl From<prisma_client_rust::QueryError> for CoreError {
+	fn from(error: prisma_client_rust::QueryError) -> Self {
+		Self::QueryError(Box::new(error))
+	}
 }

--- a/core/src/job/error.rs
+++ b/core/src/job/error.rs
@@ -15,18 +15,24 @@ pub enum JobError {
 	#[error("A task experienced a critical error while executing: {0}")]
 	TaskFailed(String),
 	#[error("A query error occurred: {0}")]
-	QueryError(#[from] prisma_client_rust::QueryError),
+	QueryError(#[from] Box<prisma_client_rust::QueryError>),
 	#[error("A file error occurred: {0}")]
 	FileError(#[from] FileError),
 	#[error("An unknown error occurred: {0}")]
 	Unknown(String),
 }
 
+impl From<prisma_client_rust::QueryError> for JobError {
+	fn from(error: prisma_client_rust::QueryError) -> Self {
+		Self::QueryError(Box::new(error))
+	}
+}
+
 impl From<CoreError> for JobError {
 	fn from(err: CoreError) -> Self {
 		match err {
-			CoreError::QueryError(err) => JobError::QueryError(err),
-			_ => JobError::Unknown(err.to_string()),
+			CoreError::QueryError(err) => Self::QueryError(err),
+			_ => Self::Unknown(err.to_string()),
 		}
 	}
 }
@@ -50,7 +56,7 @@ pub enum JobManagerError {
 	#[error("A job was found which was in a deeply invalid state")]
 	JobLostError,
 	#[error("A query error occurred {0}")]
-	QueryError(#[from] prisma_client_rust::QueryError),
+	QueryError(#[from] Box<prisma_client_rust::QueryError>),
 	#[error("An unknown error occurred {0}")]
 	Unknown(String),
 }
@@ -58,8 +64,14 @@ pub enum JobManagerError {
 impl From<JobError> for JobManagerError {
 	fn from(job_error: JobError) -> Self {
 		match job_error {
-			JobError::QueryError(e) => JobManagerError::QueryError(e),
-			_ => JobManagerError::Unknown(job_error.to_string()),
+			JobError::QueryError(e) => Self::QueryError(e),
+			_ => Self::Unknown(job_error.to_string()),
 		}
+	}
+}
+
+impl From<prisma_client_rust::QueryError> for JobManagerError {
+	fn from(error: prisma_client_rust::QueryError) -> Self {
+		Self::QueryError(Box::new(error))
 	}
 }

--- a/core/src/opds/v2_0/error.rs
+++ b/core/src/opds/v2_0/error.rs
@@ -7,7 +7,7 @@ pub enum OPDSV2Error {
 	#[error("OPDS feed field was not initialized: {0}")]
 	MalformedFeed(#[from] UninitializedFieldError),
 	#[error("A query failed while generated OPDS feed: {0}")]
-	QueryError(#[from] prisma_client_rust::queries::QueryError),
+	QueryError(#[from] Box<prisma_client_rust::QueryError>),
 	#[error("Failed to generate OPDS feed: {0}")]
 	InternalError(#[from] crate::CoreError),
 }
@@ -22,6 +22,12 @@ impl From<OPDSV2Error> for crate::CoreError {
 			OPDSV2Error::QueryError(err) => err.into(),
 			OPDSV2Error::InternalError(err) => err,
 		}
+	}
+}
+
+impl From<prisma_client_rust::QueryError> for OPDSV2Error {
+	fn from(error: prisma_client_rust::QueryError) -> Self {
+		Self::QueryError(Box::new(error))
 	}
 }
 

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -8,7 +8,7 @@ pub enum CliError {
 	#[error("{0}")]
 	OperationFailed(String),
 	#[error("{0}")]
-	QueryError(#[from] QueryError),
+	QueryError(#[from] Box<QueryError>),
 	#[error("{0}")]
 	Unknown(String),
 }
@@ -19,6 +19,12 @@ impl From<CoreError> for CliError {
 			CoreError::QueryError(err) => CliError::QueryError(err),
 			_ => CliError::Unknown(format!("{:?}", err)),
 		}
+	}
+}
+
+impl From<prisma_client_rust::QueryError> for CliError {
+	fn from(error: prisma_client_rust::QueryError) -> Self {
+		Self::QueryError(Box::new(error))
 	}
 }
 


### PR DESCRIPTION
The new version of rust comes with a new clippy lint that triggers on enums with large sizes. Enums have a size equal to their largest contained variant.

The `CoreError` enum came in at 144 bytes as the result of containing `prisma_client_rust::QueryError`, which is huge. This is easily fixed by boxing the type, which shut clippy up.

There are some other big variants still, but nothing over 100 bytes.