### PR TITLE
:bug: Exclude cover image from double spread and fix rtl

### DIFF
--- a/packages/browser/src/components/readers/imageBased/paged/PageSet.tsx
+++ b/packages/browser/src/components/readers/imageBased/paged/PageSet.tsx
@@ -44,6 +44,7 @@ const PageSet = forwardRef<HTMLDivElement, Props>(
 		const renderSet = () => {
 			const shouldDisplayDoubleSpread =
 				displayedPages.length > 1 &&
+				currentPage != 1 &&
 				dimensionSet.every((dimensions) => !dimensions || dimensions.isPortrait)
 
 			if (shouldDisplayDoubleSpread) {

--- a/packages/browser/src/components/readers/imageBased/paged/PagedReader.tsx
+++ b/packages/browser/src/components/readers/imageBased/paged/PagedReader.tsx
@@ -51,11 +51,17 @@ function PagedReader({ currentPage, media, onPageChange, getPageUrl }: PagedRead
 	const pageSetRef = useRef<HTMLDivElement | null>(null)
 
 	// TODO: this needs to be aware of overflow / if the page is too small to render double spread
-	const displayedPages = useMemo(
-		() =>
-			doubleSpread ? [currentPage, currentPage + 1].filter((p) => p <= media.pages) : [currentPage],
-		[currentPage, doubleSpread, media.pages],
-	)
+	const displayedPages = useMemo(() => {
+		if (readingDirection === 'ltr') {
+			return doubleSpread
+				? [currentPage, currentPage + 1].filter((p) => p <= media.pages)
+				: [currentPage]
+		} else {
+			return doubleSpread
+				? [currentPage + 1, currentPage].filter((p) => p <= media.pages)
+				: [currentPage]
+		}
+	}, [currentPage, doubleSpread, media.pages])
 
 	/**
 	 * If the image parts are collective >= 80% of the screen width, we want to fix the side navigation
@@ -91,7 +97,8 @@ function PagedReader({ currentPage, media, onPageChange, getPageUrl }: PagedRead
 	 */
 	const handleLeftwardPageChange = useCallback(() => {
 		const direction = readingDirection === 'ltr' ? -1 : 1
-		if (doubleSpread) {
+		const skip = readingDirection === 'ltr' ? 2 : 1
+		if (doubleSpread && currentPage > skip) {
 			const adjustedForBounds = currentPage + direction * 2 < 1 ? 1 : currentPage + direction * 2
 			doChangePage(adjustedForBounds)
 		} else {
@@ -104,7 +111,8 @@ function PagedReader({ currentPage, media, onPageChange, getPageUrl }: PagedRead
 	 */
 	const handleRightwardPageChange = useCallback(() => {
 		const direction = readingDirection === 'ltr' ? 1 : -1
-		if (doubleSpread) {
+		const skip = readingDirection === 'ltr' ? 1 : 2
+		if (doubleSpread && currentPage > skip) {
 			const adjustedForBounds =
 				currentPage + direction * 2 > media.pages ? media.pages : currentPage + direction * 2
 			doChangePage(adjustedForBounds)


### PR DESCRIPTION
 - The first page is the cover, so it should be shown by itself instead of in double spread (maybe this could be optional)
   - requires skip variable to make it possible to go back to page 1 (else it will try to subtract two pages from page 2)
 - Reading right to left vs left to right requires flipping the ordering of the pages
 

(never coded a line of javascript before tonight, so sorry if it the code is awful...)