### PR TITLE
:bug: Fix path error in koreader router

### DIFF
--- a/apps/server/src/errors.rs
+++ b/apps/server/src/errors.rs
@@ -303,6 +303,7 @@ impl From<prisma_client_rust::QueryError> for APIError {
 
 /// The response body for API errors. This is just a basic JSON response with a status code and a message.
 /// Any axum handlers which return a [`Result`] with an Error of [`APIError`] will be converted into this response.
+#[derive(Debug)]
 pub struct APIErrorResponse {
 	status: StatusCode,
 	message: String,
@@ -323,6 +324,8 @@ impl IntoResponse for APIErrorResponse {
 			"status": self.status.as_u16(),
 			"message": self.message,
 		});
+
+		tracing::error!(error = ?self, "API error response");
 
 		let base_response = Json(body).into_response();
 

--- a/apps/server/src/routers/koreader/sync.rs
+++ b/apps/server/src/routers/koreader/sync.rs
@@ -25,6 +25,19 @@ use crate::{
 	middleware::auth::{api_key_middleware, RequestContext},
 };
 
+#[derive(Debug, Serialize, Deserialize)]
+struct KOReaderURLParams<D> {
+	#[serde(flatten)]
+	params: D,
+	#[serde(default)]
+	api_key: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct KOReaderDocumentURLParams {
+	document: String,
+}
+
 // TODO(koreader): healthcheck? I don't think it is required, since I could configure Stump as a
 // sync server just fine without it.
 
@@ -98,7 +111,10 @@ struct GetProgressResponse {
 async fn get_progress(
 	State(ctx): State<AppState>,
 	Extension(req): Extension<RequestContext>,
-	Path(document): Path<String>,
+	Path(KOReaderURLParams {
+		params: KOReaderDocumentURLParams { document },
+		..
+	}): Path<KOReaderURLParams<KOReaderDocumentURLParams>>,
 ) -> APIResult<Json<GetProgressResponse>> {
 	let client = &ctx.db;
 	let user = req.user();


### PR DESCRIPTION
This PR fixes the following error:

```
Wrong number of path arguments for `Path`. Expected 1 but got 2. Note that multiple parameters must be extracted with a tuple `Path<(_, _)>` or a struct `Path<YourParams>`
```

I just did the same fix I did when this happened for OPDS v1.2 after adding API key support to that router. The issue is that I can't force Axum to "ignore" the parent Path params for handlers of nested routers (e.g., `:document`). So when I construct a handler that only has one Path (e.g., `Path(document): Path<String>`) it rejects the request outright with that error.

Ideally, I don't need this work around but I haven't figured out how to achieve that wiht Axum yet