### PR TITLE
🐛 Change CORS layer construction to allow wildcard

### DIFF
--- a/apps/server/src/config/cors.rs
+++ b/apps/server/src/config/cors.rs
@@ -32,14 +32,46 @@ fn merge_origins(origins: &[&str], local_origins: Vec<String>) -> Vec<HeaderValu
 pub fn get_cors_layer(config: StumpConfig) -> CorsLayer {
 	let is_debug = config.is_debug();
 
-	let mut allowed_origins = Vec::new();
-	for origin in config.allowed_origins {
-		if let Ok(val) = origin.parse::<HeaderValue>() {
-			allowed_origins.push(val)
-		} else {
-			tracing::error!("Failed to parse allowed origin: {:?}", origin);
-		}
+	// Create CORS layer
+	let mut cors_layer = CorsLayer::new();
+	cors_layer = cors_layer
+		.allow_methods([
+			Method::GET,
+			Method::PUT,
+			Method::POST,
+			Method::PATCH,
+			Method::DELETE,
+			Method::OPTIONS,
+			Method::CONNECT,
+		])
+		.allow_headers([ACCEPT, AUTHORIZATION, CONTENT_TYPE])
+		.allow_credentials(true);
+
+	// If allowed origins include the general wildcard ("*") then we can return a permissive CORS layer and exit early.
+	if config.allowed_origins.contains(&"*".to_string()) {
+		cors_layer = cors_layer.allow_origin(AllowOrigin::any());
+
+		#[cfg(debug_assertions)]
+		tracing::trace!(
+			?cors_layer,
+			"Cors configuration completed (allowing any origin)"
+		);
+
+		return cors_layer;
 	}
+
+	// Convert allowed origins from config into `HeaderValue`s for CORS layer.
+	let allowed_origins: Vec<_> = config
+		.allowed_origins
+		.into_iter()
+		.filter_map(|origin| match origin.parse::<HeaderValue>() {
+			Ok(val) => Some(val),
+			Err(e) => {
+				tracing::error!("Failed to parse allowed origin: {origin:?}: {e}");
+				None
+			},
+		})
+		.collect();
 
 	let local_ip = local_ip()
 		.map_err(|e| {
@@ -70,8 +102,6 @@ pub fn get_cors_layer(config: StumpConfig) -> CorsLayer {
 		base
 	};
 
-	let mut cors_layer = CorsLayer::new();
-
 	let defaults = if is_debug {
 		DEBUG_ALLOWED_ORIGINS
 	} else {
@@ -86,19 +116,6 @@ pub fn get_cors_layer(config: StumpConfig) -> CorsLayer {
 			.chain(allowed_origins)
 			.collect::<Vec<HeaderValue>>(),
 	));
-
-	cors_layer = cors_layer
-		.allow_methods([
-			Method::GET,
-			Method::PUT,
-			Method::POST,
-			Method::PATCH,
-			Method::DELETE,
-			Method::OPTIONS,
-			Method::CONNECT,
-		])
-		.allow_headers([ACCEPT, AUTHORIZATION, CONTENT_TYPE])
-		.allow_credentials(true);
 
 	#[cfg(debug_assertions)]
 	tracing::trace!(?cors_layer, "Cors configuration complete");


### PR DESCRIPTION
This pull request addresses the problem raised in #537, which causes Stump to fail to start when a wildcard ("*") is used in the allowed origins configuration variable.

The cause is that Axum doesn't like wildcards being added via the `AllowOrigin::list()` function and wants you to use `AllowOrigin::any()` instead. I slightly reorganized the server's `get_cors_layer()` function to detect when a "*" is present in the list of allowed origins and exit early with an `AllowOrigin::any()` configuration. 

I'm making the assumption is that there is no case where the allowed origin list would include a wildcard and then other origins but the user would expect behavior other than any origin being allowed. I think that's right.