### PR TITLE
:sparkles: Support basic keyword search for OPDS v1.2

### DIFF
--- a/core/src/db/query/pagination.rs
+++ b/core/src/db/query/pagination.rs
@@ -22,6 +22,12 @@ pub struct PageQuery {
 	pub page_size: Option<u32>,
 }
 
+impl PageQuery {
+	pub fn is_empty(&self) -> bool {
+		self.page.is_none() && self.page_size.is_none()
+	}
+}
+
 #[skip_serializing_none]
 #[derive(
 	Clone, Default, Debug, Deserialize, Serialize, PartialEq, Eq, Type, ToSchema,

--- a/core/src/opds/v1_2/opensearch.rs
+++ b/core/src/opds/v1_2/opensearch.rs
@@ -12,51 +12,47 @@ use super::{
 
 /// A struct for building an OpenSearch SearchDescription XML string as
 /// specified at https://developer.mozilla.org/en-US/docs/Web/OpenSearch
-pub struct OpdsOpenSearch {}
+pub struct OpdsOpenSearch {
+	service_url: Option<String>,
+}
 
 impl OpdsOpenSearch {
+	pub fn new(service_url: Option<String>) -> Self {
+		Self { service_url }
+	}
+
+	fn format_url(&self, url: &str) -> String {
+		if let Some(service_url) = &self.service_url {
+			format!("{}/{}", service_url, url)
+		} else {
+			url.to_string()
+		}
+	}
+
 	/// Build an xml string for the OpenSearchDescription
-	pub fn build() -> CoreResult<String> {
+	pub fn build(self) -> CoreResult<String> {
 		let raw = Vec::new();
 		let mut writer = EventWriter::new(raw);
 
-		writer.write(XmlEvent::start_element("OpenSearchDescription"))?;
+		writer.write(
+			XmlEvent::start_element("OpenSearchDescription")
+				.attr("xmlns", "http://a9.com/-/spec/opensearch/1.1/"),
+		)?;
 
 		write_xml_element("ShortName", "Search", &mut writer)?;
 		write_xml_element("Description", "Search by keyword", &mut writer)?;
 		write_xml_element("InputEncoding", "UTF-8", &mut writer)?;
 		write_xml_element("OutputEncoding", "UTF-8", &mut writer)?;
 
-		let series_example = "/opds/v1.2/series?search={searchTerms}";
-		let library_example = "/opds/v1.2/libraries?search={searchTerms}";
-		let media_example = "/opds/v1.2/books?search={searchTerms}";
+		let series_example = self.format_url("series?search={searchTerms}");
 
-		// series template URL
+		// start of series template URL
 		writer.write(
 			XmlEvent::start_element("Url")
-				.attr("type", OpdsLinkType::Acquisition.as_str())
-				.attr("template", series_example),
+				.attr("template", &series_example)
+				.attr("type", OpdsLinkType::Acquisition.as_str()),
 		)?;
-
-		writer.write(XmlEvent::end_element())?; // end of URL
-
-		// libraries template URL
-		writer.write(
-			XmlEvent::start_element("Url")
-				.attr("type", OpdsLinkType::Acquisition.as_str())
-				.attr("template", library_example),
-		)?;
-
-		writer.write(XmlEvent::end_element())?; // end of URL
-
-		// media template URL
-		writer.write(
-			XmlEvent::start_element("Url")
-				.attr("type", OpdsLinkType::Acquisition.as_str())
-				.attr("template", media_example),
-		)?;
-
-		writer.write(XmlEvent::end_element())?; // end of URL
+		writer.write(XmlEvent::end_element())?; // end series template URL
 
 		// TODO: more templates? have to look into open search spec to see
 		// if that 'is possible' or if it is only supposed to be one


### PR DESCRIPTION
Resolves https://github.com/stumpapp/stump/issues/552

The linked issue is marked as a bug, but really this just wasn't implemented 😛 I'll leave as a draft until I resolve a quirk with Panels, I wrote a note for it in the code. For those following and interested, I posted about it in the Panels discord.