### PR TITLE
🎨 Server housekeeping

### DIFF
--- a/apps/server/src/errors.rs
+++ b/apps/server/src/errors.rs
@@ -135,7 +135,7 @@ pub enum APIError {
 	SessionFetchError(#[from] SessionError),
 	#[error("{0}")]
 	#[schema(value_type = String)]
-	PrismaError(#[from] QueryError),
+	PrismaError(#[from] Box<QueryError>),
 }
 
 impl APIError {
@@ -286,6 +286,12 @@ impl From<ProcessorError> for APIError {
 impl From<std::io::Error> for APIError {
 	fn from(error: std::io::Error) -> APIError {
 		APIError::InternalServerError(error.to_string())
+	}
+}
+
+impl From<prisma_client_rust::QueryError> for APIError {
+	fn from(error: prisma_client_rust::QueryError) -> Self {
+		Self::PrismaError(Box::new(error))
 	}
 }
 

--- a/apps/server/src/routers/api/mod.rs
+++ b/apps/server/src/routers/api/mod.rs
@@ -22,45 +22,20 @@ mod tests {
 
 	use crate::{
 		config::jwt::CreatedToken,
-		filter::{
-			LibraryBaseFilter, LibraryFilter, LibraryRelationFilter, LogFilter,
-			MediaBaseFilter, MediaFilter, MediaMetadataBaseFilter, MediaMetadataFilter,
-			MediaMetadataRelationFilter, Range, ReadStatus, SeriesBaseFilter,
-			SeriesFilter, SeriesMetadataFilter, SeriesQueryRelation, UserQueryRelation,
-			ValueOrRange,
-		},
+		filter::*,
 		routers::api::v1::{
-			auth::{AuthenticationOptions, LoginOrRegisterArgs, LoginResponse},
-			book_club::{
-				BookClubInvitationAnswer, CreateBookClub, CreateBookClubInvitation,
-				CreateBookClubMember, CreateBookClubSchedule, CreateBookClubScheduleBook,
-				CreateBookClubScheduleBookOption, GetBookClubsParams, UpdateBookClub,
-				UpdateBookClubMember,
-			},
-			config::UploadConfig,
-			emailer::{
-				CreateOrUpdateEmailDevice, CreateOrUpdateEmailer, EmailerIncludeParams,
-				EmailerSendRecordIncludeParams, PatchEmailDevice,
-				SendAttachmentEmailResponse, SendAttachmentEmailsPayload,
-			},
-			epub::{CreateOrUpdateBookmark, DeleteBookmark},
-			job::UpdateSchedulerConfig,
-			library::{
-				CleanLibraryResponse, CreateLibrary, GenerateLibraryThumbnails,
-				LibraryStatsParams, PatchLibraryThumbnail, UpdateLibrary,
-				UpdateLibraryExcludedUsers,
-			},
-			media::{
-				individual::{BookRelations, MediaIsComplete, PutMediaCompletionStatus},
-				thumbnails::PatchMediaThumbnail,
-			},
-			metadata::MediaMetadataOverview,
-			series::{PatchSeriesThumbnail, SeriesIsComplete},
-			smart_list::{
-				CreateOrUpdateSmartList, CreateOrUpdateSmartListView,
-				GetSmartListsParams, SmartListMeta, SmartListRelationOptions,
-			},
-			user::{CreateUser, DeleteUser, UpdateUser, UpdateUserPreferences},
+			auth::*,
+			book_club::*,
+			config::*,
+			emailer::*,
+			epub::*,
+			job::*,
+			library::*,
+			media::{individual::*, thumbnails::*},
+			metadata::*,
+			series::*,
+			smart_list::*,
+			user::*,
 			ClaimResponse, StumpVersion, UpdateCheck,
 		},
 	};


### PR DESCRIPTION
This pull request just does a couple of things:

1. It boxes the `QueryError` in `APIError`, which silences a clippy warning.
2. It walks back the silly each-item-individually change I made in routers::api::v1 for exported values. That was messy.