### PR TITLE
✨ Add GET and PUT endpoints for media metadata

### DIFF
--- a/apps/server/src/routers/api/v1/media/mod.rs
+++ b/apps/server/src/routers/api/v1/media/mod.rs
@@ -50,6 +50,11 @@ pub(crate) fn mount(app_state: AppState) -> Router<AppState> {
 				.route(
 					"/page/:page/dimensions",
 					get(individual::get_media_page_dimensions),
+				)
+				.route(
+					"/metadata",
+					get(individual::get_media_metadata)
+						.put(individual::put_media_metadata),
 				),
 		)
 		.layer(middleware::from_fn_with_state(app_state, auth_middleware))

--- a/core/src/db/entity/media/prisma_macros.rs
+++ b/core/src/db/entity/media/prisma_macros.rs
@@ -1,5 +1,7 @@
 use crate::prisma::{active_reading_session, finished_reading_session, media};
 
+media::select!(media_id_select { id });
+
 media::select!(media_path_select { path });
 
 media::select!(media_path_modified_at_select {

--- a/core/src/db/entity/metadata/prisma_macros.rs
+++ b/core/src/db/entity/metadata/prisma_macros.rs
@@ -1,4 +1,4 @@
-use crate::prisma::media_metadata;
+use crate::prisma::{media, media_metadata};
 
 media_metadata::select!(metadata_available_genre_select { genre });
 media_metadata::select!(metadata_available_writers_select { writers });

--- a/core/src/db/entity/metadata/prisma_macros.rs
+++ b/core/src/db/entity/metadata/prisma_macros.rs
@@ -1,4 +1,4 @@
-use crate::prisma::{media, media_metadata};
+use crate::prisma::media_metadata;
 
 media_metadata::select!(metadata_available_genre_select { genre });
 media_metadata::select!(metadata_available_writers_select { writers });

--- a/packages/sdk/src/controllers/media-api.ts
+++ b/packages/sdk/src/controllers/media-api.ts
@@ -148,6 +148,27 @@ export class MediaAPI extends APIBase {
 	}
 
 	/**
+	 * Fetch the metadata of a media entity
+	 *
+	 * @param id The ID of the media entity
+	 */
+	async getMeta(id: string): Promise<MediaMetadata | null> {
+		const { data: meta } = await this.axios.get<MediaMetadata>(mediaURL(`${id}/metadata`))
+		return meta
+	}
+
+	/**
+	 * Update the metadata of a media entity. If the metadata does not exist, it will be created.
+	 *
+	 * @param id The ID of the media entity
+	 * @param payload The metadata to update or create
+	 */
+	async updateMeta(id: string, payload: MediaMetadata): Promise<MediaMetadata> {
+		const { data: updatedMeta } = await this.axios.put(mediaURL(`${id}/metadata`), payload)
+		return updatedMeta
+	}
+
+	/**
 	 * The keys for the media API, used for query caching on a client (e.g. react-query)
 	 */
 	get keys(): ClassQueryKeys<InstanceType<typeof MediaAPI>> {
@@ -164,6 +185,8 @@ export class MediaAPI extends APIBase {
 			recentlyAdded: 'media.recentlyAdded',
 			updateProgress: 'media.updateProgress',
 			uploadThumbnail: 'media.uploadThumbnail',
+			getMeta: 'media.getMeta',
+			updateMeta: 'media.updateMeta',
 		}
 	}
 }

--- a/packages/sdk/src/controllers/media-api.ts
+++ b/packages/sdk/src/controllers/media-api.ts
@@ -2,6 +2,7 @@ import { APIBase } from '../base'
 import {
 	Media,
 	MediaFilter,
+	MediaMetadata,
 	Pageable,
 	PatchMediaThumbnail,
 	ProgressUpdateReturn,


### PR DESCRIPTION
This was asked on Discord to allow for better scripting capabilities when using the SDK

Note that PUT'ing the metadata requires `library:manage` permission