### PR TITLE
:bug: Remove auto-pagination for `usePageQuery` wrapper

### DIFF
--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -131,8 +131,8 @@ export function usePageQuery<Entity = unknown, Error = AxiosError>(
 	queryKey: QueryKey,
 	queryFn: PageQueryFunction<Entity>,
 	{
-		page = 1,
-		page_size = 20,
+		page,
+		page_size,
 		params,
 		...options
 	}: PageQueryOptions<Entity, Pageable<Entity[]>, Error, Pageable<Entity[]>> = {},


### PR DESCRIPTION
A user reported missing libraries in their sidebar, since it was capped at 20 I knew exactly where to look. The `usePageQuery` wrapper function I created auto adds page details to the request, but the sidebar assumes unpaginated responses. The long term fix will be to implement cursor fetching as you scroll the sidebar, but this should do for now. 

I don't have time to test right away, but I'll try to poke around and make sure this doesn't inadvertently break something else.