### PR TITLE
🐛 Enforce case-insensitive username uniqueness 

### DIFF
--- a/core/prisma/migrations/20250108021921_case_insensitive_usernames/migration.sql
+++ b/core/prisma/migrations/20250108021921_case_insensitive_usernames/migration.sql
@@ -1,0 +1,24 @@
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_users" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "username" TEXT NOT NULL COLLATE NOCASE,
+    "hashed_password" TEXT NOT NULL,
+    "is_server_owner" BOOLEAN NOT NULL DEFAULT false,
+    "avatar_url" TEXT,
+    "last_login" DATETIME,
+    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "deleted_at" DATETIME,
+    "is_locked" BOOLEAN NOT NULL DEFAULT false,
+    "max_sessions_allowed" INTEGER,
+    "permissions" TEXT,
+    "user_preferences_id" TEXT,
+    CONSTRAINT "users_user_preferences_id_fkey" FOREIGN KEY ("user_preferences_id") REFERENCES "user_preferences" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_users" ("avatar_url", "created_at", "deleted_at", "hashed_password", "id", "is_locked", "is_server_owner", "last_login", "max_sessions_allowed", "permissions", "user_preferences_id", "username") SELECT "avatar_url", "created_at", "deleted_at", "hashed_password", "id", "is_locked", "is_server_owner", "last_login", "max_sessions_allowed", "permissions", "user_preferences_id", "username" FROM "users";
+DROP TABLE "users";
+ALTER TABLE "new_users" RENAME TO "users";
+CREATE UNIQUE INDEX "users_username_key" ON "users"("username");
+CREATE UNIQUE INDEX "users_user_preferences_id_key" ON "users"("user_preferences_id");
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/packages/browser/src/scenes/settings/server/users/create-or-update/schema.ts
+++ b/packages/browser/src/scenes/settings/server/users/create-or-update/schema.ts
@@ -71,7 +71,7 @@ export const buildSchema = (
 			.refine(
 				(value) =>
 					(!!editingUser && value === editingUser.username) ||
-					existingUsers.every((user) => user.username !== value),
+					existingUsers.every((user) => user.username.toLowerCase() !== value.toLowerCase()),
 				() => ({
 					message: t(
 						'settingsScene.server/users.createOrUpdateForm.validation.usernameAlreadyExists',

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -1582,7 +1582,10 @@
 					}
 				},
 				"validation": {
-					"ageRestrictionTooLow": "Age restriction cannot be less than 0"
+					"ageRestrictionTooLow": "Age restriction cannot be less than 0",
+					"missingUsername": "Username is required",
+					"missingPassword": "Password is required",
+					"usernameAlreadyExists": "Username already exists"
 				},
 				"createSubmitButton": "Create user",
 				"updateSubmitButton": "Update user"


### PR DESCRIPTION
Fixes #556

I've adjusted the `username` column manually to add `COLLATE NOCASE` according to https://www.prisma.io/docs/orm/prisma-client/queries/case-sensitivity#sqlite-provider. I've also adjusted the frontend validation to ignore case when comparing.

I have tested manual DB insertion/updates and confirmed the migration enforces case-insensitive usernames (e.g., `oromei` or `OrOmEI` are equal). I'll try to do another validation pass tomorrow before merging, though. Edit to add that I've also tested the migration doesn't blow up my user or existing preferences, which is good I guess lol