### PR TITLE
:bug: Fix cursor-based media queries

### DIFF
--- a/apps/server/src/http_server.rs
+++ b/apps/server/src/http_server.rs
@@ -53,7 +53,7 @@ pub async fn run_http_server(config: StumpConfig) -> ServerResult<()> {
 	let app_state = server_ctx.arced();
 	let cors_layer = cors::get_cors_layer(config.clone());
 
-	tracing::info!("{}", core.get_shadow_text());
+	println!("{}", core.get_shadow_text());
 
 	let app = Router::new()
 		.merge(routers::mount(app_state.clone()))

--- a/apps/server/src/routers/api/v1/library.rs
+++ b/apps/server/src/routers/api/v1/library.rs
@@ -1728,7 +1728,9 @@ async fn get_library_stats(
 					media m
 					LEFT JOIN finished_reading_sessions frs ON frs.media_id = m.id
 					LEFT JOIN reading_sessions rs ON rs.media_id = m.id
-				WHERE {} IS TRUE OR (rs.user_id = {} OR frs.user_id = {})
+				WHERE {} IS TRUE OR (rs.user_id = {} OR frs.user_id = {}) AND m.series_id IN (
+					SELECT id FROM series WHERE library_id = {}
+				)
 			)
 			SELECT
 				*
@@ -1736,10 +1738,11 @@ async fn get_library_stats(
 				base_counts
 				INNER JOIN progress_counts;
 			",
-			PrismaValue::String(id),
+			PrismaValue::String(id.clone()),
 			PrismaValue::Boolean(params.all_users),
 			PrismaValue::String(user.id.clone()),
-			PrismaValue::String(user.id.clone())
+			PrismaValue::String(user.id.clone()),
+			PrismaValue::String(id)
 		))
 		.exec()
 		.await?

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -36,6 +36,7 @@ export default [
 					semi: false,
 				},
 			],
+			...pluginReactHooks.configs.recommended.rules,
 		},
 	},
 	{ languageOptions: { globals: globals.node } },

--- a/packages/browser/src/App.tsx
+++ b/packages/browser/src/App.tsx
@@ -51,7 +51,7 @@ function RouterContainer(props: StumpClientProps) {
 		}
 
 		setMounted(true)
