### PR TITLE
🐛 Fix directory listing performance issues

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -64,8 +64,11 @@ jobs:
         with:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_PASSWORD }}
-          tags: 'nightly'
-          load: ${{ env.LOAD }}
-          push: ${{ env.PUSH }}
+          # tags: 'nightly'
+          # load: ${{ env.LOAD }}
+          # push: ${{ env.PUSH }}
+          tags: 'nightly-fix-list-dir'
+          load: false
+          push: true
           archs: ${{ env.ARCHS }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -64,11 +64,8 @@ jobs:
         with:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_PASSWORD }}
-          # tags: 'nightly'
-          # load: ${{ env.LOAD }}
-          # push: ${{ env.PUSH }}
-          tags: 'nightly-fix-list-dir'
-          load: false
-          push: true
+          tags: 'nightly'
+          load: ${{ env.LOAD }}
+          push: ${{ env.PUSH }}
           archs: ${{ env.ARCHS }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7757,6 +7757,7 @@ dependencies = [
 name = "stump_server"
 version = "0.0.10"
 dependencies = [
+ "alphanumeric-sort",
  "async-stream",
  "async-trait",
  "axum",
@@ -7771,6 +7772,7 @@ dependencies = [
  "futures-util",
  "hyper 0.14.27",
  "infer",
+ "itertools 0.13.0",
  "jsonwebtoken",
  "linemux",
  "local-ip-address",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ version = "0.0.10"
 rust-version = "1.81.0"
 
 [workspace.dependencies]
+alphanumeric-sort = "1.5.3"
 async-trait = "0.1.81"
 async-stream = "0.3.5"
 base64 = "0.22.1"

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 default-run = "stump_server"
 
 [dependencies]
+alphanumeric-sort = { workspace = true }
 async-stream = { workspace = true }
 async-trait = { workspace = true }
 axum = { version = "0.7.5", features = [
@@ -24,6 +25,7 @@ chrono = { workspace = true }
 futures-util = { workspace = true }
 hyper = "0.14.27"
 infer = { workspace = true }
+itertools = { workspace = true }
 jsonwebtoken = "9.3.0"
 linemux = { git = "https://github.com/jmagnuson/linemux.git", rev = "acaafc602afac5d7a9cd3e087dafc937cac1e364" }
 local-ip-address = "0.6.2"

--- a/apps/server/src/routers/api/v1/filesystem.rs
+++ b/apps/server/src/routers/api/v1/filesystem.rs
@@ -107,7 +107,7 @@ pub async fn list_directory(
 fn read_and_filter_directory(
 	start_path: &Path,
 	ignore_params: DirectoryListingIgnoreParams,
-) -> Result<Vec<DirectoryListingFile>, std::io::Error> {
+) -> Result<Vec<DirectoryListingFile>, APIError> {
 	let listing = std::fs::read_dir(start_path)?;
 
 	let files = listing

--- a/apps/server/src/routers/api/v1/filesystem.rs
+++ b/apps/server/src/routers/api/v1/filesystem.rs
@@ -1,4 +1,5 @@
 use axum::{extract::Query, middleware, routing::post, Extension, Json, Router};
+use itertools::Itertools;
 use std::{
 	fs::DirEntry,
 	path::{Path, PathBuf},
@@ -69,10 +70,12 @@ pub async fn list_directory(
 		)));
 	}
 
-	let mut files = read_and_filter_directory(&start_path)?;
-
-	// Sort the files by name, ignore case
-	files.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+	let files = read_and_filter_directory(&start_path)?
+		.into_iter()
+		.sorted_by(|a, b| {
+			alphanumeric_sort::compare_path(a.name.to_lowercase(), b.name.to_lowercase())
+		})
+		.collect::<Vec<_>>();
 
 	trace!(
 		"{} files in directory listing for: {}",

--- a/apps/server/src/routers/api/v1/series.rs
+++ b/apps/server/src/routers/api/v1/series.rs
@@ -140,6 +140,8 @@ async fn get_series(
 	// series, total series count
 	let (series, series_count) = db
 		._transaction()
+		.with_max_wait(chrono::Duration::seconds(10).num_milliseconds() as u64)
+		.with_timeout(chrono::Duration::seconds(30).num_milliseconds() as u64)
 		.run(|client| async move {
 			let mut query = db.series().find_many(where_conditions.clone());
 			if load_media {

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -4,7 +4,7 @@ version = { workspace = true }
 edition = "2021"
 
 [dependencies]
-alphanumeric-sort = "1.5.3"
+alphanumeric-sort = { workspace = true }
 async-channel = "2.1.0"
 async-trait = { workspace = true }
 cuid = "1.3.2"

--- a/core/src/filesystem/directory_listing.rs
+++ b/core/src/filesystem/directory_listing.rs
@@ -6,15 +6,42 @@ use utoipa::ToSchema;
 
 use crate::filesystem::PathUtils;
 
+fn default_true() -> bool {
+	true
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize, Type, ToSchema)]
 pub struct DirectoryListingInput {
 	pub path: Option<String>,
+	#[serde(flatten, default)]
+	pub ignore_params: DirectoryListingIgnoreParams,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Type, ToSchema)]
+pub struct DirectoryListingIgnoreParams {
+	#[serde(default = "default_true")]
+	pub ignore_hidden: bool,
+	#[serde(default)]
+	pub ignore_files: bool,
+	#[serde(default)]
+	pub ignore_directories: bool,
+}
+
+impl Default for DirectoryListingIgnoreParams {
+	fn default() -> Self {
+		Self {
+			ignore_hidden: true,
+			ignore_files: false,
+			ignore_directories: false,
+		}
+	}
 }
 
 impl Default for DirectoryListingInput {
 	fn default() -> Self {
 		Self {
 			path: Some("/".to_string()),
+			ignore_params: DirectoryListingIgnoreParams::default(),
 		}
 	}
 }

--- a/core/src/filesystem/mod.rs
+++ b/core/src/filesystem/mod.rs
@@ -13,7 +13,8 @@ pub mod scanner;
 pub use common::*;
 pub use content_type::ContentType;
 pub use directory_listing::{
-	DirectoryListing, DirectoryListingFile, DirectoryListingInput,
+	DirectoryListing, DirectoryListingFile, DirectoryListingIgnoreParams,
+	DirectoryListingInput,
 };
 pub use error::FileError;
 pub use media::*;

--- a/packages/browser/src/components/DirectoryPickerModal.tsx
+++ b/packages/browser/src/components/DirectoryPickerModal.tsx
@@ -27,6 +27,10 @@ export default function DirectoryPickerModal({
 		useDirectoryListing({
 			enabled: isOpen,
 			initialPath: startingPath,
+			ignoreParams: {
+				ignore_files: true,
+				ignore_hidden: !showHidden,
+			},
 		})
 
 	const handleConfirm = useCallback(() => {

--- a/packages/browser/src/components/DirectoryPickerModal.tsx
+++ b/packages/browser/src/components/DirectoryPickerModal.tsx
@@ -1,8 +1,10 @@
 import { useDirectoryListing } from '@stump/client'
 import { Button, CheckBox, cx, Dialog, Input, Text, useBoolean } from '@stump/components'
 import { ArrowLeft, Folder } from 'lucide-react'
-import { useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import toast from 'react-hot-toast'
+import AutoSizer from 'react-virtualized-auto-sizer'
+import { Virtuoso, VirtuosoHandle } from 'react-virtuoso'
 
 interface Props {
 	isOpen: boolean
@@ -17,23 +19,28 @@ export default function DirectoryPickerModal({
 	startingPath,
 	onPathChange,
 }: Props) {
+	const virtuosoRef = useRef<VirtuosoHandle>(null)
+
 	const [showHidden, { toggle }] = useBoolean(false)
 
-	// FIXME: This component needs to render a *virtual* list AND pass a page param as the user scrolls
-	// down the list. I recently tested a directory with 1000+ files and it took a while to load. So,
-	// I am paging the results to 100 per page. Might reduce to 50.
-	const { errorMessage, path, directories, canGoBack, setPath, goBack } = useDirectoryListing({
-		enabled: isOpen,
-		initialPath: startingPath,
-		// TODO: page
-	})
+	const { errorMessage, path, directories, canGoBack, setPath, goBack, canLoadMore, loadMore } =
+		useDirectoryListing({
+			enabled: isOpen,
+			initialPath: startingPath,
+		})
 
-	function handleConfirm() {
+	const handleConfirm = useCallback(() => {
 		if (!errorMessage) {
 			onPathChange(path)
 			onClose()
 		}
-	}
+	}, [errorMessage, path, onPathChange, onClose])
+
+	const onLoadMore = useCallback(() => {
+		if (canLoadMore) {
+			loadMore()
+		}
+	}, [canLoadMore, loadMore])
 
 	useEffect(() => {
 		if (errorMessage) {
@@ -55,6 +62,17 @@ export default function DirectoryPickerModal({
 		}
 	}
 
+	/**
+	 * Scroll to the top of the list when the path changes, otherwise Virtuoso will
+	 * retain the scroll position which could land you in the middle of the list.
+	 */
+	useEffect(() => {
+		virtuosoRef.current?.scrollToIndex({
+			index: 0,
+			behavior: 'smooth',
+		})
+	}, [path])
+
 	return (
 		<Dialog open={isOpen} onOpenChange={handleOpenChange}>
 			<Dialog.Content size="md">
@@ -66,7 +84,7 @@ export default function DirectoryPickerModal({
 					<Dialog.Close onClick={onClose} />
 				</Dialog.Header>
 
-				<div className="flex flex-col space-y-2 overflow-hidden">
+				<div className="flex flex-col space-y-2 overflow-hidden p-1">
 					<div className="flex items-center space-x-2">
 						<Button
 							className="h-8 w-8 p-0 text-sm"
@@ -94,21 +112,35 @@ export default function DirectoryPickerModal({
 						/>
 					</div>
 
-					<div className="flex h-[20rem] flex-col divide-y divide-edge/75 overflow-y-auto px-1 pt-1 scrollbar-hide">
-						{directoryList.map((directory, i) => (
-							<button
-								key={directory.path}
-								className={cx('justify-start px-2 py-1.5 text-left hover:bg-background-surface', {
-									'bg-background-surface/40': i % 2 === 0,
-								})}
-								onClick={() => setPath(directory.path)}
-							>
-								<Text className="line-clamp-1 inline-flex items-center gap-x-2">
-									<Folder size="1.25rem" className="shrink-0" />
-									<span className="line-clamp-1">{directory.name}</span>
-								</Text>
-							</button>
-						))}
+					<div className="flex h-[20rem] flex-col divide-y divide-edge/75 overflow-hidden">
+						<AutoSizer>
+							{({ height, width }) => (
+								<Virtuoso
+									ref={virtuosoRef}
+									className="overflow-x-hidden"
+									style={{ height, width }}
+									data={directoryList}
+									itemContent={(index, directory) => (
+										<button
+											className={cx(
+												'my-0.5 w-full justify-start rounded-lg px-2 py-1.5 text-left hover:bg-background-surface',
+												{
+													'bg-background-surface/40': index % 2 === 0,
+												},
+											)}
+											onClick={() => setPath(directory.path)}
+										>
+											<Text className="line-clamp-1 inline-flex items-center gap-x-2">
+												<Folder size="1.25rem" className="shrink-0" />
+												<span className="line-clamp-1">{directory.name}</span>
+											</Text>
+										</button>
+									)}
+									endReached={onLoadMore}
+									increaseViewportBy={5 * (320 / 3)}
+								/>
+							)}
+						</AutoSizer>
 					</div>
 				</div>
 

--- a/packages/browser/src/components/explorer/context.ts
+++ b/packages/browser/src/components/explorer/context.ts
@@ -15,6 +15,8 @@ export type IExplorerContext = {
 	currentPath: string | null
 	rootPath: string
 	files: DirectoryListingFile[]
+	canLoadMore: boolean
+	loadMore: () => void
 	onSelect: (item: DirectoryListingFile) => void
 	canGoBack: boolean
 	canGoForward: boolean

--- a/packages/browser/src/components/explorer/grid/FileGrid.tsx
+++ b/packages/browser/src/components/explorer/grid/FileGrid.tsx
@@ -6,7 +6,7 @@ import { useFileExplorerContext } from '../context'
 import FileGridItem from './FileGridItem'
 
 export default function FileGrid() {
-	const { files } = useFileExplorerContext()
+	const { files, loadMore } = useFileExplorerContext()
 
 	const renderItem = (idx: number) => {
 		const file = files[idx]
@@ -29,6 +29,7 @@ export default function FileGrid() {
 						itemClassName="py-1.5"
 						itemContent={renderItem}
 						overscan={{ main: 15, reverse: 10 }}
+						endReached={loadMore}
 					/>
 				)}
 			</AutoSizer>

--- a/packages/browser/src/components/explorer/table/FileTable.tsx
+++ b/packages/browser/src/components/explorer/table/FileTable.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import { cn, Text } from '@stump/components'
 import { DirectoryListingFile } from '@stump/sdk'
 import {
@@ -11,6 +12,7 @@ import {
 } from '@tanstack/react-table'
 import { useMemo, useState } from 'react'
 import AutoSizer from 'react-virtualized-auto-sizer'
+import { TableVirtuoso } from 'react-virtuoso'
 import { useWindowSize } from 'rooks'
 
 import { SortIcon } from '@/components/table'
@@ -37,28 +39,38 @@ const baseColumns = [
 ]
 
 export default function FileTable() {
-	const { files, onSelect } = useFileExplorerContext()
+	const { files, onSelect, loadMore } = useFileExplorerContext()
 	const { innerWidth } = useWindowSize()
 
 	const [sorting, setSorting] = useState<SortingState>([])
 
 	const columns = useMemo(
-		() => [
-			...baseColumns.slice(0, 1),
-			columnHelper.accessor('name', {
-				cell: ({ row: { original: file }, getValue }) => (
-					<Text size="sm" className="cursor-pointer hover:underline" onClick={() => onSelect(file)}>
-						{getValue()}
-					</Text>
-				),
-				header: () => (
-					<Text size="sm" variant="secondary">
-						Name
-					</Text>
-				),
-				size: innerWidth ? innerWidth * 0.2 : 250,
-			}),
-		],
+		() =>
+			[
+				...baseColumns.slice(0, 1),
+				columnHelper.accessor('name', {
+					cell: ({ row: { original: file }, getValue }) => (
+						<Text
+							size="sm"
+							className="cursor-pointer hover:underline"
+							onClick={() => onSelect(file)}
+						>
+							{getValue()}
+						</Text>
+					),
+					header: () => (
+						<Text size="sm" variant="secondary">
+							Name
+						</Text>
+					),
+					size: innerWidth ? innerWidth * 0.2 : 250,
+				}),
+			].map((column) => ({
+				...column,
+				// TODO: Allow sorting once the API supports it, otherwise we sort the current page and not the whole dataset
+				// which is obviously not what we want
+				enableSorting: false,
+			})),
 		[onSelect, innerWidth],
 	)
 
@@ -81,60 +93,27 @@ export default function FileTable() {
 		<div className="relative mb-5 h-full w-full flex-1 flex-grow">
 			<AutoSizer>
 				{({ height, width }) => (
-					<div
-						className={cn('h-full min-w-full overflow-x-auto', {
-							'scrollbar-hide': true,
-						})}
-						style={{
-							height,
-							width,
-						}}
-					>
-						<table
-							className="min-w-full table-fixed"
-							style={{
-								width: table.getCenterTotalSize(),
-							}}
-						>
-							<thead>
-								<tr>
-									{table.getFlatHeaders().map((header) => {
-										const isSortable = header.column.getCanSort()
-										return (
-											<th
-												key={header.id}
-												className="h-10 pl-1.5 pr-1.5 first:pl-4 last:pr-4"
-												style={{
-													width: header.getSize(),
-												}}
-											>
-												<div
-													className={cn('flex items-center', {
-														'cursor-pointer select-none gap-x-2': isSortable,
-													})}
-													onClick={header.column.getToggleSortingHandler()}
-													style={{
-														width: header.getSize(),
-													}}
-												>
-													{flexRender(header.column.columnDef.header, header.getContext())}
+					<TableVirtuoso
+						style={{ height, width }}
+						totalCount={rows.length}
+						components={{
+							Table: (props) => (
+								<table
+									{...props}
+									className="min-w-full table-fixed"
+									style={{
+										width: table.getCenterTotalSize(),
+									}}
+								/>
+							),
+							TableRow: (props) => {
+								const index = props['data-index']
+								const isEven = index % 2 === 0
+								const row = rows[index]
 
-													{isSortable && (
-														<SortIcon
-															direction={(header.column.getIsSorted() as SortDirection) ?? null}
-														/>
-													)}
-												</div>
-											</th>
-										)
-									})}
-								</tr>
-							</thead>
-
-							<tbody>
-								{rows.map((row) => (
-									<tr key={row.id} className="odd:bg-background-surface">
-										{row.getVisibleCells().map((cell) => (
+								return (
+									<tr {...props} className={cn({ 'bg-background-surface': !isEven })}>
+										{row?.getVisibleCells().map((cell) => (
 											<td
 												className="py-1 pl-1.5 pr-1.5 first:pl-4 last:pr-4"
 												key={cell.id}
@@ -146,10 +125,40 @@ export default function FileTable() {
 											</td>
 										))}
 									</tr>
-								))}
-							</tbody>
-						</table>
-					</div>
+								)
+							},
+						}}
+						fixedHeaderContent={() =>
+							table.getFlatHeaders().map((header) => (
+								<th
+									key={header.id}
+									className="h-10 bg-background pl-1.5 pr-1.5 first:pl-4 last:pr-4"
+									style={{
+										width: header.getSize(),
+									}}
+								>
+									<div
+										className={cn('flex items-center', {
+											'cursor-pointer select-none gap-x-2': header.column.getCanSort(),
+										})}
+										onClick={header.column.getToggleSortingHandler()}
+										style={{
+											width: header.getSize(),
+										}}
+									>
+										{flexRender(header.column.columnDef.header, header.getContext())}
+
+										{header.column.getCanSort() && (
+											<SortIcon
+												direction={(header.column.getIsSorted() as SortDirection) ?? null}
+											/>
+										)}
+									</div>
+								</th>
+							))
+						}
+						endReached={loadMore}
+					/>
 				)}
 			</AutoSizer>
 		</div>

--- a/packages/browser/src/components/table/EntityTable.tsx
+++ b/packages/browser/src/components/table/EntityTable.tsx
@@ -135,7 +135,7 @@ export default function EntityTable<Entity>({
 						<tr key={row.id} className="odd:bg-background-surface">
 							{row.getVisibleCells().map((cell) => (
 								<td
-									className="h-14 pl-1.5 pr-1.5 first:pl-4 last:pr-4"
+									className="py-1 pl-1.5 pr-1.5 first:pl-4 last:pr-4"
 									key={cell.id}
 									style={{
 										width: cell.column.getSize(),

--- a/packages/browser/src/scenes/home/RecentlyAddedSeries.tsx
+++ b/packages/browser/src/scenes/home/RecentlyAddedSeries.tsx
@@ -19,6 +19,8 @@ function RecentlyAddedSeries() {
 		},
 		queryKey: [sdk.series.keys.recentlyAdded],
 		suspense: true,
+		useErrorBoundary: false,
+		retry: (attempts) => attempts < 3,
 	})
 
 	const cards = series.map((series) => (

--- a/packages/client/src/queries/filesystem.ts
+++ b/packages/client/src/queries/filesystem.ts
@@ -1,7 +1,7 @@
 import { AxiosError } from 'axios'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
-import { queryClient, useQuery } from '../client'
+import { queryClient, useInfiniteQuery, useQuery } from '../client'
 import { useSDK } from '../sdk'
 
 type PrefetchFileParams = {
@@ -86,18 +86,53 @@ export function useDirectoryListing({
 	const [history, setHistory] = useState(currentPath ? [currentPath] : [])
 	const [currentIndex, setCurrentIndex] = useState(0)
 
-	const { isLoading, error, data, refetch } = useQuery(
-		[sdk.filesystem.keys.listDirectory, currentPath, page],
-		async () => sdk.filesystem.listDirectory({ page, path: currentPath }),
+	const [initialPage, setInitialPage] = useState(() => page)
+
+	const { isLoading, error, data, refetch, ...rest } = useInfiniteQuery(
+		[sdk.filesystem.keys.listDirectory, currentPath, initialPage],
+		async ({ pageParam }) => sdk.filesystem.listDirectory({ page: pageParam, path: currentPath }),
 		{
 			// Do not run query until `enabled` aka modal is opened.
 			enabled,
 			keepPreviousData: true,
 			suspense: false,
+			getNextPageParam: (lastPage) => {
+				const totalPages = lastPage?._page?.total_pages
+				const currentPage = lastPage?._page?.current_page
+				if (totalPages == null || currentPage == null) {
+					return undefined
+				}
+				return currentPage < totalPages ? currentPage + 1 : undefined
+			},
+			getPreviousPageParam: (firstPage) => {
+				const currentPage = firstPage?._page?.current_page
+				if (currentPage == null) {
+					return undefined
+				}
+				return currentPage > 1 ? currentPage - 1 : undefined
+			},
 		},
 	)
 
-	const directoryListing = data?.data
+	/**
+	 * Whenever the current path changes, reset the initial page to 1. This is because
+	 * we are using a somewhat complex pagination state that is shared between different
+	 * directories. For example, if I scroll 4 pages deep into one directory, then switch
+	 * to another directory, the new directory should start at page 1.
+	 */
+	useEffect(() => {
+		setInitialPage(1)
+	}, [currentPath])
+
+	const directoryListing = data?.pages
+		.flatMap((page) => page.data)
+		.reduce(
+			(acc, curr) => ({
+				files: [...acc.files, ...curr.files],
+				parent: curr.parent,
+			}),
+			{ files: [], parent: null },
+		)
 	const parent = directoryListing?.parent
 
 	useEffect(() => {
@@ -251,6 +286,8 @@ export function useDirectoryListing({
 		path: currentPath,
 		refetch,
 		setPath,
+		canLoadMore: rest.hasNextPage || false,
+		loadMore: rest.fetchNextPage,
 	}
 }
 

--- a/packages/client/src/queries/filesystem.ts
+++ b/packages/client/src/queries/filesystem.ts
@@ -1,3 +1,4 @@
+import { DirectoryListingInput } from '@stump/sdk'
 import { AxiosError } from 'axios'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
@@ -54,6 +55,10 @@ export type DirectoryListingQueryParams = {
 	 */
 	initialPath?: string
 	/**
+	 * Additional parameters to pass to the directory listing query.
+	 */
+	ignoreParams?: Omit<DirectoryListingInput, 'path'>
+	/**
 	 * The minimum path that can be queried for. This is useful for enforcing no access to parent
 	 * directories relative to the enforcedRoot.
 	 */
@@ -76,6 +81,7 @@ export type DirectoryListingQueryParams = {
 export function useDirectoryListing({
 	enabled,
 	initialPath,
+	ignoreParams = { ignore_hidden: true },
 	enforcedRoot,
 	page = 1,
 	onGoForward,
@@ -89,8 +95,9 @@ export function useDirectoryListing({
 	const [initialPage, setInitialPage] = useState(() => page)
 
 	const { isLoading, error, data, refetch, ...rest } = useInfiniteQuery(
-		[sdk.filesystem.keys.listDirectory, currentPath, initialPage],
-		async ({ pageParam }) => sdk.filesystem.listDirectory({ page: pageParam, path: currentPath }),
+		[sdk.filesystem.keys.listDirectory, currentPath, ignoreParams, initialPage],
+		async ({ pageParam }) =>
+			sdk.filesystem.listDirectory({ page: pageParam, path: currentPath, ...ignoreParams }),
 		{
 			// Do not run query until `enabled` aka modal is opened.
 			enabled,

--- a/packages/sdk/src/controllers/filesystem-api.ts
+++ b/packages/sdk/src/controllers/filesystem-api.ts
@@ -17,10 +17,10 @@ const filesystemURL = createRouteURLHandler(FILESYSTEM_ROUTE)
  */
 export class FilesystemAPI extends APIBase {
 	async listDirectory(
-		input?: DirectoryListingInput & { page?: number },
+		{ page, ...input }: DirectoryListingInput & { page?: number } = { page: 1, path: null },
 	): Promise<Pageable<DirectoryListing>> {
 		const { data: listing } = await this.axios.post<Pageable<DirectoryListing>>(
-			filesystemURL('', input),
+			filesystemURL('', { page }),
 			input,
 		)
 		return listing

--- a/packages/sdk/src/types/generated.ts
+++ b/packages/sdk/src/types/generated.ts
@@ -310,7 +310,7 @@ export type DirectoryListing = { parent: string | null; files: DirectoryListingF
 
 export type DirectoryListingFile = { is_directory: boolean; name: string; path: string }
 
-export type DirectoryListingInput = { path: string | null }
+export type DirectoryListingInput = ({ ignore_hidden?: boolean; ignore_files?: boolean; ignore_directories?: boolean }) & { path: string | null }
 
 export type Direction = "asc" | "desc"
 


### PR DESCRIPTION
Relates to https://github.com/stumpapp/stump/issues/589

This PR should fix an issue where really large directories don't render anything in the picker modal when creating a library. I've programmatically created a folder with 100,000 (tiny) ZIP files as a test, but haven't done any real world tests. I'll try and get validation before merging this