### PR TITLE
🐛 Fix popover and dropdown on mobile sidebar

### DIFF
--- a/packages/browser/src/components/UserMenu.tsx
+++ b/packages/browser/src/components/UserMenu.tsx
@@ -24,7 +24,7 @@ export default function UserMenu({ variant = 'sidebar' }: Props) {
 	return (
 		<AutoSizer style={{ height: '2.35rem', width: isSidebar ? '100%' : '2.35rem' }}>
 			{({ width }) => (
-				<Popover onOpenChange={setIsOpen} open={isOpen}>
+				<Popover onOpenChange={setIsOpen} open={isOpen} modal>
 					<Popover.Trigger asChild>
 						<Card
 							className={cn(

--- a/packages/browser/src/components/navigation/sidebar/SideBar.tsx
+++ b/packages/browser/src/components/navigation/sidebar/SideBar.tsx
@@ -42,10 +42,11 @@ export default function SideBar({ asChild, hidden }: Props) {
 	const { shouldUseGradient } = useTheme()
 
 	const isBrowser = platform === 'browser'
+	const isAtLeastMedium = useMediaMatch('(min-width: 768px)')
 	const isMobile = useMediaMatch('(max-width: 768px)')
 
 	const renderHeader = () => {
-		if (!isBrowser && !isMobile) {
+		if (!isBrowser && isAtLeastMedium) {
 			return (
 				<header className="flex w-full justify-between gap-1">
 					<UserMenu />
@@ -131,12 +132,12 @@ export default function SideBar({ asChild, hidden }: Props) {
 				{renderHeader()}
 
 				<div className="flex max-h-full grow flex-col gap-2 overflow-y-auto p-1 scrollbar-hide">
-					{!isMobile && isBrowser && <UserMenu />}
+					{isAtLeastMedium && isBrowser && <UserMenu />}
 					{sections}
 				</div>
 				<Spacer />
 
-				{!isMobile && <SideBarFooter />}
+				{isAtLeastMedium && <SideBarFooter />}
 			</>
 		)
 	}

--- a/packages/browser/src/components/navigation/sidebar/sections/library/LibraryOptionsMenu.tsx
+++ b/packages/browser/src/components/navigation/sidebar/sections/library/LibraryOptionsMenu.tsx
@@ -62,6 +62,7 @@ export default function LibraryOptionsMenu({ library }: Props) {
 				libraryId={library.id}
 			/>
 			<DropdownMenu
+				modal={isMobile}
 				trigger={
 					<button className="p-1 text-foreground-muted text-opacity-50 outline-none hover:text-opacity-100 focus:ring-0 focus:ring-offset-0 data-[state=open]:text-opacity-100">
 						<MoreHorizontal className="h-4 w-4 shrink-0" />

--- a/packages/browser/src/scenes/library/tabs/settings/LibrarySettingsHeader.tsx
+++ b/packages/browser/src/scenes/library/tabs/settings/LibrarySettingsHeader.tsx
@@ -12,12 +12,13 @@ import { routeGroups } from './routes'
 export default function LibrarySettingsHeader() {
 	const location = useLocation()
 	const {
-		preferences: { primary_navigation_mode, layout_max_width_px },
+		preferences: { primary_navigation_mode, layout_max_width_px, enable_double_sidebar },
 	} = usePreferences()
 	const { t } = useLocaleContext()
 
 	const isMobile = useMediaMatch('(max-width: 768px)')
 	const preferTopBar = primary_navigation_mode === 'TOPBAR'
+	const displayingSideBar = !!enable_double_sidebar && !isMobile
 
 	/**
 	 * The active route based on the current location
@@ -52,9 +53,10 @@ export default function LibrarySettingsHeader() {
 
 	return (
 		<header
-			className={cn('flex w-full flex-col space-y-4 border-b border-b-edge p-4 md:pl-52', {
+			className={cn('flex w-full flex-col space-y-4 border-b border-b-edge p-4', {
 				// Note: We make the border transparent because the width constraint when using a top bar
 				'mx-auto border-b-transparent': preferTopBar && !!layout_max_width_px,
+				'pl-52': displayingSideBar,
 			})}
 			style={{
 				maxWidth: preferTopBar ? layout_max_width_px || undefined : undefined,

--- a/packages/components/src/dropdown/DropdownMenu.tsx
+++ b/packages/components/src/dropdown/DropdownMenu.tsx
@@ -47,6 +47,7 @@ type BaseProps = LabelOrTrigger &
 	ContentProps & {
 		contentWrapperClassName?: string
 		subContentWrapperClassName?: string
+		modal?: boolean
 	}
 export type DropdownMenuProps = GenericMenu<DropdownItem, DropdownItemGroup> & BaseProps
 
@@ -61,6 +62,7 @@ export function DropdownMenu({
 	contentWrapperClassName,
 	subContentWrapperClassName,
 	align,
+	modal = false,
 	...props
 }: DropdownMenuProps) {
 	const renderItems = (items: DropdownItem[]) => {
@@ -114,7 +116,7 @@ export function DropdownMenu({
 	}
 
 	return (
-		<Dropdown modal={false}>
+		<Dropdown modal={modal}>
 			<DropdownTrigger asChild>{renderTrigger()}</DropdownTrigger>
 
 			<DropdownContent className={cn('w-56', contentWrapperClassName)} align={align}>


### PR DESCRIPTION
I noticed my [previous PR](https://github.com/stumpapp/stump/pull/497) introduced an issue on mobile viewports 😱  :

https://github.com/user-attachments/assets/f9b7beac-308b-4267-a198-adf98f70b65b

This PR fixes the issue! I took some time to look at the other uses of `<DropdownMenu/>` to make sure they work as expected in mobile and desktop viewports. Also fixed UserMenu's Popover which was having the same issue as shown above.

https://github.com/user-attachments/assets/763dbf6c-a72d-442c-9a50-e23a759d77fa


------

Separately, I noticed some small UI issues that only happened if the viewport was exactly `768px` so I took care of those as well:
- missing header and footer in sidebar
- library settings header padding offset 
<details><summary>Screenshots</summary>
<p>

#### Before
<img src="https://github.com/user-attachments/assets/cec3d3af-dda7-47c4-8e4d-37b03a3cca24" width="500">

#### After
<img src="https://github.com/user-attachments/assets/5fe5b55f-9d1b-456c-aa4f-4978eb975174" width="500">

</p>
</details> 

