### PR TITLE
:bug: Fix auth redirect issue after logout

### DIFF
--- a/apps/server/src/config/session/utils.rs
+++ b/apps/server/src/config/session/utils.rs
@@ -46,7 +46,7 @@ pub fn delete_cookie_header() -> (String, String) {
 	(
 		"Set-Cookie".to_string(),
 		format!(
-			"{}={}; Path={}; Domain={}; Expires={}; Max-Age=0",
+			"{}={}; HttpOnly; SameSite=Lax; Path={}; Domain={}; Expires={}; Max-Age=0",
 			SESSION_NAME, "", SESSION_PATH, "", "Thu, 01 Jan 1970 00:00:00 GMT"
 		),
 	)

--- a/packages/browser/src/components/navigation/sidebar/Logout.tsx
+++ b/packages/browser/src/components/navigation/sidebar/Logout.tsx
@@ -22,7 +22,7 @@ export default function Logout({ trigger }: Props) {
 			.promise(sdk.auth.logout(), {
 				error: 'There was an error logging you out. Please try again.',
 				loading: null,
-				success: 'You have been logged out. Redirecting...',
+				success: 'You have been logged out',
 			})
 			.then(() => {
 				invalidateQueries({ keys: [sdk.server.keys.claimedStatus] })

--- a/packages/browser/src/components/navigation/sidebar/SignOut.tsx
+++ b/packages/browser/src/components/navigation/sidebar/SignOut.tsx
@@ -1,4 +1,4 @@
-import { invalidateQueries, useSDK } from '@stump/client'
+import { queryClient, useSDK } from '@stump/client'
 import { ConfirmationModal, Text, useBoolean } from '@stump/components'
 import { LogOut } from 'lucide-react'
 import toast from 'react-hot-toast'
@@ -21,7 +21,7 @@ export default function SignOut() {
 				success: 'You have been logged out. Redirecting...',
 			})
 			.then(() => {
-				invalidateQueries({ keys: [sdk.server.keys.claimedStatus] })
+				queryClient.clear()
 				setUser(null)
 				navigate('/auth')
 			})

--- a/packages/browser/src/scenes/auth/LoginOrClaimScene.tsx
+++ b/packages/browser/src/scenes/auth/LoginOrClaimScene.tsx
@@ -1,14 +1,14 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import { queryClient, useLoginOrRegister } from '@stump/client'
+import { queryClient, useLoginOrRegister, useSDK } from '@stump/client'
 import { Alert, Button, cx, Form, Heading, Input } from '@stump/components'
 import { useLocaleContext } from '@stump/i18n'
 import { isAxiosError } from '@stump/sdk'
 import { motion, Variants } from 'framer-motion'
 import { ArrowLeft, ArrowRight, ShieldAlert } from 'lucide-react'
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import { FieldValues, useForm } from 'react-hook-form'
 import { toast } from 'react-hot-toast'
-import { Navigate } from 'react-router'
+import { useNavigate } from 'react-router'
 import { useSearchParams } from 'react-router-dom'
 import { z } from 'zod'
 
@@ -16,17 +16,17 @@ import { ConfiguredServersList } from '@/components/savedServer'
 import { useAppStore, useUserStore } from '@/stores'
 
 export default function LoginOrClaimScene() {
+	const navigate = useNavigate()
+
 	const [params] = useSearchParams()
-	const redirect = params.get('redirect') || '/'
+	const [redirect] = useState(() => params.get('redirect') || '/')
 
 	const [showServers, setShowServers] = useState(false)
 
-	const { user, setUser } = useUserStore((store) => ({
-		setUser: store.setUser,
-		user: store.user,
-	}))
+	const setUser = useUserStore((store) => store.setUser)
 	const isDesktop = useAppStore((store) => store.platform !== 'browser')
 
+	const { sdk } = useSDK()
 	const { t } = useLocaleContext()
 	const {
 		isClaimed,
@@ -37,7 +37,15 @@ export default function LoginOrClaimScene() {
 		isRegistering,
 		loginError,
 	} = useLoginOrRegister({
-		onSuccess: setUser,
+		onSuccess: async (user) => {
+			setUser(user)
+			await queryClient.refetchQueries([sdk.auth.keys.me], { exact: false })
+			if (redirect.includes('/swagger')) {
+				window.location.href = redirect
+			} else {
+				navigate(redirect, { replace: true })
+			}
+		},
 		refetchClaimed: !showServers,
 	})
 
@@ -50,52 +58,34 @@ export default function LoginOrClaimScene() {
 		resolver: zodResolver(schema),
 	})
 
-	async function handleSubmit(values: FieldValues) {
-		const { username, password } = values
-		const doLogin = async (firstTime = false) =>
-			toast.promise(loginUser({ password, username }), {
-				error: (error) => {
-					console.error('Error logging in:', error)
-					return t('authScene.toasts.loginFailed')
-				},
-				loading: t('authScene.toasts.loggingIn'),
-				success: firstTime
-					? t('authScene.toasts.loggedInFirstTime')
-					: t('authScene.toasts.loggedIn'),
-			})
-		if (isClaimed) {
+	const login = useCallback(
+		async ({ username, password }: FieldValues) => {
 			try {
-				await doLogin()
-			} catch (_) {
-				// We already report the error from above with toast, but
-				// it still throws there error (annoyingly). In order for
-				// the form to not log up (i.e. get stuck in submitting state)
-				// we need to at the very least catch the error here
+				await loginUser({ password, username })
+			} catch (error) {
+				console.error('Error logging in:', error)
+				toast.error(t('authScene.toasts.loginFailed'))
 			}
-		} else {
-			toast
-				.promise(registerUser({ password, username }), {
-					error: t('authScene.toasts.registrationFailed'),
-					loading: t('authScene.toasts.registering'),
-					success: t('authScene.toasts.registered'),
-				})
-				.then(() => doLogin(true))
-		}
-	}
+		},
+		[loginUser, t],
+	)
 
-	if (user) {
-		queryClient.invalidateQueries(['getLibraries'])
-		// NOTE: if swagger UI, we need a redirect outside of react-router context, otherwise
-		// we will get a 404 trying to route to a server-rendered page via react-router
-		if (redirect.includes('/swagger')) {
-			window.location.href = redirect
-			return null
-		}
-
-		return <Navigate to={redirect} />
-	} else if (isCheckingClaimed) {
-		return null
-	}
+	const handleSubmit = useCallback(
+		async ({ username, password }: FieldValues) => {
+			if (isClaimed) {
+				await login({ password, username })
+			} else {
+				try {
+					await registerUser({ password, username })
+					await login({ password, username })
+				} catch (error) {
+					console.error('Error registering', error)
+					toast.error(t('authScene.toasts.registrationFailed'))
+				}
+			}
+		},
+		[isClaimed, login, registerUser, t],
+	)
 
 	const renderHeader = () => {
 		if (isClaimed) {
@@ -133,6 +123,10 @@ export default function LoginOrClaimScene() {
 			)
 		}
 
+		return null
+	}
+
+	if (isCheckingClaimed) {
 		return null
 	}
 


### PR DESCRIPTION
This PR should fix a bit of an annoying bug which caused an overload of history pushes after login in a *very* specific scenario. At first, I thought this was just a quirk of having 3-4 testing instances of Stump with competing cookies causing flakes. The issue seemed to present when you manually log out and try to re-auth immediately.

The actual cause was that the query cache for fetching the logged in user did not clear correctly after logout. A logout triggered a refetch, which returned a 401. When you re-logged in (without a full browser refresh) that 401 remained the non-stale result so you immediately would get smacked back into auth, and then back, and then back again, etc.

The fix was really a mix of a few things:

- Update the delete cookie response for 401 API errors to have `SameSite` attribute
   - Make the `logout` API response encourage cookie deletion
- Remove all navigation from effects (in relevant auth flow)
- Ensure the `me` query is re-fetched _before_ navigating to the page which would otherwise send you back to `/auth`