### PR TITLE
:sparkles: Add hardcover source

### DIFF
--- a/crates/metadata_sources/src/lib.rs
+++ b/crates/metadata_sources/src/lib.rs
@@ -42,6 +42,7 @@ pub const REGISTERED_SOURCES: &[&str] = &[
 	open_library::SOURCE_NAME,
 	google_books::SOURCE_NAME,
 	comicvine::SOURCE_NAME,
+	hardcover::SOURCE_NAME,
 ];
 
 /// Information provided to a [`MetadataSource`] implementation to locate the correct metadata.
@@ -123,6 +124,7 @@ pub fn get_source_by_name(
 		open_library::SOURCE_NAME => Ok(Box::new(open_library::OpenLibrarySource)),
 		google_books::SOURCE_NAME => Ok(Box::new(google_books::GoogleBooksSource)),
 		comicvine::SOURCE_NAME => Ok(Box::new(comicvine::ComicVineSource)),
+		hardcover::SOURCE_NAME => Ok(Box::new(hardcover::HardcoverSource)),
 		_ => Err(MetadataSourceError::InvalidName(name.to_string())),
 	}
 }

--- a/crates/metadata_sources/src/sources/hardcover/mod.rs
+++ b/crates/metadata_sources/src/sources/hardcover/mod.rs
@@ -1,0 +1,158 @@
+//! This module contains the [Hardcover](https://docs.hardcover.app/) implementation of
+//! the [`MetadataSource`] trait.
+
+mod request;
+mod response;
+
+use request::build_request;
+use response::HardcoverResponse;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+	ConfigSchema, MetadataOutput, MetadataSource, MetadataSourceError,
+	MetadataSourceInput,
+};
+
+/// The name used to identify the source in the database, retrieve the [`MetadataSource`]
+/// implementation, and displayed to the user in the UI.
+pub const SOURCE_NAME: &str = "Hardcover";
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(default)]
+pub struct HardcoverConfig {
+	api_key: Option<String>,
+	max_result_count: u32,
+}
+
+impl Default for HardcoverConfig {
+	fn default() -> Self {
+		Self {
+			api_key: Default::default(),
+			max_result_count: 10,
+		}
+	}
+}
+
+/// Implements metadata retrieval using the Hardcover API.
+pub struct HardcoverSource;
+
+#[async_trait::async_trait]
+impl MetadataSource for HardcoverSource {
+	fn name(&self) -> &'static str {
+		SOURCE_NAME
+	}
+
+	async fn get_metadata(
+		&self,
+		input: &MetadataSourceInput,
+		config: &Option<String>,
+	) -> Result<Vec<MetadataOutput>, MetadataSourceError> {
+		// Parse config JSON or error
+		let config: HardcoverConfig = if let Some(cfg_json) = config {
+			serde_json::from_str(cfg_json)?
+		} else {
+			return Err(MetadataSourceError::ConfigError(
+				"No Hardcover config provided.".to_string(),
+			));
+		};
+
+		// We can't proceed without an api key
+		let Some(api_key) = config.api_key else {
+			return Err(MetadataSourceError::ConfigError(
+				"An API key is necessary to use the Hardcover metadata source."
+					.to_string(),
+			));
+		};
+
+		// Make the request
+		let client = reqwest::Client::new();
+		let request = build_request(&client, input, api_key, config.max_result_count)?;
+		let response = request.send().await?.json::<HardcoverResponse>().await?;
+
+		// TODO - Remove
+		println!("{response:?}");
+
+		// Convert response items into MetadataOutput
+		if let Some(items) = response.data.search.results.hits {
+			if !items.is_empty() {
+				let metadata_outputs: Vec<MetadataOutput> = items
+					.into_iter()
+					.map(|item: response::Hit| MetadataOutput {
+						title: item.document.title,
+						authors: item.document.author_names,
+						description: item.document.description,
+						published: item.document.release_date,
+					})
+					.collect();
+				return Ok(metadata_outputs);
+			}
+		}
+
+		// Return an error if response.items was None or empty
+		return Err(MetadataSourceError::ResponseError(
+			"Hardcover response contained no items.".to_string(),
+		));
+	}
+
+	fn get_config_schema(&self) -> Option<ConfigSchema> {
+		Some(ConfigSchema::from(schemars::schema_for!(HardcoverConfig)))
+	}
+
+	fn get_default_config(&self) -> Option<String> {
+		Some(
+			serde_json::to_string(&HardcoverConfig::default())
+				.expect("HardcoverConfig should be serializable."),
+		)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	const API_KEY: &str = "_";
+
+	#[tokio::test]
+	async fn title_test() {
+		let source = HardcoverSource;
+
+		let test_input = MetadataSourceInput {
+			title: Some("Dune".to_string()),
+			..Default::default()
+		};
+
+		let test_config = format!("{{ \"api_key\": \"{API_KEY}\" }}").to_string();
+
+		let metadata_output = source
+			.get_metadata(&test_input, &Some(test_config))
+			.await
+			.unwrap();
+		let first_metadata = metadata_output
+			.first()
+			.expect("Expected at least one metadata entry");
+
+		assert_eq!(first_metadata.title.as_deref(), Some("Dune"));
+	}
+
+	#[tokio::test]
+	async fn isbn_test() {
+		let source = HardcoverSource;
+
+		let test_input = MetadataSourceInput {
+			isbn: Some("9780425027066".to_string()),
+			..Default::default()
+		};
+
+		let test_config = format!("{{ \"api_key\": \"{API_KEY}\" }}").to_string();
+
+		let metadata_output = source
+			.get_metadata(&test_input, &Some(test_config))
+			.await
+			.unwrap();
+		let first_metadata = metadata_output
+			.first()
+			.expect("Expected at least one metadata entry");
+
+		assert_eq!(first_metadata.title.as_deref(), Some("Dune"));
+	}
+}

