### PR TITLE
:sparkles: Add clickable progress bar for epubs

### DIFF
--- a/packages/browser/src/components/readers/epub/EpubJsReader.tsx
+++ b/packages/browser/src/components/readers/epub/EpubJsReader.tsx
@@ -207,9 +207,13 @@ export default function EpubJsReader({ id, initialCfi }: EpubJsReaderProps) {
 			if (book.spine) {
 				const defaultLoc = book.rendition?.location?.start?.cfi
 
+				const boundingClient = ref.current?.getBoundingClientRect()
+				const height = boundingClient?.height ? boundingClient.height - 2 : '100%'
+				const width = boundingClient?.width ?? '100%'
+
 				const rendition_ = book.renderTo(ref.current!, {
-					height: '100%',
-					width: '100%',
+					width,
+					height,
 				})
 
 				//? TODO: I guess here I would need to wait for and load in custom theme blobs...
@@ -494,7 +498,7 @@ export default function EpubJsReader({ id, initialCfi }: EpubJsReaderProps) {
 				percentage,
 			})
 		}
-	}, [currentLocation, spineSize])
+	}, [currentLocation, spineSize, epub, sdk.epub])
 
 	/**
 	 * A callback for attempting to extract preview text from a given cfi. This is used for bookmarks,
@@ -634,7 +638,7 @@ export default function EpubJsReader({ id, initialCfi }: EpubJsReaderProps) {
 			<div className="h-full w-full">
 				<AutoSizer>
 					{({ height, width }) => {
-						return <div ref={ref} style={{ height, width }} />
+						return <div ref={ref} key={epub.media_entity.id} style={{ height, width }} />
 					}}
 				</AutoSizer>
 			</div>

--- a/packages/browser/src/components/readers/epub/EpubReaderContainer.tsx
+++ b/packages/browser/src/components/readers/epub/EpubReaderContainer.tsx
@@ -13,6 +13,7 @@ type Props = {
 		| 'onLinkClick'
 		| 'onPaginateBackward'
 		| 'onPaginateForward'
+		| 'jumpToSection'
 		| 'getCfiPreviewText'
 		| 'searchEntireBook'
 		| 'onGoToCfi'

--- a/packages/browser/src/components/readers/epub/EpubReaderFooter.tsx
+++ b/packages/browser/src/components/readers/epub/EpubReaderFooter.tsx
@@ -1,11 +1,7 @@
-import { useEpubReader } from '@stump/client'
-import { ProgressBar, Text } from '@stump/components'
-import { cx } from '@stump/components'
-import { ArrowLeft, ArrowRight } from 'lucide-react'
+import { Text } from '@stump/components'
 
 import { useEpubReaderContext, useEpubReaderControls } from './context'
 import { ControlsContainer } from './controls'
-import ControlButton from './controls/ControlButton'
 
 /**
  * A component that shows at the bottom of the epub reader that shows, at least
@@ -23,15 +19,8 @@ function getSectionWidths(sectionsLengths: { [key: number]: number }) {
 }
 
 export default function EpubReaderFooter() {
-	const { visible, jumpToSection } = useEpubReaderControls()
+	const { jumpToSection } = useEpubReaderControls()
 	const { bookMeta } = useEpubReaderContext().readerMeta
-	const { readingDirection } = useEpubReader((state) => ({
-		readingDirection: state.preferences.readingDirection,
-	}))
-
-	const invertControls = readingDirection === 'rtl'
-
-	const [forwardOffset, backwardOffset] = invertControls ? [-1, 1] : [1, -1]
 
 	const visiblePages = (bookMeta?.chapter.currentPage ?? []).filter(Boolean)
 	const pagesVisible = visiblePages.length
@@ -57,44 +46,33 @@ export default function EpubReaderFooter() {
 
 	return (
 		<div>
-			<ControlsContainer position="bottom">
-				<Text size="sm" variant="muted">
-					{chapterName} ({virtualPage}/{virtualPageCount})
-				</Text>
+			<ControlsContainer position="bottom" className="h-[33px]">
+				<div className="z-50 flex flex-1 flex-col gap-y-1">
+					<div>
+						<Text size="xs" variant="muted">
+							{chapterName} ({virtualPage}/{virtualPageCount})
+						</Text>
+					</div>
+
+					<div className="flex flex-1 items-center justify-center space-x-px">
+						{sectionWidthKeys.map((index) => (
+							<div
+								key={`section-${index}`}
+								className="relative h-[5px] cursor-pointer bg-foreground-muted/50"
+								style={{ width: `${sectionWidths[index] ? sectionWidths[index] : 0}%` }}
+								onClick={() => jumpToSection(index)}
+							>
+								{index === currentSectionIndex && (
+									<div
+										className="absolute top-0 h-full w-[2px] bg-foreground-muted"
+										style={{ left: `${chapterProgress}%` }}
+									/>
+								)}
+							</div>
+						))}
+					</div>
+				</div>
 			</ControlsContainer>
-			<div className="flex items-center justify-center space-x-px">
-				<ControlButton
-					className={cx({ hidden: !visible })}
-					onClick={() => jumpToSection(currentSectionIndex + backwardOffset)}
-				>
-					<ArrowLeft className={cx({ hidden: !visible }) + ' h-4 w-4'} />
-				</ControlButton>
-				{!!sectionWidthKeys.length &&
-					sectionWidthKeys.map((index) => (
-						<ProgressBar
-							key={index}
-							value={
-								index < currentSectionIndex
-									? 100
-									: index === currentSectionIndex
-										? chapterProgress
-										: 0
-							}
-							size={index == currentSectionIndex ? 'lg' : 'default'}
-							rounded={'default'}
-							variant={index == currentSectionIndex ? 'primary' : 'default'}
-							className={cx({ hidden: !visible })}
-							style={{ width: `${sectionWidths[index] ? sectionWidths[index] : 0}%` }}
-							onClick={() => jumpToSection(index)}
-						></ProgressBar>
-					))}
-				<ControlButton
-					className={cx({ hidden: !visible })}
-					onClick={() => jumpToSection(currentSectionIndex + forwardOffset)}
-				>
-					<ArrowRight className={cx({ hidden: !visible }) + ' h-4 w-4'} />
-				</ControlButton>
-			</div>
 		</div>
 	)
 }

--- a/packages/browser/src/components/readers/epub/EpubReaderFooter.tsx
+++ b/packages/browser/src/components/readers/epub/EpubReaderFooter.tsx
@@ -1,15 +1,37 @@
-import { Text } from '@stump/components'
+import { useEpubReader } from '@stump/client'
+import { ProgressBar, Text } from '@stump/components'
+import { cx } from '@stump/components'
+import { ArrowLeft, ArrowRight } from 'lucide-react'
 
-import { useEpubReaderContext } from './context'
+import { useEpubReaderContext, useEpubReaderControls } from './context'
 import { ControlsContainer } from './controls'
+import ControlButton from './controls/ControlButton'
 
-// TODO: I LOVE Yomu's footer controls! I want to make something like that!
 /**
  * A component that shows at the bottom of the epub reader that shows, at least
  * currently, mostly the number of pages left in the current chapter
  */
