### PR TITLE
:bug: Fix Path extractor error in v1.2 OPDS router

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -64,10 +64,8 @@ jobs:
         with:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_PASSWORD }}
-          tags: 'opds-path-error-patch'
-          # load: ${{ env.LOAD }}
-          # push: ${{ env.PUSH }}
-          load: false
-          push: true
+          tags: 'nightly'
+          load: ${{ env.LOAD }}
+          push: ${{ env.PUSH }}
           archs: ${{ env.ARCHS }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -64,8 +64,10 @@ jobs:
         with:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_PASSWORD }}
-          tags: 'nightly'
-          load: ${{ env.LOAD }}
-          push: ${{ env.PUSH }}
+          tags: 'opds-path-error-patch'
+          # load: ${{ env.LOAD }}
+          # push: ${{ env.PUSH }}
+          load: false
+          push: true
           archs: ${{ env.ARCHS }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}


### PR DESCRIPTION
Fixes #513

This was a classic instance of organizing the router layers incorrectly, so the API key middleware was being run for both variants of the router instead of just when the `:api-key` path hits a match.

This is a pretty large bug that somehow went missed for the 3-4 weeks this sat in the nightly image lol I'll release `0.0.9` as a hotfix ideally tomorrow