### PR TITLE
:arrow_up: Update `arrayvec` transient dependency

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,5 +67,5 @@ jobs:
           tags: 'nightly'
           load: ${{ env.LOAD }}
           push: ${{ env.PUSH }}
-          archs: 'arm64,amd64'
+          archs: ${{ env.ARCHS }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,5 +67,5 @@ jobs:
           tags: 'nightly'
           load: ${{ env.LOAD }}
           push: ${{ env.PUSH }}
-          archs: ${{ env.ARCHS }}
+          archs: 'arm64,amd64'
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,9 +267,9 @@ checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 dependencies = [
  "serde",
 ]


### PR DESCRIPTION
It seems that `arrayvec` is not pulling correctly for `arm` in the Docker build. I'm hoping this manual update fixes the issue. 

See https://github.com/stumpapp/stump/actions/runs/11603151339/job/32310833324#step:4:886