### PR TITLE
🐛 Allow sorting media by the last time the file was modified

### DIFF
--- a/core/src/db/query/ordering.rs
+++ b/core/src/db/query/ordering.rs
@@ -62,6 +62,7 @@ impl TryInto<media::OrderByParam> for QueryOrder {
 			"pages" => media::pages::order(dir),
 			"series_id" => media::series_id::order(dir),
 			"created_at" => media::created_at::order(dir),
+			"modified_at" => media::modified_at::order(dir),
 			_ => {
 				return Err(CoreError::InvalidQuery(format!(
 					"You cannot order media by {:?}",

--- a/core/src/filesystem/scanner/utils.rs
+++ b/core/src/filesystem/scanner/utils.rs
@@ -118,6 +118,15 @@ pub(crate) async fn create_media(
 				None
 			};
 
+			let modified_at = generated
+				.modified_at
+				.as_deref()
+				.and_then(|date| DateTime::parse_from_rfc3339(date).ok())
+				.or_else(|| {
+					tracing::error!("Failed to parse modified_at date");
+					None
+				});
+
 			let created_media = client
 				.media()
 				.create(
@@ -130,6 +139,7 @@ pub(crate) async fn create_media(
 						media::hash::set(generated.hash),
 						media::koreader_hash::set(generated.koreader_hash),
 						media::series::connect(series::id::equals(generated.series_id)),
+						media::modified_at::set(modified_at),
 					],
 				)
 				.exec()

--- a/core/src/filesystem/scanner/utils.rs
+++ b/core/src/filesystem/scanner/utils.rs
@@ -118,14 +118,15 @@ pub(crate) async fn create_media(
 				None
 			};
 
-			let modified_at = generated
-				.modified_at
-				.as_deref()
-				.and_then(|date| DateTime::parse_from_rfc3339(date).ok())
-				.or_else(|| {
-					tracing::error!("Failed to parse modified_at date");
-					None
-				});
+			let modified_at = generated.modified_at.as_deref().and_then(|date| {
+				match DateTime::parse_from_rfc3339(date) {
+					Ok(dt) => Some(dt), // Successfully parsed
+					Err(e) => {
+						tracing::error!(?e, "Failed to parse modified_at date");
+						None
+					},
+				}
+			});
 
 			let created_media = client
 				.media()

--- a/packages/browser/src/components/filters/form/OrderBySelect.tsx
+++ b/packages/browser/src/components/filters/form/OrderBySelect.tsx
@@ -6,7 +6,7 @@ import { FilterableEntity } from '.'
 const commonOptions = ['name', 'status', 'created_at', 'path']
 const options: Record<FilterableEntity, string[]> = {
 	library: commonOptions,
-	media: [...commonOptions, 'size', 'extension', 'pages', 'series_id'],
+	media: [...commonOptions, 'size', 'extension', 'pages', 'series_id', 'modified_at'],
 	series: [...commonOptions, 'description', 'library_id'],
 }
 


### PR DESCRIPTION
Relatively straightforward. It looks like modified_at was not being added to the database and also not available as a sort option.

To use it, I re-created the library. I did not test if re-scanning would update modified_at.