### PR TITLE
💄 improve experience with IOS 'add to home screen' PWA

### DIFF
--- a/apps/web/src/index.html
+++ b/apps/web/src/index.html
@@ -57,6 +57,8 @@
 		<link rel="icon" type="image/icon" href="/assets/favicon.ico" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<meta name="apple-mobile-web-app-capable" content="yes" />
+		<link rel="manifest" href="/assets/web-app-manifest.json" />
+		<meta name="theme-color" content="#ffffff" />
 	</head>
 	<body>
 		<div id="root">

--- a/packages/browser/public/assets/web-app-manifest.json
+++ b/packages/browser/public/assets/web-app-manifest.json
@@ -1,0 +1,10 @@
+{
+	"name": "My Super App",
+	"short_name": "My App",
+	"display": "standalone",
+	"scope": "/",
+	"start_url": "/",
+	"background_color": "#f6f6f6",
+	"theme_color": "#f6f6f6",
+	"id": "stump"
+}


### PR DESCRIPTION
Adds a manifest file for progressive web app specification. This should allow users to 'save to home screen' on mobile devices (I was only able to test on iOS) and get a better 'native' feel without browser controls.