### PR TITLE
♻️ Rework the BookOverviewScene to include metadata information

### DIFF
--- a/packages/browser/src/components/SearchLinkBadge.tsx
+++ b/packages/browser/src/components/SearchLinkBadge.tsx
@@ -1,4 +1,4 @@
-import { Text, Link } from '@stump/components'
+import { Link, Text } from '@stump/components'
 
 type Props = {
 	searchKey: string

--- a/packages/browser/src/components/SearchLinkBadge.tsx
+++ b/packages/browser/src/components/SearchLinkBadge.tsx
@@ -1,0 +1,19 @@
+import { Text, Link } from '@stump/components'
+
+type Props = {
+	searchKey: string
+	text: string
+}
+
+export default function SearchLinkBadge({ searchKey, text }: Props) {
+	const href = '/books?' + encodeURIComponent(searchKey) + '=' + encodeURIComponent(text)
+	const renderText = '     ' + text
+
+	return (
+		<Text>
+			<Link href={href} rel="noopener noreferrer" className="flex items-center">
+				{renderText}
+			</Link>
+		</Text>
+	)
+}

--- a/packages/browser/src/scenes/book/BookOverviewScene.tsx
+++ b/packages/browser/src/scenes/book/BookOverviewScene.tsx
@@ -1,5 +1,5 @@
 import { useMediaByIdQuery } from '@stump/client'
-import { Badge, ButtonOrLink, Heading, Spacer, Text } from '@stump/components'
+import { ButtonOrLink, Heading, Spacer, Text } from '@stump/components'
 import dayjs from 'dayjs'
 import sortBy from 'lodash/sortBy'
 import { Suspense, useEffect, useMemo } from 'react'
@@ -11,7 +11,6 @@ import MediaCard from '@/components/book/BookCard'
 import { SceneContainer } from '@/components/container'
 import LinkBadge from '@/components/LinkBadge'
 import ReadMore from '@/components/ReadMore'
-import TagList from '@/components/tags/TagList'
 import { formatBookName } from '@/utils/format'
 
 import { useAppContext } from '../../context'
@@ -19,19 +18,12 @@ import paths from '../../paths'
 import { PDF_EXTENSION } from '../../utils/patterns'
 import BookCompletionToggleButton from './BookCompletionToggleButton'
 import BookFileInformation from './BookFileInformation'
-import BookLibrarySeriesLinks from './BookLibrarySeriesLinks'
 import BookReaderDropdown from './BookReaderDropdown'
 import BooksAfterCursor from './BooksAfterCursor'
 import DownloadMediaButton from './DownloadMediaButton'
 import EmailBookDropdown from './EmailBookDropdown'
+import BookOverviewSceneHeader from './BookOverviewSceneHeader'
 
-// TODO: redesign page!!
-// TODO: with metadata being collected now, there is a lot more information to display:
-// - publish date
-// - publisher
-// - pencillers, authors, etc
-// - links
-// - featured characters
 export default function BookOverviewScene() {
 	const { checkPermission, isServerOwner } = useAppContext()
 
@@ -59,26 +51,11 @@ export default function BookOverviewScene() {
 		throw new Error('Media not found')
 	}
 
-	const renderHeader = () => {
-		return (
-			<div className="flex flex-col items-center text-center tablet:items-start tablet:text-left">
-				<Heading size="sm">{formatBookName(media)}</Heading>
-
-				<BookLibrarySeriesLinks
-					libraryId={media.series?.library_id}
-					seriesId={media.series_id}
-					series={media.series}
-				/>
-
-				<TagList tags={media.tags || null} baseUrl={paths.bookSearch()} />
-			</div>
-		)
-	}
+	const sceneHeaderBuilder = new BookOverviewSceneHeader(media)
 
 	const completedAt = sortBy(media.finished_reading_sessions, ({ completed_at }) =>
 		dayjs(completed_at).toDate(),
 	).at(-1)?.completed_at
-	const genres = media.metadata?.genre?.filter((g) => !!g) ?? []
 	const links = media.metadata?.links?.filter((l) => !!l) ?? []
 
 	return (
@@ -92,7 +69,7 @@ export default function BookOverviewScene() {
 					<div className="flex flex-col items-center gap-3 tablet:mb-2 tablet:flex-row tablet:items-start">
 						<MediaCard media={media} readingLink variant="cover" />
 						<div className="flex h-full w-full flex-col gap-2 tablet:gap-4">
-							{renderHeader()}
+							{sceneHeaderBuilder.renderHeader()}
 							{completedAt && (
 								<Text size="xs" variant="muted">
 									Completed on {dayjs(completedAt).format('LLL')}
@@ -133,16 +110,6 @@ export default function BookOverviewScene() {
 							)}
 						</div>
 					</div>
-
-					{!!genres.length && (
-						<div className="flex flex-row space-x-2">
-							{genres.map((genre) => (
-								<Badge key={genre} variant="primary">
-									{genre}
-								</Badge>
-							))}
-						</div>
-					)}
 
 					{!!links.length && (
 						<div className="flex flex-row space-x-2">

--- a/packages/browser/src/scenes/book/BookOverviewScene.tsx
+++ b/packages/browser/src/scenes/book/BookOverviewScene.tsx
@@ -18,11 +18,11 @@ import paths from '../../paths'
 import { PDF_EXTENSION } from '../../utils/patterns'
 import BookCompletionToggleButton from './BookCompletionToggleButton'
 import BookFileInformation from './BookFileInformation'
+import BookOverviewSceneHeader from './BookOverviewSceneHeader'
 import BookReaderDropdown from './BookReaderDropdown'
 import BooksAfterCursor from './BooksAfterCursor'
 import DownloadMediaButton from './DownloadMediaButton'
 import EmailBookDropdown from './EmailBookDropdown'
-import BookOverviewSceneHeader from './BookOverviewSceneHeader'
 
 export default function BookOverviewScene() {
 	const { checkPermission, isServerOwner } = useAppContext()

--- a/packages/browser/src/scenes/book/BookOverviewScene.tsx
+++ b/packages/browser/src/scenes/book/BookOverviewScene.tsx
@@ -51,8 +51,6 @@ export default function BookOverviewScene() {
 		throw new Error('Media not found')
 	}
 
-	const sceneHeaderBuilder = new BookOverviewSceneHeader(media)
-
 	const completedAt = sortBy(media.finished_reading_sessions, ({ completed_at }) =>
 		dayjs(completed_at).toDate(),
 	).at(-1)?.completed_at
@@ -69,7 +67,7 @@ export default function BookOverviewScene() {
 					<div className="flex flex-col items-center gap-3 tablet:mb-2 tablet:flex-row tablet:items-start">
 						<MediaCard media={media} readingLink variant="cover" />
 						<div className="flex h-full w-full flex-col gap-2 tablet:gap-4">
-							{sceneHeaderBuilder.renderHeader()}
+							<BookOverviewSceneHeader media={media} />
 							{completedAt && (
 								<Text size="xs" variant="muted">
 									Completed on {dayjs(completedAt).format('LLL')}

--- a/packages/browser/src/scenes/book/BookOverviewSceneHeader.tsx
+++ b/packages/browser/src/scenes/book/BookOverviewSceneHeader.tsx
@@ -7,104 +7,104 @@ import { Heading, Text } from '@stump/components'
 import paths from '../../paths'
 
 interface MetadataTableItem {
-	keyname: string
+	keynameBase: string
 	prefix: string
 	values: string[]
 	searchKey: string
 }
 
-export default class BookOverviewSceneHeader {
-	media: Media
-	metadata_table: MetadataTableItem[]
+function build_metadata_table(metadata: MediaMetadata) {
+	let table: MetadataTableItem[] = []
 
-	constructor(media: Media) {
-		this.media = media
-		this.metadata_table = this.build_metadata_table(media.metadata ?? {})
-	}
-
-	build_metadata_table(metadata: MediaMetadata) {
-		let table: MetadataTableItem[] = []
-
-		if (!metadata) {
-			return table
-		}
-
-		let add_to_table = (keyname: string, prefix: string, values: string[], searchKey: string) => {
-			if (values && values.length > 0) {
-				// if all values are empty, don't add the key
-				if (values.every((v) => !v)) {
-					return
-				}
-
-				table.push({
-					keyname: keyname,
-					prefix: prefix,
-					values: values,
-					searchKey: searchKey,
-				})
-			}
-		}
-
-		const age_rating_num = metadata.age_rating ?? 0
-		const year_num = metadata.year ?? 0
-
-		const publishers = [metadata.publisher ?? '']
-		const characters = metadata.characters?.filter((c) => !!c) ?? []
-		const colorists = metadata.colorists?.filter((c) => !!c) ?? []
-		const writers = metadata.writers?.filter((w) => !!w) ?? []
-		const pencillers = metadata.pencillers?.filter((p) => !!p) ?? []
-		const inkers = metadata.inkers?.filter((i) => !!i) ?? []
-		const letterers = metadata.letterers?.filter((l) => !!l) ?? []
-		const editors = metadata.editors?.filter((e) => !!e) ?? []
-		const genres = metadata.genre?.filter((g) => !!g) ?? []
-		const age_rating = age_rating_num > 0 ? [age_rating_num.toString()] : []
-		const year = year_num > 0 ? [year_num.toString()] : []
-
-		add_to_table('writers', 'By ', writers, 'metadata[writer]')
-		add_to_table('publisher', 'Publisher: ', publishers, 'metadata[publisher]')
-		add_to_table('genres', 'Genres: ', genres, 'metadata[genre]')
-		add_to_table('characters', 'Characters: ', characters, 'metadata[character]')
-		add_to_table('colorists', 'Colorists: ', colorists, 'metadata[colorist]')
-		add_to_table('pencillers', 'Pencillers: ', pencillers, 'metadata[penciller]')
-		add_to_table('inkers', 'Inkers: ', inkers, 'metadata[inker]')
-		add_to_table('letters', 'Letterers: ', letterers, 'metadata[letterer]')
-		add_to_table('editors', 'Editors: ', editors, 'metadata[editor]')
-		add_to_table('age_rating', 'Age Rating: ', age_rating, 'metadata[age_rating]')
-		add_to_table('year_published', 'Year: ', year, 'metadata[year]')
-
+	if (!metadata) {
 		return table
 	}
 
-	renderHeader() {
-		return (
-			<div className="flex flex-col items-center text-center tablet:items-start tablet:text-left">
-				<Heading size="sm">{formatBookName(this.media)}</Heading>
+	let add_to_table = (keynameBase: string, prefix: string, values: string[], searchKey: string) => {
+		if (values && values.length > 0) {
+			// if all values are empty, don't add the key
+			if (values.every((v) => !v)) {
+				return
+			}
 
-				{!!this.metadata_table.length && (
-					<div>
-						{this.metadata_table.map((metadata_row) => (
-							<div className="flex flex-row gap-1 space-x-2">
-								<Text>{metadata_row.prefix}</Text>
-								{metadata_row.values.map((element) => (
+			table.push({
+				keynameBase: keynameBase,
+				prefix: prefix,
+				values: values,
+				searchKey: searchKey,
+			})
+		}
+	}
+
+	const age_rating_num = metadata.age_rating ?? 0
+	const year_num = metadata.year ?? 0
+
+	const publishers = [metadata.publisher ?? '']
+	const characters = metadata.characters?.filter((c) => !!c) ?? []
+	const colorists = metadata.colorists?.filter((c) => !!c) ?? []
+	const writers = metadata.writers?.filter((w) => !!w) ?? []
+	const pencillers = metadata.pencillers?.filter((p) => !!p) ?? []
+	const inkers = metadata.inkers?.filter((i) => !!i) ?? []
+	const letterers = metadata.letterers?.filter((l) => !!l) ?? []
+	const editors = metadata.editors?.filter((e) => !!e) ?? []
+	const genres = metadata.genre?.filter((g) => !!g) ?? []
+	const age_rating = age_rating_num > 0 ? [age_rating_num.toString()] : []
+	const year = year_num > 0 ? [year_num.toString()] : []
+
+	add_to_table('writers', 'By ', writers, 'metadata[writer]')
+	add_to_table('publisher', 'Publisher: ', publishers, 'metadata[publisher]')
+	add_to_table('genres', 'Genres: ', genres, 'metadata[genre]')
+	add_to_table('characters', 'Characters: ', characters, 'metadata[character]')
+	add_to_table('colorists', 'Colorists: ', colorists, 'metadata[colorist]')
+	add_to_table('pencillers', 'Pencillers: ', pencillers, 'metadata[penciller]')
+	add_to_table('inkers', 'Inkers: ', inkers, 'metadata[inker]')
+	add_to_table('letters', 'Letterers: ', letterers, 'metadata[letterer]')
+	add_to_table('editors', 'Editors: ', editors, 'metadata[editor]')
+	add_to_table('age_rating', 'Age Rating: ', age_rating, 'metadata[age_rating]')
+	add_to_table('year_published', 'Year: ', year, 'metadata[year]')
+
+	return table
+}
+
+type Props = {
+	media: Media | null
+}
+export default function BookOverviewSceneHeader({ media }: Props) {
+	if (!media) {
+		return null
+	}
+
+	const metadata_table = build_metadata_table(media?.metadata ?? {})
+
+	return (
+		<div className="flex flex-col items-center text-center tablet:items-start tablet:text-left">
+			<Heading size="sm">{formatBookName(media)}</Heading>
+
+			{!!metadata_table.length && (
+				<div>
+					{metadata_table.map((metadata_row) => (
+						<div key={metadata_row.keynameBase} className="flex flex-row gap-1 space-x-2">
+							<Text>{metadata_row.prefix}</Text>
+							{metadata_row.values.map((element, index) => (
+								<div key={metadata_row.keynameBase + index}>
 									<SearchLinkBadge
-										key={metadata_row.keyname}
 										searchKey={metadata_row.searchKey}
 										text={element}
 									></SearchLinkBadge>
-								))}
-							</div>
-						))}
-					</div>
-				)}
+								</div>
+							))}
+						</div>
+					))}
+				</div>
+			)}
 
-				<BookLibrarySeriesLinks
-					libraryId={this.media.series?.library_id}
-					seriesId={this.media.series_id}
-					series={this.media.series}
-				/>
+			<BookLibrarySeriesLinks
+				libraryId={media.series?.library_id}
+				seriesId={media.series_id}
+				series={media.series}
+			/>
 
-				<TagList tags={this.media.tags || null} baseUrl={paths.bookSearch()} />
-			</div>
-		)
-	}
+			<TagList tags={media.tags || null} baseUrl={paths.bookSearch()} />
+		</div>
+	)
 }

--- a/packages/browser/src/scenes/book/BookOverviewSceneHeader.tsx
+++ b/packages/browser/src/scenes/book/BookOverviewSceneHeader.tsx
@@ -1,0 +1,110 @@
+import { Media, MediaMetadata } from '@stump/sdk'
+import { formatBookName } from '@/utils/format'
+import SearchLinkBadge from '@/components/SearchLinkBadge'
+import BookLibrarySeriesLinks from './BookLibrarySeriesLinks'
+import TagList from '@/components/tags/TagList'
+import { Heading, Text } from '@stump/components'
+import paths from '../../paths'
+
+interface MetadataTableItem {
+	keyname: string
+	prefix: string
+	values: string[]
+	searchKey: string
+}
+
+export default class BookOverviewSceneHeader {
+	media: Media
+	metadata_table: MetadataTableItem[]
+
+	constructor(media: Media) {
+		this.media = media
+		this.metadata_table = this.build_metadata_table(media.metadata ?? {})
+	}
+
+	build_metadata_table(metadata: MediaMetadata) {
+		let table: MetadataTableItem[] = []
+
+		if (!metadata) {
+			return table
+		}
+
+		let add_to_table = (keyname: string, prefix: string, values: string[], searchKey: string) => {
+			if (values && values.length > 0) {
+				// if all values are empty, don't add the key
+				if (values.every((v) => !v)) {
+					return
+				}
+
+				table.push({
+					keyname: keyname,
+					prefix: prefix,
+					values: values,
+					searchKey: searchKey,
+				})
+			}
+		}
+
+		const age_rating_num = metadata.age_rating ?? 0
+		const year_num = metadata.year ?? 0
+
+		const publishers = [metadata.publisher ?? '']
+		const characters = metadata.characters?.filter((c) => !!c) ?? []
+		const colorists = metadata.colorists?.filter((c) => !!c) ?? []
+		const writers = metadata.writers?.filter((w) => !!w) ?? []
+		const pencillers = metadata.pencillers?.filter((p) => !!p) ?? []
+		const inkers = metadata.inkers?.filter((i) => !!i) ?? []
+		const letterers = metadata.letterers?.filter((l) => !!l) ?? []
+		const editors = metadata.editors?.filter((e) => !!e) ?? []
+		const genres = metadata.genre?.filter((g) => !!g) ?? []
+		const age_rating = age_rating_num > 0 ? [age_rating_num.toString()] : []
+		const year = year_num > 0 ? [year_num.toString()] : []
+
+		add_to_table('writers', 'By ', writers, 'metadata[writer]')
+		add_to_table('publisher', 'Publisher: ', publishers, 'metadata[publisher]')
+		add_to_table('genres', 'Genres: ', genres, 'metadata[genre]')
+		add_to_table('characters', 'Characters: ', characters, 'metadata[character]')
+		add_to_table('colorists', 'Colorists: ', colorists, 'metadata[colorist]')
+		add_to_table('pencillers', 'Pencillers: ', pencillers, 'metadata[penciller]')
+		add_to_table('inkers', 'Inkers: ', inkers, 'metadata[inker]')
+		add_to_table('letters', 'Letterers: ', letterers, 'metadata[letterer]')
+		add_to_table('editors', 'Editors: ', editors, 'metadata[editor]')
+		add_to_table('age_rating', 'Age Rating: ', age_rating, 'metadata[age_rating]')
+		add_to_table('year_published', 'Year: ', year, 'metadata[year]')
+
+		return table
+	}
+
+	renderHeader() {
+		return (
+			<div className="flex flex-col items-center text-center tablet:items-start tablet:text-left">
+				<Heading size="sm">{formatBookName(this.media)}</Heading>
+
+				{!!this.metadata_table.length && (
+					<div>
+						{this.metadata_table.map((metadata_row) => (
+							<div className="flex flex-row gap-1 space-x-2">
+								<Text>{metadata_row.prefix}</Text>
+								{metadata_row.values.map((element) => (
+									<SearchLinkBadge
+										key={metadata_row.keyname}
+										searchKey={metadata_row.searchKey}
+										text={element}
+									></SearchLinkBadge>
+								))}
+							</div>
+						))}
+					</div>
+				)}
+
+				<BookLibrarySeriesLinks
+					libraryId={this.media.series?.library_id}
+					seriesId={this.media.series_id}
+					series={this.media.series}
+				/>
+
+				<TagList tags={this.media.tags || null} baseUrl={paths.bookSearch()} />
+			</div>
+		)
+	}
+}

--- a/packages/browser/src/scenes/book/BookOverviewSceneHeader.tsx
+++ b/packages/browser/src/scenes/book/BookOverviewSceneHeader.tsx
@@ -1,10 +1,12 @@
-import { Media, MediaMetadata } from '@stump/sdk'
-import { formatBookName } from '@/utils/format'
-import SearchLinkBadge from '@/components/SearchLinkBadge'
-import BookLibrarySeriesLinks from './BookLibrarySeriesLinks'
-import TagList from '@/components/tags/TagList'
 import { Heading, Text } from '@stump/components'
+import { Media, MediaMetadata } from '@stump/sdk'
+
+import SearchLinkBadge from '@/components/SearchLinkBadge'
+import TagList from '@/components/tags/TagList'
+import { formatBookName } from '@/utils/format'
+
 import paths from '../../paths'
+import BookLibrarySeriesLinks from './BookLibrarySeriesLinks'
 
 interface MetadataTableItem {
 	keynameBase: string
@@ -14,13 +16,18 @@ interface MetadataTableItem {
 }
 
 function build_metadata_table(metadata: MediaMetadata) {
-	let table: MetadataTableItem[] = []
+	const table: MetadataTableItem[] = []
 
 	if (!metadata) {
 		return table
 	}
 
-	let add_to_table = (keynameBase: string, prefix: string, values: string[], searchKey: string) => {
+	const add_to_table = (
+		keynameBase: string,
+		prefix: string,
+		values: string[],
+		searchKey: string,
+	) => {
 		if (values && values.length > 0) {
 			// if all values are empty, don't add the key
 			if (values.every((v) => !v)) {


### PR DESCRIPTION
Adds metadata into the book scene header. Each element links to a search page. I moved genres into this section but left the external links where they were.

The inspiration here came from [audibookshelf](https://audiobooks.dev/audiobookshelf/item/1551eb8a-7b16-48a7-9357-16af75d825d8) and audible. Both have a similar header section right below the titles with links to search results. The user/pass for the demo audiobookshelf is demo/demo. 

I also moved out the render header logic into a separate file. I generally try to keep files small, and this seemed link enough logic to move it out.