--- a/crates/metadata_sources/src/sources/hardcover/request.rs
+++ b/crates/metadata_sources/src/sources/hardcover/request.rs
@@ -1,0 +1,37 @@
+use crate::{MetadataSourceError, MetadataSourceInput};
+use reqwest::{Client, RequestBuilder};
+
+/// The base url used to access the Hardcover API.
+const BASE_URL: &str = "https://api.hardcover.app/v1/graphql";
+
+pub fn build_request(
+	request_client: &Client,
+	input: &MetadataSourceInput,
+	api_key: String,
+	max_result_count: u32,
+) -> Result<RequestBuilder, MetadataSourceError> {
+	// Build query
+	let query;
+	if let Some(title) = input.title.clone() {
+		// from title
+		query = serde_json::json!({
+		"query": format!("query Search {{ search(query: \"{title}\", query_type: \"Book\", per_page: {max_result_count}, page: 1 ) {{results}}}}")
+		});
+	} else if let Some(isbn) = input.isbn.clone() {
+		// from isbn
+		query = serde_json::json!({
+		"query": format!("query Search {{ search(query: \"{isbn}\", query_type: \"Book\", per_page: {max_result_count}, page: 1 ) {{results}}}}")
+		});
+	} else {
+		return Err(MetadataSourceError::IncompatibleInput(
+			"missing title and / or isbn".to_string(),
+		));
+	}
+
+	// Build request
+	Ok(request_client
+		.post(BASE_URL)
+		.header("Content-Type", "application/json")
+		.header("authorization", api_key)
+		.json(&query))
+}

--- a/crates/metadata_sources/src/sources/hardcover/response.rs
+++ b/crates/metadata_sources/src/sources/hardcover/response.rs
@@ -1,0 +1,46 @@
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct HardcoverResponse {
+	pub data: SearchData,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SearchData {
+	pub search: SearchResults,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SearchResults {
+	pub results: HitsContainer,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HitsContainer {
+	pub hits: Option<Vec<Hit>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Hit {
+	pub document: Document,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Document {
+	pub title: Option<String>,
+	pub activities_count: u32,
+	pub id: String,
+	pub isbns: Vec<String>,
+	pub series_names: Vec<String>,
+	pub author_names: Vec<String>,
+	pub description: Option<String>,
+	pub featured_series: Option<FeaturedSeries>,
+	pub release_date: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FeaturedSeries {
+	pub series_name: Option<String>,
+	pub position: Option<f32>,
+	pub series_book_count: Option<u32>,
+}

--- a/crates/metadata_sources/src/sources/mod.rs
+++ b/crates/metadata_sources/src/sources/mod.rs
@@ -1,3 +1,4 @@
 pub mod comicvine;
 pub mod google_books;
+pub mod hardcover;
 pub mod open_library;


### PR DESCRIPTION
A proof of concept for interacting with the hardcover API for fetching book data.
Tests both title search and ISBN search.