### PR TITLE
:bug: Fix unordered OPDS entries

### DIFF
--- a/apps/server/src/routers/opds/v1_2.rs
+++ b/apps/server/src/routers/opds/v1_2.rs
@@ -283,6 +283,7 @@ async fn get_libraries(
 	let libraries = db
 		.library()
 		.find_many(vec![library_not_hidden_from_user_filter(user)])
+		.order_by(library::name::order(Direction::Asc))
 		.exec()
 		.await?;
 	let entries = libraries
@@ -424,6 +425,7 @@ async fn get_series(
 				.find_many(chain_optional_iter([], [age_restrictions.clone()]))
 				.skip(skip)
 				.take(take)
+				.order_by(series::name::order(Direction::Asc))
 				.exec()
 				.await?;
 
@@ -516,7 +518,6 @@ async fn get_series_by_id(
 		params: OPDSIDURLParams { id },
 		..
 	}): Path<OPDSURLParams<OPDSIDURLParams>>,
-	// Path((id, _)): Path<(String, String)>,
 	State(ctx): State<AppState>,
 	pagination: Query<PageQuery>,
 	Extension(req): Extension<RequestContext>,

--- a/apps/server/src/routers/opds/v2_0.rs
+++ b/apps/server/src/routers/opds/v2_0.rs
@@ -278,6 +278,7 @@ async fn browse_libraries(
 		.find_many(library_conditions.clone())
 		.take(take)
 		.skip(skip)
+		.order_by(library::name::order(Direction::Asc))
 		.exec()
 		.await?;
 	let library_count = client.library().count(library_conditions).exec().await?;


### PR DESCRIPTION
Fixes #551

There were two queries I noticed which just didn't have any ordering applied, which caused the bug