### PR TITLE
🐛 Fix bookmark click navigation

### DIFF
--- a/packages/browser/src/components/readers/epub/locations/Bookmarks.tsx
+++ b/packages/browser/src/components/readers/epub/locations/Bookmarks.tsx
@@ -11,7 +11,7 @@ type Props = {
 export default function Bookmarks({ onLocationChanged }: Props) {
 	const {
 		readerMeta: { bookMeta },
-		controls: { onLinkClick },
+		controls: { onGoToCfi },
 	} = useEpubReaderContext()
 
 	const bookmarks = useMemo(() => bookMeta?.bookmarks || {}, [bookMeta])
@@ -21,11 +21,11 @@ export default function Bookmarks({ onLocationChanged }: Props) {
 	)
 
 	const handleSelect = useCallback(
-		(href: string) => {
-			onLinkClick(href)
+		(cfi: string) => {
+			onGoToCfi(cfi)
 			onLocationChanged?.()
 		},
-		[onLinkClick, onLocationChanged],
+		[onGoToCfi, onLocationChanged],
 	)
 
 	if (!bookmarksArray.length) {


### PR DESCRIPTION
Bookmarks were actually redirecting to the relevant page and instead navigated to the closest chapter. 

#### Before
https://github.com/user-attachments/assets/65a3719a-5d7d-4a81-9033-30ba8fb070f1

#### After
https://github.com/user-attachments/assets/d921a4ad-b4ba-4c6a-a679-801e1c8f538f

