### PR TITLE
:sparkles: Support `apple-mobile-web-app-capable` meta

### DIFF
--- a/apps/web/src/index.html
+++ b/apps/web/src/index.html
@@ -56,6 +56,7 @@
 		</style>
 		<link rel="icon" type="image/icon" href="/assets/favicon.ico" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<meta name="apple-mobile-web-app-capable" content="yes" />
 	</head>
 	<body>
 		<div id="root">


### PR DESCRIPTION
This enables a more seamless "Add to Home Screen" experience on iOS. See https://github.com/stumpapp/stump/issues/566#issuecomment-2610645866

I tested locally and it seems to have done the trick. The one thing to note is that it seems styling the status bar is no longer supported, e.g. `<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">`