### PR TITLE
:memo: Remove Tachiyomi plans from repo and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Stump is a free and open source comics, manga and digital book server with OPDS 
 - [Roadmap 🗺](#roadmap-)
 - [Getting Started 🚀](#getting-started-)
 - [Developer Guide 💻](#developer-guide-)
-  - [Where to start?](#where-to-start)
+    - [Where to start?](#where-to-start)
 - [Project Structure 📦](#project-structure-)
   - [Apps](#apps)
   - [Core](#core)
@@ -62,7 +62,6 @@ The following items are the major targets for Stump's first stable release:
 Things you can expect to see afterwards:
 
 - 🖥️ Cross-platform desktop app _(Windows, Mac, Linux)_
-- 📖 [Tachiyomi](https://github.com/stumpapp/tachiyomi-extensions) support
 - 📱 In-house mobile app _(Android, iOS)_
 - 🔎 Versatile full-text search _(blocked by [prisma#9414](https://github.com/prisma/prisma/issues/9414))_
 - 👥 Configurable book clubs _(see [this issue](https://github.com/stumpapp/stump/issues/120))_

--- a/docs/pages/guides/mobile/_meta.ts
+++ b/docs/pages/guides/mobile/_meta.ts
@@ -2,5 +2,4 @@ import { Meta } from 'nextra'
 
 export default {
 	app: 'App',
-	tachiyomi: 'Tachiyomi',
 } satisfies Meta

--- a/docs/pages/guides/mobile/tachiyomi.md
+++ b/docs/pages/guides/mobile/tachiyomi.md
@@ -1,3 +1,0 @@
-# Tachiyomi
-
-A Tachiyomi extension for Stump is planned for development, but is not currently in development. If you are a developer familiar with Tachiyomi and would like to help out, please feel free to reach out on [Discord](https://discord.gg/63Ybb7J3as) or browse the relevant [GitHub issue](https://github.com/stumpapp/stump/issues?q=is%3Aissue+is%3Aopen+label%3Amobile).


### PR DESCRIPTION
Tachi seems to be deprecated, and official extensions can no longer be supported. See https://tachiyomi.org/news/2024-01-13-goodbye. If there is an alternative folks would like to see, please create a feature request