### PR TITLE
🐛 Fix API key OPDS links in v1.2 feed

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -64,10 +64,8 @@ jobs:
         with:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_PASSWORD }}
-          tags: 'opds-path-error-patch'
-          # load: ${{ env.LOAD }}
-          # push: ${{ env.PUSH }}
-          load: false
-          push: true
+          tags: 'nightly'
+          load: ${{ env.LOAD }}
+          push: ${{ env.PUSH }}
           archs: ${{ env.ARCHS }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -64,8 +64,10 @@ jobs:
         with:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_PASSWORD }}
-          tags: 'nightly'
-          load: ${{ env.LOAD }}
-          push: ${{ env.PUSH }}
+          tags: 'opds-path-error-patch'
+          # load: ${{ env.LOAD }}
+          # push: ${{ env.PUSH }}
+          load: false
+          push: true
           archs: ${{ env.ARCHS }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/apps/server/src/routers/opds/v1_2.rs
+++ b/apps/server/src/routers/opds/v1_2.rs
@@ -93,9 +93,18 @@ struct OPDSIDURLParams {
 	id: String,
 }
 
+fn number_or_string_deserializer<'de, D>(deserializer: D) -> Result<i32, D::Error>
+where
+	D: serde::Deserializer<'de>,
+{
+	let value = String::deserialize(deserializer)?;
+	value.parse::<i32>().map_err(serde::de::Error::custom)
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 struct OPDSPageURLParams {
 	id: String,
+	#[serde(deserialize_with = "number_or_string_deserializer")]
 	page: i32,
 }
 

--- a/apps/server/src/routers/opds/v1_2.rs
+++ b/apps/server/src/routers/opds/v1_2.rs
@@ -5,6 +5,7 @@ use axum::{
 	Extension, Router,
 };
 use prisma_client_rust::{chrono, Direction};
+use serde::{Deserialize, Serialize};
 use stump_core::{
 	db::{entity::UserPermission, query::pagination::PageQuery},
 	filesystem::{
@@ -13,8 +14,8 @@ use stump_core::{
 		ContentType,
 	},
 	opds::v1_2::{
-		entry::OpdsEntry,
-		feed::OpdsFeed,
+		entry::{IntoOPDSEntry, OPDSEntryBuilder, OpdsEntry},
+		feed::{OPDSFeedBuilder, OpdsFeed},
 		link::{OpdsLink, OpdsLinkRel, OpdsLinkType},
 	},
 	prisma::{active_reading_session, library, media, series, user},
@@ -62,24 +63,46 @@ pub(crate) fn mount(app_state: AppState) -> Router<AppState> {
 				.route("/file/:filename", get(download_book)),
 		);
 
-	Router::new().nest(
-		"/v1.2",
-		Router::new()
-			.nest(
-				"/",
-				primary_router.clone().layer(middleware::from_fn_with_state(
-					app_state.clone(),
-					auth_middleware,
-				)),
-			)
-			.nest(
-				"/:api_key/v1.2",
-				primary_router.layer(middleware::from_fn_with_state(
-					app_state,
-					api_key_middleware,
-				)),
-			),
-	)
+	Router::new()
+		.nest(
+			"/v1.2",
+			primary_router.clone().layer(middleware::from_fn_with_state(
+				app_state.clone(),
+				auth_middleware,
+			)),
+		)
+		.nest(
+			"/:api_key/v1.2",
+			primary_router.layer(middleware::from_fn_with_state(
+				app_state,
+				api_key_middleware,
+			)),
+		)
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct OPDSURLParams<D> {
+	#[serde(flatten)]
+	params: D,
+	#[serde(default)]
+	api_key: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct OPDSIDURLParams {
+	id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct OPDSPageURLParams {
+	id: String,
+	page: i32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct OPDSFilenameURLParams {
+	id: String,
+	filename: String,
 }
 
 fn pagination_bounds(page: i64, page_size: i64) -> (i64, i64) {
@@ -87,7 +110,15 @@ fn pagination_bounds(page: i64, page_size: i64) -> (i64, i64) {
 	(skip, page_size)
 }
 
-async fn catalog() -> APIResult<Xml> {
+fn catalog_url(req_ctx: &RequestContext, path: &str) -> String {
+	if let Some(api_key) = req_ctx.api_key() {
+		format!("/opds/{}/v1.2/{}", api_key, path)
+	} else {
+		format!("/opds/v1.2/{}", path)
+	}
+}
+
+async fn catalog(Extension(req): Extension<RequestContext>) -> APIResult<Xml> {
 	let entries = vec![
 		OpdsEntry::new(
 			"keepReading".to_string(),
@@ -98,7 +129,7 @@ async fn catalog() -> APIResult<Xml> {
 			Some(vec![OpdsLink {
 				link_type: OpdsLinkType::Navigation,
 				rel: OpdsLinkRel::Subsection,
-				href: String::from("/opds/v1.2/keep-reading"),
+				href: catalog_url(&req, "keep-reading"),
 			}]),
 			None,
 		),
@@ -111,7 +142,7 @@ async fn catalog() -> APIResult<Xml> {
 			Some(vec![OpdsLink {
 				link_type: OpdsLinkType::Navigation,
 				rel: OpdsLinkRel::Subsection,
-				href: String::from("/opds/v1.2/series"),
+				href: catalog_url(&req, "series"),
 			}]),
 			None,
 		),
@@ -124,7 +155,7 @@ async fn catalog() -> APIResult<Xml> {
 			Some(vec![OpdsLink {
 				link_type: OpdsLinkType::Navigation,
 				rel: OpdsLinkRel::Subsection,
-				href: String::from("/opds/v1.2/series/latest"),
+				href: catalog_url(&req, "series/latest"),
 			}]),
 			None,
 		),
@@ -137,36 +168,10 @@ async fn catalog() -> APIResult<Xml> {
 			Some(vec![OpdsLink {
 				link_type: OpdsLinkType::Navigation,
 				rel: OpdsLinkRel::Subsection,
-				href: String::from("/opds/v1.2/libraries"),
+				href: catalog_url(&req, "libraries"),
 			}]),
 			None,
 		),
-		// OpdsEntry::new(
-		// 	"allCollections".to_string(),
-		// 	chrono::Utc::now().into(),
-		// 	"All collections".to_string(),
-		// 	Some(String::from("Browse by collection")),
-		// 	None,
-		// 	Some(vec![OpdsLink {
-		// 		link_type: OpdsLinkType::Navigation,
-		// 		rel: OpdsLinkRel::Subsection,
-		// 		href: String::from("/opds/v1.2/collections"),
-		// 	}]),
-		// 	None,
-		// ),
-		// OpdsEntry::new(
-		// 	"allReadLists".to_string(),
-		// 	chrono::Utc::now().into(),
-		// 	"All read lists".to_string(),
-		// 	Some(String::from("Browse by read list")),
-		// 	None,
-		// 	Some(vec![OpdsLink {
-		// 		link_type: OpdsLinkType::Navigation,
-		// 		rel: OpdsLinkRel::Subsection,
-		// 		href: String::from("/opds/v1.2/readlists"),
-		// 	}]),
-		// 	None,
-		// ),
 		// TODO: more?
 		// TODO: get user stored searches, so they don't have to redo them over and over?
 		// e.g. /opds/v1.2/series?search={searchTerms}, /opds/v1.2/libraries?search={searchTerms}, etc.
@@ -176,18 +181,13 @@ async fn catalog() -> APIResult<Xml> {
 		OpdsLink {
 			link_type: OpdsLinkType::Navigation,
 			rel: OpdsLinkRel::ItSelf,
-			href: String::from("/opds/v1.2/catalog"),
+			href: catalog_url(&req, "catalog"),
 		},
 		OpdsLink {
 			link_type: OpdsLinkType::Navigation,
 			rel: OpdsLinkRel::Start,
-			href: String::from("/opds/v1.2/catalog"),
+			href: catalog_url(&req, "catalog"),
 		},
-		// OpdsLink {
-		// 	link_type: OpdsLinkType::Search,
-		// 	rel: OpdsLinkRel::Search,
-		// 	href: String::from("/opds/v1.2/search"),
-		// },
 	];
 
 	let feed = OpdsFeed::new(
@@ -237,7 +237,10 @@ async fn keep_reading(
 		}
 	});
 
-	let entries = books_in_progress.into_iter().map(OpdsEntry::from).collect();
+	let entries = books_in_progress
+		.into_iter()
+		.map(|m| OPDSEntryBuilder::<media::Data>::new(m, req.api_key()).into_opds_entry())
+		.collect::<Vec<OpdsEntry>>();
 
 	let feed = OpdsFeed::new(
 		"keepReading".to_string(),
@@ -246,12 +249,12 @@ async fn keep_reading(
 			OpdsLink {
 				link_type: OpdsLinkType::Navigation,
 				rel: OpdsLinkRel::ItSelf,
-				href: String::from("/opds/v1.2/keep-reading"),
+				href: catalog_url(&req, "keep-reading"),
 			},
 			OpdsLink {
 				link_type: OpdsLinkType::Navigation,
 				rel: OpdsLinkRel::Start,
-				href: String::from("/opds/v1.2/catalog"),
+				href: catalog_url(&req, "catalog"),
 			},
 		]),
 		entries,
@@ -273,7 +276,12 @@ async fn get_libraries(
 		.find_many(vec![library_not_hidden_from_user_filter(user)])
 		.exec()
 		.await?;
-	let entries = libraries.into_iter().map(OpdsEntry::from).collect();
+	let entries = libraries
+		.into_iter()
+		.map(|l| {
+			OPDSEntryBuilder::<library::Data>::new(l, req.api_key()).into_opds_entry()
+		})
+		.collect::<Vec<OpdsEntry>>();
 
 	let feed = OpdsFeed::new(
 		"allLibraries".to_string(),
@@ -282,12 +290,12 @@ async fn get_libraries(
 			OpdsLink {
 				link_type: OpdsLinkType::Navigation,
 				rel: OpdsLinkRel::ItSelf,
-				href: String::from("/opds/v1.2/libraries"),
+				href: catalog_url(&req, "libraries"),
 			},
 			OpdsLink {
 				link_type: OpdsLinkType::Navigation,
 				rel: OpdsLinkRel::Start,
-				href: String::from("/opds/v1.2/catalog"),
+				href: catalog_url(&req, "catalog"),
 			},
 		]),
 		entries,
@@ -298,7 +306,10 @@ async fn get_libraries(
 
 async fn get_library_by_id(
 	State(ctx): State<AppState>,
-	Path(id): Path<String>,
+	Path(OPDSURLParams {
+		params: OPDSIDURLParams { id },
+		..
+	}): Path<OPDSURLParams<OPDSIDURLParams>>,
 	pagination: Query<PageQuery>,
 	Extension(req): Extension<RequestContext>,
 ) -> APIResult<Xml> {
@@ -354,15 +365,23 @@ async fn get_library_by_id(
 			library_series_count,
 			"Fetched library with series"
 		);
-		Ok(Xml(OpdsFeed::paginated(
+
+		let entries = library_series
+			.into_iter()
+			.map(|s| {
+				OPDSEntryBuilder::<series::Data>::new(s, req.api_key()).into_opds_entry()
+			})
+			.collect::<Vec<OpdsEntry>>();
+
+		let feed = OPDSFeedBuilder::new(req.api_key()).paginated(
 			library.id.as_str(),
 			library.name.as_str(),
+			entries,
 			format!("libraries/{}", &library.id).as_str(),
-			library_series,
 			page.into(),
 			library_series_count,
-		)
-		.build()?))
+		)?;
+		Ok(Xml(feed.build()?))
 	} else {
 		Err(APIError::NotFound(format!(
 			"Library {library_id} not found"
@@ -408,15 +427,23 @@ async fn get_series(
 		})
 		.await?;
 
-	Ok(Xml(OpdsFeed::paginated(
+	let entries = series
+		.into_iter()
+		.map(|s| {
+			OPDSEntryBuilder::<series::Data>::new(s, req.api_key()).into_opds_entry()
+		})
+		.collect::<Vec<OpdsEntry>>();
+
+	let feed = OPDSFeedBuilder::new(req.api_key()).paginated(
 		"allSeries",
 		"All Series",
+		entries,
 		"series",
-		series,
 		page.into(),
 		count,
-	)
-	.build()?))
+	)?;
+
+	Ok(Xml(feed.build()?))
 }
 
 async fn get_latest_series(
@@ -456,19 +483,31 @@ async fn get_latest_series(
 		})
 		.await?;
 
-	Ok(Xml(OpdsFeed::paginated(
+	let entries = series
+		.into_iter()
+		.map(|s| {
+			OPDSEntryBuilder::<series::Data>::new(s, req.api_key()).into_opds_entry()
+		})
+		.collect::<Vec<OpdsEntry>>();
+
+	let feed = OPDSFeedBuilder::new(req.api_key()).paginated(
 		"latestSeries",
 		"Latest Series",
+		entries,
 		"series/latest",
-		series,
 		page.into(),
 		count,
-	)
-	.build()?))
+	)?;
+
+	Ok(Xml(feed.build()?))
 }
 
 async fn get_series_by_id(
-	Path(id): Path<String>,
+	Path(OPDSURLParams {
+		params: OPDSIDURLParams { id },
+		..
+	}): Path<OPDSURLParams<OPDSIDURLParams>>,
+	// Path((id, _)): Path<(String, String)>,
 	State(ctx): State<AppState>,
 	pagination: Query<PageQuery>,
 	Extension(req): Extension<RequestContext>,
@@ -518,15 +557,23 @@ async fn get_series_by_id(
 		.await?;
 
 	if let (Some(series), Some(series_book_count)) = tx_result {
-		Ok(Xml(OpdsFeed::paginated(
+		let series_media = series.media().unwrap_or(&Vec::new()).to_owned();
+		let entries = series_media
+			.into_iter()
+			.map(|m| {
+				OPDSEntryBuilder::<media::Data>::new(m, req.api_key()).into_opds_entry()
+			})
+			.collect();
+
+		let feed = OPDSFeedBuilder::new(req.api_key()).paginated(
 			series.id.as_str(),
 			series.name.as_str(),
+			entries,
 			format!("series/{}", &series.id).as_str(),
-			series.media().unwrap_or(&Vec::new()).to_owned(),
 			page.into(),
 			series_book_count,
-		)
-		.build()?))
+		)?;
+		Ok(Xml(feed.build()?))
 	} else {
 		Err(APIError::NotFound(format!("Series {series_id} not found")))
 	}
@@ -557,7 +604,10 @@ fn handle_opds_image_response(
 
 /// A handler for GET /opds/v1.2/books/{id}/thumbnail, returns the thumbnail
 async fn get_book_thumbnail(
-	Path(id): Path<String>,
+	Path(OPDSURLParams {
+		params: OPDSIDURLParams { id },
+		..
+	}): Path<OPDSURLParams<OPDSIDURLParams>>,
 	State(ctx): State<AppState>,
 	Extension(req): Extension<RequestContext>,
 ) -> APIResult<ImageResponse> {
@@ -569,7 +619,10 @@ async fn get_book_thumbnail(
 
 /// A handler for GET /opds/v1.2/books/{id}/page/{page}, returns the page
 async fn get_book_page(
-	Path((id, page)): Path<(String, i32)>,
+	Path(OPDSURLParams {
+		params: OPDSPageURLParams { id, page },
+		..
+	}): Path<OPDSURLParams<OPDSPageURLParams>>,
 	State(ctx): State<AppState>,
 	pagination: Query<PageQuery>,
 	Extension(req): Extension<RequestContext>,
@@ -650,7 +703,10 @@ async fn get_book_page(
 
 /// A handler for GET /opds/v1.2/books/{id}/file/{filename}, returns the book
 async fn download_book(
-	Path((id, filename)): Path<(String, String)>,
+	Path(OPDSURLParams {
+		params: OPDSFilenameURLParams { id, filename },
+		..
+	}): Path<OPDSURLParams<OPDSFilenameURLParams>>,
 	State(ctx): State<AppState>,
 	Extension(req): Extension<RequestContext>,
 ) -> APIResult<NamedFile> {

--- a/core/src/opds/v1_2/entry.rs
+++ b/core/src/opds/v1_2/entry.rs
@@ -104,23 +104,46 @@ impl OpdsEntry {
 	}
 }
 
-impl From<library::Data> for OpdsEntry {
-	fn from(l: library::Data) -> Self {
+pub trait IntoOPDSEntry {
+	fn into_opds_entry(self) -> OpdsEntry;
+}
+
+pub struct OPDSEntryBuilder<T> {
+	data: T,
+	api_key: Option<String>,
+}
+
+impl<T> OPDSEntryBuilder<T> {
+	pub fn new(data: T, api_key: Option<String>) -> Self {
+		Self { data, api_key }
+	}
+
+	fn format_url(&self, path: &str) -> String {
+		if let Some(ref api_key) = self.api_key {
+			format!("/opds/{}/v1.2/{}", api_key, path)
+		} else {
+			format!("/opds/v1.2/{}", path)
+		}
+	}
+}
+
+impl IntoOPDSEntry for OPDSEntryBuilder<library::Data> {
+	fn into_opds_entry(self) -> OpdsEntry {
 		let mut links = Vec::new();
 
 		let nav_link = OpdsLink::new(
 			OpdsLinkType::Navigation,
 			OpdsLinkRel::Subsection,
-			format!("/opds/v1.2/libraries/{}", l.id),
+			self.format_url(&format!("libraries/{}", self.data.id)),
 		);
 
 		links.push(nav_link);
 
 		OpdsEntry {
-			id: l.id,
-			updated: l.updated_at,
-			title: l.name,
-			content: l.description,
+			id: self.data.id,
+			updated: self.data.updated_at,
+			title: self.data.name,
+			content: self.data.description,
 			authors: None,
 			links,
 			stream_link: None,
@@ -128,23 +151,23 @@ impl From<library::Data> for OpdsEntry {
 	}
 }
 
-impl From<series::Data> for OpdsEntry {
-	fn from(s: series::Data) -> Self {
+impl IntoOPDSEntry for OPDSEntryBuilder<series::Data> {
+	fn into_opds_entry(self) -> OpdsEntry {
 		let mut links = Vec::new();
 
 		let nav_link = OpdsLink::new(
 			OpdsLinkType::Navigation,
 			OpdsLinkRel::Subsection,
-			format!("/opds/v1.2/series/{}", s.id),
+			self.format_url(&format!("series/{}", self.data.id)),
 		);
 
 		links.push(nav_link);
 
 		OpdsEntry {
-			id: s.id.to_string(),
-			updated: s.updated_at,
-			title: s.name,
-			content: s.description,
+			id: self.data.id.to_string(),
+			updated: self.data.updated_at,
+			title: self.data.name,
+			content: self.data.description,
 			authors: None,
 			links,
 			stream_link: None,
@@ -152,20 +175,16 @@ impl From<series::Data> for OpdsEntry {
 	}
 }
 
-// TODO: I was panicking here on my hosted server, and added additional safe guards. I need to check what was happening
-// once these changes are deployed and I can see the logs on my server.
+impl IntoOPDSEntry for OPDSEntryBuilder<media::Data> {
+	fn into_opds_entry(self) -> OpdsEntry {
+		let base_url = self.format_url(&format!("books/{}", self.data.id));
 
-impl From<media::Data> for OpdsEntry {
-	fn from(value: media::Data) -> Self {
-		tracing::trace!(book = ?value, "Converting book to OPDS entry");
-
-		let base_url = format!("/opds/v1.2/books/{}", value.id);
-
-		let path_buf = PathBuf::from(value.path.as_str());
+		let path_buf = PathBuf::from(self.data.path.as_str());
 		let FileParts { file_name, .. } = path_buf.file_parts();
 		let file_name_encoded = encode(&file_name);
 
-		let active_reading_session = value
+		let active_reading_session = self
+			.data
 			.active_user_reading_sessions()
 			.ok()
 			.and_then(|sessions| sessions.first().cloned());
@@ -180,11 +199,13 @@ impl From<media::Data> for OpdsEntry {
 			vec![1]
 		};
 
-		let page_content_types = get_content_types_for_pages(&value.path, target_pages)
-			.unwrap_or_else(|error| {
-				tracing::error!(error = ?error, "Failed to get content types for pages");
-				HashMap::default()
-			});
+		let page_content_types =
+			get_content_types_for_pages(&self.data.path, target_pages).unwrap_or_else(
+				|error| {
+					tracing::error!(error = ?error, "Failed to get content types for pages");
+					HashMap::default()
+				},
+			);
 		tracing::trace!(?page_content_types, "Got page content types");
 
 		let thumbnail_link_type = page_content_types
@@ -196,7 +217,7 @@ impl From<media::Data> for OpdsEntry {
 			.to_owned();
 
 		let current_page_link_type = match current_page {
-			Some(page) if page < value.pages => page_content_types
+			Some(page) if page < self.data.pages => page_content_types
 				.get(&page)
 				.unwrap_or_else(|| {
 					tracing::error!("Failed to get content type for current page");
@@ -204,7 +225,7 @@ impl From<media::Data> for OpdsEntry {
 				})
 				.to_owned(),
 			Some(page) => {
-				tracing::warn!(current_page=?page, book_pages=?value.pages, "Current page is out of bounds!");
+				tracing::warn!(current_page=?page, book_pages=?self.data.pages, "Current page is out of bounds!");
 				thumbnail_link_type
 			},
 			_ => thumbnail_link_type,
@@ -217,8 +238,8 @@ impl From<media::Data> for OpdsEntry {
 		});
 
 		let entry_file_acquisition_link_type =
-			OpdsLinkType::from_extension(&value.extension).unwrap_or_else(|| {
-				tracing::error!(?value.extension, "Failed to convert file extension to OPDS link type");
+			OpdsLinkType::from_extension(&self.data.extension).unwrap_or_else(|| {
+				tracing::error!(?self.data.extension, "Failed to convert file extension to OPDS link type");
 				OpdsLinkType::Zip
 			});
 
@@ -241,16 +262,17 @@ impl From<media::Data> for OpdsEntry {
 		];
 
 		let stream_link = OpdsStreamLink::new(
-			value.id.clone(),
-			value.pages.to_string(),
+			self.data.id.clone(),
+			self.data.pages.to_string(),
 			current_page_link_type.to_string(),
 			current_page.map(|page| page.to_string()),
 			last_read_at.map(|date| date.to_string()),
 		);
 
-		let mib = value.size as f64 / (1024.0 * 1024.0);
+		let mib = self.data.size as f64 / (1024.0 * 1024.0);
 
-		let metadata = value
+		let metadata = self
+			.data
 			.metadata()
 			.ok()
 			.flatten()
@@ -263,14 +285,14 @@ impl From<media::Data> for OpdsEntry {
 		let content = match description {
 			Some(s) => Some(format!(
 				"{:.1} MiB - {}<br/><br/>{}",
-				mib, value.extension, s
+				mib, self.data.extension, s
 			)),
-			None => Some(format!("{:.1} MiB - {}", mib, value.extension)),
+			None => Some(format!("{:.1} MiB - {}", mib, self.data.extension)),
 		};
 
 		OpdsEntry {
-			id: value.id.to_string(),
-			title: value.name,
+			id: self.data.id.to_string(),
+			title: self.data.name,
 			updated: chrono::Utc::now().into(),
 			content,
 			links,


### PR DESCRIPTION
Fixes #516

The feed generation logic was missing some key changes to properly route users to the correct location when using API keys in the OPDS v1.2 feed. The logic had to be made a bit more dynamic to account for the two scenarios:

1. No API key
2. API key