-	}, [baseUrl])
+	}, [baseUrl, props.baseUrl, setBaseUrl])
 
 	useEffect(() => {
 		setPlatform(props.platform)

--- a/packages/browser/src/components/entity/EntityCard.tsx
+++ b/packages/browser/src/components/entity/EntityCard.tsx
@@ -84,7 +84,7 @@ export default function EntityCard({
 	const renderTitle = () => {
 		if (typeof title === 'string') {
 			return (
-				<Text size="sm" className="line-clamp-2 h-[40px]">
+				<Text size="sm" className="line-clamp-2 h-[40px] min-w-0 whitespace-normal">
 					{title}
 				</Text>
 			)
@@ -150,7 +150,7 @@ export default function EntityCard({
 		<Container
 			{...containerProps}
 			className={cn(
-				'relative flex flex-1 flex-col space-y-1 overflow-hidden rounded-lg border-[1.5px] border-edge bg-background/80 shadow-sm transition-colors duration-100',
+				'relative flex flex-1 flex-col space-y-1 overflow-hidden rounded-lg border-[1.5px] border-edge bg-background/80 transition-colors duration-100',
 				{ 'cursor-pointer hover:border-edge-brand dark:hover:border-edge-brand': hasClickAction },
 				{ 'max-w-[16rem]': isCover },
 				{

--- a/packages/browser/src/components/readers/epub/EpubStreamReader.tsx
+++ b/packages/browser/src/components/readers/epub/EpubStreamReader.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
+
 // FIXME: this file is a mess
 import { UseEpubReturn, useSDK } from '@stump/client'
 import { useEffect, useState } from 'react'
@@ -45,7 +46,7 @@ export default function EpubStreamReader({ epub, actions, ...rest }: UseEpubRetu
 				// FIXME: don't cast
 				setContent(rest.correctHtmlUrls(res as string))
 			})
-	}, [])
+	}, [epub, actions, sdk, rest])
 
 	function handleClickEvent(e: React.MouseEvent<HTMLDivElement, MouseEvent>) {
 		if (e.target instanceof HTMLAnchorElement && e.target.href) {

--- a/packages/browser/src/components/readers/imageBased/ImageBasedReader.tsx
+++ b/packages/browser/src/components/readers/imageBased/ImageBasedReader.tsx
@@ -129,14 +129,18 @@ export default function ImageBasedReader({
 	 *    when the user navigates away from the reader, the in-progress media is accurately reflected with
 	 *    the latest reading session.
 	 */
-	useEffect(() => {
-		return () => {
-			setSettings({
-				showToolBar: false,
-			})
-			queryClient.invalidateQueries([sdk.media.keys.inProgress], { exact: false })
-		}
-	}, [])
+	useEffect(
+		() => {
+			return () => {
+				setSettings({
+					showToolBar: false,
+				})
+				queryClient.invalidateQueries([sdk.media.keys.inProgress], { exact: false })
+			}
+		},
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[],
+	)
 
 	const renderReader = () => {
 		if (readingMode.startsWith('continuous')) {

--- a/packages/browser/src/components/readers/imageBased/paged/AnimatedPagedReader.tsx
+++ b/packages/browser/src/components/readers/imageBased/paged/AnimatedPagedReader.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import { motion, useAnimation, useMotionValue, useTransform } from 'framer-motion'
 import { useEffect, useMemo, useRef } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'

--- a/packages/browser/src/components/readers/pdf/NativePDFViewer.tsx
+++ b/packages/browser/src/components/readers/pdf/NativePDFViewer.tsx
@@ -35,14 +35,17 @@ export default function NativePDFViewer({ id }: Props) {
 			const arrayBuffer = await blob.arrayBuffer()
 			setPdfObjectUrl(URL.createObjectURL(new Blob([arrayBuffer], { type: 'application/pdf' })))
 		}
-		fetchPdf()
+
+		if (!pdfObjectUrl) {
+			fetchPdf()
+		}
 
 		return () => {
 			if (pdfObjectUrl) {
 				URL.revokeObjectURL(pdfObjectUrl)
 			}
 		}
-	}, [])
+	}, [sdk, id, pdfObjectUrl])
 
 	// TODO: consider some sort of loading state here
 	if (!pdfObjectUrl) {

--- a/packages/browser/src/scenes/book/BookOverviewScene.tsx
+++ b/packages/browser/src/scenes/book/BookOverviewScene.tsx
@@ -51,7 +51,7 @@ export default function BookOverviewScene() {
 		return () => {
 			remove()
 		}
-	}, [])
+	}, [remove])
 
 	if (isLoading) {
 		return null

--- a/packages/browser/src/scenes/book/BooksAfterCursor.tsx
+++ b/packages/browser/src/scenes/book/BooksAfterCursor.tsx
@@ -1,6 +1,8 @@
 import { useMediaCursorQuery } from '@stump/client'
+import { Text } from '@stump/components'
 import { Media } from '@stump/sdk'
-import { useEffect } from 'react'
+import { BookX } from 'lucide-react'
+import { useCallback, useEffect } from 'react'
 
 import MediaCard from '@/components/book/BookCard'
 import HorizontalCardList from '@/components/HorizontalCardList'
@@ -9,8 +11,8 @@ type Props = {
 	cursor: Media
 }
 
-export default function BooksAfterCurrent({ cursor }: Props) {
-	const { media, fetchNextPage, hasNextPage, remove } = useMediaCursorQuery({
+function BooksAfterCurrent({ cursor }: Props) {
+	const { media, fetchNextPage, hasNextPage, remove, isFetching } = useMediaCursorQuery({
 		initialCursor: cursor.id,
 		limit: 20,
 		params: {
@@ -18,9 +20,10 @@ export default function BooksAfterCurrent({ cursor }: Props) {
 				id: cursor.series_id,
 			},
 		},
+		suspense: true,
+		useErrorBoundary: false,
 	})
 
-	const title = cursor.series ? `Next in ${cursor.series.name}` : 'Next in Series'
 	const cards = media.map((media) => <MediaCard media={media} key={media.id} fullWidth={false} />)
 
 	useEffect(() => {
@@ -30,14 +33,38 @@ export default function BooksAfterCurrent({ cursor }: Props) {
 		return () => {
 			remove()
 		}
-	}, [])
+	}, [remove])
+
+	const handleFetchMore = useCallback(() => {
+		if (!hasNextPage || isFetching) {
+			return
+		} else {
+			fetchNextPage()
+		}
+	}, [fetchNextPage, hasNextPage, isFetching])
 
 	return (
 		<HorizontalCardList
-			title={title}
-			cards={cards}
-			fetchNext={fetchNextPage}
-			hasMore={hasNextPage}
+			title="Up next"
+			items={cards}
+			onFetchMore={handleFetchMore}
+			emptyState={
+				<div className="flex items-start justify-start space-x-3 rounded-lg border border-dashed border-edge-subtle px-4 py-4">
+					<span className="rounded-lg border border-edge bg-background-surface p-2">
+						<BookX className="h-8 w-8 text-foreground-muted" />
+					</span>
+					<div>
+						<Text>Nothing to show</Text>
+						<Text size="sm" variant="muted">
+							No books remain after this one
+						</Text>
+					</div>
+				</div>
+			}
 		/>
 	)
+}
+
+export default function BooksAfterCurrentContainer({ cursor }: Props) {
+	return <BooksAfterCurrent cursor={cursor} />
 }

--- a/packages/browser/src/scenes/book/settings/BookPageGrid.tsx
+++ b/packages/browser/src/scenes/book/settings/BookPageGrid.tsx
@@ -47,10 +47,14 @@ export default function BookPageGrid({ bookId, pages, selectedPage, onSelectPage
 		overscan: 5,
 	})
 
-	useEffect(() => {
-		rowVirtualizer.measure()
-		columnVirtualizer.measure()
-	}, [isAtLeastMedium, isAtLeastSmall])
+	useEffect(
+		() => {
+			rowVirtualizer.measure()
+			columnVirtualizer.measure()
+		},
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[isAtLeastMedium, isAtLeastSmall],
+	)
 
 	return (
 		<div className="h-96 w-full flex-1">

--- a/packages/browser/src/scenes/bookClub/tabs/settings/scheduler/AddBookCard.tsx
+++ b/packages/browser/src/scenes/bookClub/tabs/settings/scheduler/AddBookCard.tsx
@@ -46,7 +46,7 @@ export default function AddBookCard({ index }: Props) {
 			form.setValue(`books.${index}.book.author`, '')
 			form.setValue(`books.${index}.book.url`, undefined)
 		}
-	}, [isEntityBook, selectedBook])
+	}, [isEntityBook, selectedBook, form, index])
 
 	const handleSelectBook = useCallback(
 		(book: Media) => {

--- a/packages/browser/src/scenes/bookSearch/BookSearchScene.tsx
+++ b/packages/browser/src/scenes/bookSearch/BookSearchScene.tsx
@@ -75,15 +75,19 @@ export default function BookSearchScene() {
 
 	const previousPage = usePrevious(current_page)
 	const shouldScroll = !!previousPage && previousPage !== current_page
-	useEffect(() => {
-		if (!isInView && shouldScroll) {
-			containerRef.current?.scrollIntoView({
-				behavior: 'smooth',
-				block: 'nearest',
-				inline: 'start',
-			})
-		}
-	}, [shouldScroll])
+	useEffect(
+		() => {
+			if (!isInView && shouldScroll) {
+				containerRef.current?.scrollIntoView({
+					behavior: 'smooth',
+					block: 'nearest',
+					inline: 'start',
+				})
+			}
+		},
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[isInView, shouldScroll],
+	)
 
 	const renderContent = () => {
 		if (layoutMode === 'GRID') {

--- a/packages/browser/src/scenes/error/ServerConnectionErrorScene.tsx
+++ b/packages/browser/src/scenes/error/ServerConnectionErrorScene.tsx
@@ -64,7 +64,7 @@ export default function ServerConnectionErrorScene() {
 				})
 				.then(() => setGoHome(true))
 		}
-	}, [backOnline])
+	}, [backOnline, t])
 
 	if (goHome) {
 		const from = location.state?.from || '/'

--- a/packages/browser/src/scenes/home/ContinueReading.tsx
+++ b/packages/browser/src/scenes/home/ContinueReading.tsx
@@ -1,36 +1,55 @@
 import { useContinueReading } from '@stump/client'
-import { Heading, Text } from '@stump/components'
+import { Text } from '@stump/components'
 import { useLocaleContext } from '@stump/i18n'
-import { CircleSlash2 } from 'lucide-react'
+import { BookMarked } from 'lucide-react'
+import { Suspense, useCallback } from 'react'
 
 import MediaCard from '@/components/book/BookCard'
 import HorizontalCardList from '@/components/HorizontalCardList'
 
-export default function ContinueReadingMedia() {
+function ContinueReadingMedia() {
 	const { t } = useLocaleContext()
-	const { media, fetchNextPage, hasNextPage, isLoading } = useContinueReading({
+	const { media, fetchNextPage, hasNextPage, isFetching } = useContinueReading({
 		limit: 20,
+		suspense: true,
 	})
 
 	const cards = media.map((media) => <MediaCard media={media} key={media.id} fullWidth={false} />)
 
+	const handleFetchMore = useCallback(() => {
+		if (!hasNextPage || isFetching) {
+			return
+		} else {
+			fetchNextPage()
+		}
+	}, [fetchNextPage, hasNextPage, isFetching])
+
 	return (
 		<HorizontalCardList
 			title={t('homeScene.continueReading.title')}
-			cards={cards}
-			fetchNext={fetchNextPage}
-			hasMore={hasNextPage}
-			emptyMessage={() =>
-				isLoading ? null : (
-					<div className="flex min-h-[150px] flex-col items-start justify-center gap-2">
-						<CircleSlash2 className="h-10 w-10 pb-2 pt-1 text-foreground-muted" />
-						<Heading size="sm">{t('homeScene.continueReading.emptyState.heading')}</Heading>
+			items={cards}
+			onFetchMore={handleFetchMore}
+			emptyState={
+				<div className="flex items-start justify-start space-x-3 rounded-lg border border-dashed border-edge-subtle px-4 py-4">
+					<span className="rounded-lg border border-edge bg-background-surface p-2">
+						<BookMarked className="h-8 w-8 text-foreground-muted" />
+					</span>
+					<div>
+						<Text>{t('homeScene.continueReading.emptyState.heading')}</Text>
 						<Text size="sm" variant="muted">
 							{t('homeScene.continueReading.emptyState.message')}
 						</Text>
 					</div>
-				)
+				</div>
 			}
 		/>
+	)
+}
+
+export default function ContinueReadingMediaContainer() {
+	return (
+		<Suspense>
+			<ContinueReadingMedia />
+		</Suspense>
 	)
 }

--- a/packages/browser/src/scenes/home/RecentlyAddedMedia.tsx
+++ b/packages/browser/src/scenes/home/RecentlyAddedMedia.tsx
@@ -1,40 +1,55 @@
 import { useRecentlyAddedMediaQuery } from '@stump/client'
-import { Heading, Text } from '@stump/components'
+import { Text } from '@stump/components'
 import { useLocaleContext } from '@stump/i18n'
-import { CircleSlash2 } from 'lucide-react'
+import { BookX } from 'lucide-react'
+import { Suspense, useCallback } from 'react'
 
 import MediaCard from '@/components/book/BookCard'
 import HorizontalCardList from '@/components/HorizontalCardList'
 
-export default function RecentlyAddedMedia() {
+function RecentlyAddedMedia() {
 	const { t } = useLocaleContext()
-	const { data, media, isLoading, fetchNextPage, hasNextPage } = useRecentlyAddedMediaQuery({
+	const { media, fetchNextPage, hasNextPage, isFetching } = useRecentlyAddedMediaQuery({
 		limit: 20,
+		suspense: true,
 	})
 
-	if (isLoading || !data) {
-		return null
-	}
-
 	const cards = media.map((media) => <MediaCard media={media} key={media.id} fullWidth={false} />)
+
+	const handleFetchMore = useCallback(() => {
+		if (!hasNextPage || isFetching) {
+			return
+		} else {
+			fetchNextPage()
+		}
+	}, [fetchNextPage, hasNextPage, isFetching])
 
 	return (
 		<HorizontalCardList
 			title={t('homeScene.recentlyAddedBooks.title')}
-			cards={cards}
-			fetchNext={fetchNextPage}
-			hasMore={hasNextPage}
-			emptyMessage={() =>
-				isLoading ? null : (
-					<div className="flex min-h-[150px] flex-col items-start justify-center gap-2">
-						<CircleSlash2 className="h-10 w-10 pb-2 pt-1 text-foreground-muted" />
-						<Heading size="sm">{t('homeScene.recentlyAddedBooks.emptyState.heading')}</Heading>
+			items={cards}
+			onFetchMore={handleFetchMore}
+			emptyState={
+				<div className="flex items-start justify-start space-x-3 rounded-lg border border-dashed border-edge-subtle px-4 py-4">
+					<span className="rounded-lg border border-edge bg-background-surface p-2">
+						<BookX className="h-8 w-8 text-foreground-muted" />
+					</span>
+					<div>
+						<Text>{t('homeScene.recentlyAddedBooks.emptyState.heading')}</Text>
 						<Text size="sm" variant="muted">
 							{t('homeScene.recentlyAddedBooks.emptyState.message')}
 						</Text>
 					</div>
-				)
+				</div>
 			}
 		/>
+	)
+}
+
+export default function RecentlyAddedMediaContainer() {
+	return (
+		<Suspense>
+			<RecentlyAddedMedia />
+		</Suspense>
 	)
 }

--- a/packages/browser/src/scenes/home/RecentlyAddedSeries.tsx
+++ b/packages/browser/src/scenes/home/RecentlyAddedSeries.tsx
@@ -1,15 +1,16 @@
 import { useSDK, useSeriesCursorQuery } from '@stump/client'
-import { Heading, Text } from '@stump/components'
+import { Text } from '@stump/components'
 import { useLocaleContext } from '@stump/i18n'
-import { CircleSlash2 } from 'lucide-react'
+import { BookCopy } from 'lucide-react'
+import { Suspense, useCallback } from 'react'
 
 import HorizontalCardList from '@/components/HorizontalCardList'
 import SeriesCard from '@/components/series/SeriesCard'
 
-export default function RecentlyAddedSeries() {
+function RecentlyAddedSeries() {
 	const { sdk } = useSDK()
 	const { t } = useLocaleContext()
-	const { series, fetchNextPage, hasNextPage, isLoading } = useSeriesCursorQuery({
+	const { series, fetchNextPage, hasNextPage, isFetching } = useSeriesCursorQuery({
 		limit: 20,
 		params: {
 			count_media: true,
@@ -17,29 +18,47 @@ export default function RecentlyAddedSeries() {
 			order_by: 'created_at',
 		},
 		queryKey: [sdk.series.keys.recentlyAdded],
+		suspense: true,
 	})
 
 	const cards = series.map((series) => (
 		<SeriesCard series={series} key={series.id} fullWidth={false} />
 	))
 
+	const handleFetchMore = useCallback(() => {
+		if (!hasNextPage || isFetching) {
+			return
+		} else {
+			fetchNextPage()
+		}
+	}, [fetchNextPage, hasNextPage, isFetching])
+
 	return (
 		<HorizontalCardList
 			title={t('homeScene.recentlyAddedSeries.title')}
-			cards={cards}
-			fetchNext={fetchNextPage}
-			hasMore={hasNextPage}
-			emptyMessage={() =>
-				isLoading ? null : (
-					<div className="flex min-h-[150px] flex-col items-start justify-center gap-2">
-						<CircleSlash2 className="h-10 w-10 pb-2 pt-1 text-foreground-muted" />
-						<Heading size="sm">{t('homeScene.recentlyAddedSeries.emptyState.heading')}</Heading>
+			items={cards}
+			onFetchMore={handleFetchMore}
+			emptyState={
+				<div className="flex items-start justify-start space-x-3 rounded-lg border border-dashed border-edge-subtle px-4 py-4">
+					<span className="rounded-lg border border-edge bg-background-surface p-2">
+						<BookCopy className="h-8 w-8 text-foreground-muted" />
+					</span>
+					<div>
+						<Text>{t('homeScene.recentlyAddedSeries.emptyState.heading')}</Text>
 						<Text size="sm" variant="muted">
 							{t('homeScene.recentlyAddedSeries.emptyState.message')}
 						</Text>
 					</div>
-				)
+				</div>
 			}
 		/>
+	)
+}
+
+export default function RecentlyAddedSeriesContainer() {
+	return (
+		<Suspense>
+			<RecentlyAddedSeries />
+		</Suspense>
 	)
 }

--- a/packages/browser/src/scenes/library/tabs/books/LibraryBooksScene.tsx
+++ b/packages/browser/src/scenes/library/tabs/books/LibraryBooksScene.tsx
@@ -81,15 +81,19 @@ export default function LibraryBooksScene() {
 	)
 
 	const shouldScroll = usePreviousIsDifferent(current_page)
-	useEffect(() => {
-		if (!isInView && shouldScroll) {
-			containerRef.current?.scrollIntoView({
-				behavior: 'smooth',
-				block: 'nearest',
-				inline: 'start',
-			})
-		}
-	}, [shouldScroll])
+	useEffect(
+		() => {
+			if (!isInView && shouldScroll) {
+				containerRef.current?.scrollIntoView({
+					behavior: 'smooth',
+					block: 'nearest',
+					inline: 'start',
+				})
+			}
+		},
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[isInView, shouldScroll],
+	)
 
 	const renderContent = () => {
 		if (layoutMode === 'GRID') {

--- a/packages/browser/src/scenes/library/tabs/series/LibrarySeriesScene.tsx
+++ b/packages/browser/src/scenes/library/tabs/series/LibrarySeriesScene.tsx
@@ -101,15 +101,19 @@ function LibrarySeriesScene() {
 
 	const previousPage = usePrevious(current_page)
 	const shouldScroll = !!previousPage && previousPage !== current_page
-	useEffect(() => {
-		if (!isInView && shouldScroll) {
-			containerRef.current?.scrollIntoView({
-				behavior: 'smooth',
-				block: 'nearest',
-				inline: 'start',
-			})
-		}
-	}, [shouldScroll])
+	useEffect(
+		() => {
+			if (!isInView && shouldScroll) {
+				containerRef.current?.scrollIntoView({
+					behavior: 'smooth',
+					block: 'nearest',
+					inline: 'start',
+				})
+			}
+		},
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[isInView, shouldScroll],
+	)
 
 	useEffect(() => {
 		if (library?.id && !alreadyVisited.current) {

--- a/packages/browser/src/scenes/library/tabs/settings/LibrarySeriesGrid.tsx
+++ b/packages/browser/src/scenes/library/tabs/settings/LibrarySeriesGrid.tsx
@@ -54,10 +54,14 @@ export default function LibrarySeriesGrid({ libraryId, onSelectSeries }: Props) 
 		overscan: 5,
 	})
 
-	useEffect(() => {
-		rowVirtualizer.measure()
-		columnVirtualizer.measure()
-	}, [isAtLeastMedium, isAtLeastSmall])
+	useEffect(
+		() => {
+			rowVirtualizer.measure()
+			columnVirtualizer.measure()
+		},
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[isAtLeastMedium, isAtLeastSmall],
+	)
 
 	const handleScroll = () => {
 		if (!hasNextPage) return

--- a/packages/browser/src/scenes/series/tabs/books/SeriesBooksScene.tsx
+++ b/packages/browser/src/scenes/series/tabs/books/SeriesBooksScene.tsx
@@ -82,15 +82,19 @@ export default function SeriesOverviewScene() {
 
 	const previousPage = usePrevious(current_page)
 	const shouldScroll = !!previousPage && previousPage !== current_page
-	useEffect(() => {
-		if (!isInView && shouldScroll) {
-			containerRef.current?.scrollIntoView({
-				behavior: 'smooth',
-				block: 'nearest',
-				inline: 'start',
-			})
-		}
-	}, [shouldScroll])
+	useEffect(
+		() => {
+			if (!isInView && shouldScroll) {
+				containerRef.current?.scrollIntoView({
+					behavior: 'smooth',
+					block: 'nearest',
+					inline: 'start',
+				})
+			}
+		},
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[shouldScroll, isInView],
+	)
 
 	const renderContent = () => {
 		if (layoutMode === 'GRID') {

--- a/packages/browser/src/scenes/series/tabs/settings/SeriesBookGrid.tsx
+++ b/packages/browser/src/scenes/series/tabs/settings/SeriesBookGrid.tsx
@@ -58,10 +58,14 @@ export default function SeriesBookGrid({ seriesId, onSelectBook }: Props) {
 		overscan: 5,
 	})
 
-	useEffect(() => {
-		rowVirtualizer.measure()
-		columnVirtualizer.measure()
-	}, [isAtLeastMedium, isAtLeastSmall])
+	useEffect(
+		() => {
+			rowVirtualizer.measure()
+			columnVirtualizer.measure()
+		},
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[isAtLeastMedium, isAtLeastSmall],
+	)
 
 	const handleScroll = () => {
 		if (!hasNextPage) return

--- a/packages/browser/src/stores/desktop.ts
+++ b/packages/browser/src/stores/desktop.ts
@@ -51,28 +51,32 @@ export const useTauriStore = () => {
 	/**
 	 * An effect to load the store from disk on mount and sync it with the local store
 	 */
-	useEffect(() => {
-		const init = async () => {
-			try {
-				const storeEntries = await store.entries()
-				const loadedStore = storeEntries.reduce(
-					(acc, [key, value]) => {
-						acc[key] = value
-						return acc
-					},
-					{} as Record<string, unknown>,
-				)
-				// TODO: smarter type assertions here
-				if ('connected_servers' in loadedStore) {
-					localStore.set(loadedStore as DesktopAppStore)
+	useEffect(
+		() => {
+			const init = async () => {
+				try {
+					const storeEntries = await store.entries()
+					const loadedStore = storeEntries.reduce(
+						(acc, [key, value]) => {
+							acc[key] = value
+							return acc
+						},
+						{} as Record<string, unknown>,
+					)
+					// TODO: smarter type assertions here
+					if ('connected_servers' in loadedStore) {
+						localStore.set(loadedStore as DesktopAppStore)
+					}
+				} catch (e) {
+					console.error('Failed to load store', e)
 				}
-			} catch (e) {
-				console.error('Failed to load store', e)
 			}
-		}
 
-		init()
-	}, [])
+			init()
+		},
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[],
+	)
 
 	/**
 	 * Add a server to the list of connected servers. If this is the first server added,

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -210,31 +210,15 @@ export function useCursorQuery<Entity = unknown, TError = AxiosError>(
 		[initialCursor, limit, params, ...queryKey],
 		async ({ pageParam }: CursorQueryContext) => {
 			return queryFn({
-				afterId: pageParam || initialCursor,
+				cursor: pageParam || initialCursor,
 				limit: limit || 20,
 				params,
 			})
 		},
 		{
-			getNextPageParam: (lastPage) => {
-				const hasData = !!lastPage.data.length
-				if (!hasData) {
-					return undefined
-				}
-
-				if (lastPage._cursor?.next_cursor) {
-					return lastPage._cursor?.next_cursor
-				}
-
-				return undefined
-			},
-			getPreviousPageParam: (firstPage) => {
-				const hasCursor = !!firstPage?._cursor?.current_cursor
-				if (hasCursor) {
-					return firstPage?._cursor?.current_cursor
-				}
-				return undefined
-			},
+			getNextPageParam: (lastPage) => lastPage?._cursor?.next_cursor,
+			getPreviousPageParam: (firstPage) => firstPage?._cursor?.current_cursor,
+			keepPreviousData: true,
 			...restOptions,
 		},
 	)

--- a/packages/components/src/button/Button.tsx
+++ b/packages/components/src/button/Button.tsx
@@ -47,6 +47,7 @@ export const BUTTON_SIZE_VARIANTS = {
 	md: 'h-9 px-3',
 	sm: 'h-8 px-2',
 	xs: 'h-6 px-1',
+	icon: 'h-6 w-6',
 }
 
 export const BUTTON_NY_SIZE_VARIANTS = {
@@ -55,6 +56,7 @@ export const BUTTON_NY_SIZE_VARIANTS = {
 	md: 'h-8 px-3',
 	sm: 'h-7 px-2',
 	xs: 'h-5 px-1',
+	icon: 'h-6 w-6',
 }
 
 const buttonVariants = cva(BUTTON_BASE_CLASSES, {
@@ -141,7 +143,10 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 					{...props}
 				>
 					{isLoading ? (
-						<ProgressSpinner variant={variant === 'primary' ? 'primary' : 'default'} size={size} />
+						<ProgressSpinner
+							variant={variant === 'primary' ? 'primary' : 'default'}
+							size={size === 'icon' ? 'sm' : size}
+						/>
 					) : (
 						children
 					)}

--- a/packages/components/src/tooltip/ToolTip.tsx
+++ b/packages/components/src/tooltip/ToolTip.tsx
@@ -5,13 +5,13 @@ import { ToolTipContentProps, ToolTipPrimitive, ToolTipProvider } from './primit
 
 const toolTipVariants = cva(undefined, {
 	defaultVariants: {
-		size: 'md',
+		size: 'sm',
 	},
 	variants: {
 		size: {
 			lg: 'text-base',
 			md: 'text-sm',
-			sm: 'p-1 text-sm',
+			sm: 'px-2 py-1 text-sm',
 			xs: 'p-1 text-xs',
 		},
 	},

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -574,24 +574,24 @@
 	},
 	"homeScene": {
 		"continueReading": {
-			"title": "Continue Reading",
+			"title": "Continue reading",
 			"emptyState": {
-				"heading": "No books to display",
-				"message": "Any books you're currently reading will show up here"
+				"heading": "Nothing to show",
+				"message": "Any in-progress books you start will show up here"
 			}
 		},
 		"recentlyAddedSeries": {
-			"title": "Recently Added Series",
+			"title": "Recently added series",
 			"emptyState": {
 				"heading": "No series to display",
 				"message": "Any series you add to your libraries will show up here"
 			}
 		},
 		"recentlyAddedBooks": {
-			"title": "Recently Added Books",
+			"title": "Recently added books",
 			"emptyState": {
-				"heading": "No books to display",
-				"message": "Any books you add to your libraries will show up here"
+				"heading": "Nothing to show",
+				"message": "Any recent books you add will show up here"
 			}
 		}
 	},

--- a/packages/sdk/src/controllers/media-api.ts
+++ b/packages/sdk/src/controllers/media-api.ts
@@ -35,7 +35,7 @@ export class MediaAPI extends APIBase {
 	 * Fetch media and maintain a cursor
 	 */
 	async getCursor(params: CursorQueryParams): Promise<Pageable<Media[]>> {
-		const { data: media } = await this.axios.get<Pageable<Media[]>>(mediaURL('cursor', params))
+		const { data: media } = await this.axios.get<Pageable<Media[]>>(mediaURL('', params))
 		return media
 	}
 

--- a/packages/sdk/src/controllers/series-api.ts
+++ b/packages/sdk/src/controllers/series-api.ts
@@ -87,11 +87,11 @@ export class SeriesAPI extends APIBase {
 	 */
 	async nextBooks(
 		forSeries: string,
-		{ afterId, limit = 25, params }: CursorQueryParams,
+		{ cursor, limit = 25, params }: CursorQueryParams,
 	): Promise<Pageable<Media[]>> {
 		const bookAPI = new MediaAPI(this.api)
 		return bookAPI.getCursor({
-			afterId,
+			cursor,
 			limit,
 			params: {
 				...params,

--- a/packages/sdk/src/controllers/types.ts
+++ b/packages/sdk/src/controllers/types.ts
@@ -12,7 +12,7 @@ export type PagedQueryParams = {
 }
 
 export type CursorQueryParams = {
-	afterId?: string
+	cursor?: string
 	limit?: number
 	params?: Record<string, unknown>
 }

--- a/packages/sdk/src/controllers/utils.ts
+++ b/packages/sdk/src/controllers/utils.ts
@@ -103,13 +103,13 @@ export const toObjectParams = <T extends object>(
 }
 
 export const mergeCursorParams = ({
-	afterId,
+	cursor,
 	limit,
 	params,
 }: CursorQueryParams): URLSearchParams => {
 	const searchParams = toUrlParams(params)
-	if (afterId) {
-		searchParams.set('cursor', afterId)
+	if (cursor) {
+		searchParams.set('cursor', cursor)
 	}
 	if (limit) {
 		searchParams.set('limit', limit.toString())


### PR DESCRIPTION
The primary issue which this fixes is passing `afterId` instead of `cursor` in the cursor-based API call. I've taken this as an opportunity to rewrite the horizontal scroller to use `virtuoso` instead of tanstack virtual