+function getSectionWidths(sectionsLengths: { [key: number]: number }) {
+	const totalLength = Object.values(sectionsLengths).reduce((acc, length) => acc + length, 0)
+	const chapterWidths: { [key: number]: number } = {}
+
+	Object.entries(sectionsLengths).forEach(([keyStr, length]) => {
+		const key = parseInt(keyStr)
+		chapterWidths[key] = (length / totalLength) * 100.0
+	})
+	return chapterWidths
+}
+
 export default function EpubReaderFooter() {
+	const { visible, jumpToSection } = useEpubReaderControls()
 	const { bookMeta } = useEpubReaderContext().readerMeta
+	const { readingDirection } = useEpubReader((state) => ({
+		readingDirection: state.preferences.readingDirection,
+	}))
+
+	const invertControls = readingDirection === 'rtl'
+
+	const [forwardOffset, backwardOffset] = invertControls ? [-1, 1] : [1, -1]
 
 	const visiblePages = (bookMeta?.chapter.currentPage ?? []).filter(Boolean)
 	const pagesVisible = visiblePages.length
@@ -25,12 +47,54 @@ export default function EpubReaderFooter() {
 	const currentPage = visiblePages[0] || 1
 	const virtualPage = Math.ceil(currentPage / pagesVisible)
 	const virtualPageCount = Math.ceil(chapterPageCount / pagesVisible)
+	const chapterProgress = Math.ceil((virtualPage / virtualPageCount) * 100)
+	const currentSectionIndex = bookMeta?.chapter.sectionSpineIndex ?? -1
+	const sectionWidths = getSectionWidths(bookMeta?.sectionLengths || {})
+
+	const sectionWidthKeys = Object.keys(sectionWidths)
+		.map((key) => parseInt(key))
+		.sort((a, b) => a - b)
 
 	return (
-		<ControlsContainer position="bottom">
-			<Text size="sm" variant="muted">
-				{chapterName} ({virtualPage}/{virtualPageCount})
-			</Text>
-		</ControlsContainer>
+		<div>
+			<ControlsContainer position="bottom">
+				<Text size="sm" variant="muted">
+					{chapterName} ({virtualPage}/{virtualPageCount})
+				</Text>
+			</ControlsContainer>
+			<div className="flex items-center justify-center space-x-px">
+				<ControlButton
+					className={cx({ hidden: !visible })}
+					onClick={() => jumpToSection(currentSectionIndex + backwardOffset)}
+				>
+					<ArrowLeft className={cx({ hidden: !visible }) + ' h-4 w-4'} />
+				</ControlButton>
+				{!!sectionWidthKeys.length &&
+					sectionWidthKeys.map((index) => (
+						<ProgressBar
+							key={index}
+							value={
+								index < currentSectionIndex
+									? 100
+									: index === currentSectionIndex
+										? chapterProgress
+										: 0
+							}
+							size={index == currentSectionIndex ? 'lg' : 'default'}
+							rounded={'default'}
+							variant={index == currentSectionIndex ? 'primary' : 'default'}
+							className={cx({ hidden: !visible })}
+							style={{ width: `${sectionWidths[index] ? sectionWidths[index] : 0}%` }}
+							onClick={() => jumpToSection(index)}
+						></ProgressBar>
+					))}
+				<ControlButton
+					className={cx({ hidden: !visible })}
+					onClick={() => jumpToSection(currentSectionIndex + forwardOffset)}
+				>
+					<ArrowRight className={cx({ hidden: !visible }) + ' h-4 w-4'} />
+				</ControlButton>
+			</div>
+		</div>
 	)
 }

--- a/packages/browser/src/components/readers/epub/context.ts
+++ b/packages/browser/src/components/readers/epub/context.ts
@@ -8,6 +8,8 @@ export type EpubReaderChapterMeta = {
 	name?: string
 	/** The chapter's position in the book. */
 	position?: number
+	/** The chapter's index in the spine */
+	sectionSpineIndex?: number
 	/** The chapter's total number of pages. */
 	totalPages?: number
 	/**
@@ -24,6 +26,7 @@ export type EpubReaderChapterMeta = {
 export type EpubReaderBookMeta = {
 	chapter: EpubReaderChapterMeta
 	toc: EpubContent[]
+	sectionLengths: { [key: number]: number }
 	bookmarks: Record<string, Bookmark>
 }
 
@@ -43,6 +46,7 @@ export type EpubReaderControls = {
 	onLinkClick: (href: string) => void
 	onPaginateForward: () => void
 	onPaginateBackward: () => void
+	jumpToSection: (section: number) => void
 	getCfiPreviewText: (cfi: string) => Promise<string | null>
 	searchEntireBook: (query: string) => Promise<SpineSearchResult[]>
 	onGoToCfi: (cfi: string) => void
@@ -73,6 +77,7 @@ export const EpubReaderContext = createContext<EpubReaderContextProps>({
 		onMouseLeaveControls: noop,
 		onPaginateBackward: noop,
 		onPaginateForward: noop,
+		jumpToSection: noop,
 		searchEntireBook: async () => [],
 		setFullscreen: noop,
 		setVisible: noop,

--- a/packages/browser/src/components/readers/epub/controls/ControlsContainer.tsx
+++ b/packages/browser/src/components/readers/epub/controls/ControlsContainer.tsx
@@ -1,31 +1,38 @@
-import { cx } from '@stump/components'
+import { cn } from '@stump/components'
 
 import { useEpubReaderControls } from '../context'
 
 type Props = {
 	children: React.ReactNode
 	position: 'top' | 'bottom'
+	className?: string
 }
-export default function ControlsContainer({ position, children }: Props) {
+export default function ControlsContainer({ position, children, className }: Props) {
 	const { visible, fullscreen, onMouseEnterControls, onMouseLeaveControls } =
 		useEpubReaderControls()
 
 	return (
 		<div
-			className={cx('h-10 w-full shrink-0', {
-				'bottom-0 left-0': position === 'bottom' && fullscreen,
-				'fixed z-[100]': fullscreen,
-				'left-0 top-0': position === 'top' && fullscreen,
-			})}
+			className={cn(
+				'h-10 w-full shrink-0',
+				{
+					'bottom-0 left-0': position === 'bottom' && fullscreen,
+					'fixed z-[100]': fullscreen,
+					'left-0 top-0': position === 'top' && fullscreen,
+				},
+				className,
+			)}
 			onMouseEnter={onMouseEnterControls}
 			onMouseLeave={onMouseLeaveControls}
 			aria-hidden="true"
 		>
 			<div
-				className={cx(
-					'flex h-full items-center gap-1 bg-background p-2 transition-opacity duration-150 md:bg-transparent',
+				className={cn(
+					'flex h-full items-center gap-1 bg-background px-2 transition-opacity duration-150',
+					{ 'md:bg-transparent': !fullscreen },
 					{ 'opacity-100': !fullscreen || visible },
 					{ 'opacity-0': !visible && fullscreen },
+					position === 'bottom' ? 'py-1' : 'py-2',
 				)}
 			>
 				{children}

--- a/packages/components/src/progress/ProgressBar.stories.tsx
+++ b/packages/components/src/progress/ProgressBar.stories.tsx
@@ -43,11 +43,11 @@ const Demo = (args: DemoProps) => {
 }
 
 export const Default: Story = {
-	render: () => <Demo value={10} />,
+	render: () => <Demo value={10} size={'lg'} rounded={'default'} variant={'default'} />,
 }
 
 export const Animated: Story = {
-	render: () => <Demo animated speed={75} />,
+	render: () => <Demo animated speed={75} size={'lg'} rounded={'default'} variant={'default'} />,
 }
 
 export default StoryMeta

--- a/packages/components/src/progress/ProgressBar.tsx
+++ b/packages/components/src/progress/ProgressBar.tsx
@@ -19,7 +19,7 @@ export const PROGRESS_BAR_INDICATOR_COLOR_VARIANTS: ColorVariant = {
 	'primary-dark': 'bg-brand-600 dark:bg-brand-500',
 }
 
-const progressVariants = cva('relative w-full overflow-hidden', {
+const progressVariants = cva('relative overflow-hidden', {
 	variants: {
 		defaultVariants: {
 			rounded: 'default',
@@ -78,7 +78,7 @@ export const ProgressBar = React.forwardRef<
 		>
 			<ProgressPrimitive.Indicator
 				className={cx(
-					'h-full w-full flex-1 transition-all',
+					'h-full flex-1 transition-all',
 					PROGRESS_BAR_INDICATOR_COLOR_VARIANTS[variant || 'default'],
 					{
 						'origin-left-to-right-indeterminate animate-indeterminate-progress': isIndeterminate,


### PR DESCRIPTION
This adds support for a yomu style progress bar for epubs. The progress bar is really a list of progress bars where each bar corresponds to a section in the book.spine. Clicking on the progress bar will jump to that section of the book.

I did consider using toc instead, but things got a little messy since you have to combine sections that are not in the toc. At least a few of my books had no toc. Checking yomu, it seems to also use sections and not the toc.

I tried making it so that it jumps into the section by the same percentage of the bar the user clicked on but could not get that working reliably with epubjs. This would be useful for books that do not have chapters (e.g. convert txt files).

One significant issue here is that it has to load each section to get the text length. A better solution here would be to cache the results or have some metadata per section server side. This might be easier to implement after streaming is supported.