### PR TITLE
 🐛 (api) Fix metadata api lookup

### DIFF
--- a/apps/server/src/routers/api/v1/media/mod.rs
+++ b/apps/server/src/routers/api/v1/media/mod.rs
@@ -3,11 +3,13 @@ pub(crate) mod individual;
 pub(crate) mod thumbnails;
 
 use axum::{
-	extract::DefaultBodyLimit,
+	extract::{DefaultBodyLimit, Extension},
 	middleware,
 	routing::{get, post, put},
 	Router,
 };
+
+use serde_qs::axum::QsQueryConfig;
 
 use crate::{config::state::AppState, middleware::auth::auth_middleware};
 
@@ -57,5 +59,6 @@ pub(crate) fn mount(app_state: AppState) -> Router<AppState> {
 						.put(individual::put_media_metadata),
 				),
 		)
+		.layer(Extension(QsQueryConfig::new(5, false)))
 		.layer(middleware::from_fn_with_state(app_state, auth_middleware))
 }


### PR DESCRIPTION
There is an issue with serde_qs (https://docs.rs/serde_qs/latest/serde_qs/#square-brackets) with non-flattened substructs. Specifically, the way to query them is to use square brackets `metadata[writer]=Sanderson`, but this needs to be url encoded so it turns into `metadata%5Bwriter%5D=Sanderson`. In strict mode, the key gets parsed as the string `"metadata[writer]"` instead of an object and key. In non-strict mode, it will correctly parse it as nested keys.

An example would be `http://localhost:10801/api/v1/media?metadata%5Bwriter%5D=Sanderson`


Another option would be to flatten all the sub-structs. While this is possible, it seems like it might cause naming conflict issues in the future. I do not really see a valid case where the key name would have square brackets.