### PR TITLE
:sparkles: scan matching opf file when scanning metadata for epubs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4172,6 +4172,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "merge"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10bbef93abb1da61525bbc45eeaff6473a41907d19f8f9aa5168d214e10693e9"
+dependencies = [
+ "merge_derive",
+ "num-traits",
+]
+
+[[package]]
+name = "merge_derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "209d075476da2e63b4b29e72a2ef627b840589588e71400a25e3565c4f849d07"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "metrics"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7718,6 +7740,7 @@ dependencies = [
  "itertools 0.13.0",
  "libc",
  "md5",
+ "merge",
  "pdf",
  "pdfium-render",
  "prefixed-api-key",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6054,6 +6054,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quick-xml"
+version = "0.37.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "165859e9e55f79d67b96c5d96f4e88b6f2695a1972849c15a6a3f5c59fc2c003"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7713,6 +7722,7 @@ dependencies = [
  "pdfium-render",
  "prefixed-api-key",
  "prisma-client-rust",
+ "quick-xml",
  "rand 0.8.5",
  "rayon",
  "regex",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -53,6 +53,7 @@ webp = "0.3.0"
 xml-rs = "0.8.21" # XML reader/writer
 zip = { workspace = true }
 quick-xml = "0.37.2"
+merge = "0.1.0"
 
 [dev-dependencies]
 temp-env = "0.3.6"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -52,6 +52,7 @@ walkdir = "2.5.0"
 webp = "0.3.0"
 xml-rs = "0.8.21" # XML reader/writer
 zip = { workspace = true }
+quick-xml = "0.37.2"
 
 [dev-dependencies]
 temp-env = "0.3.6"

--- a/core/integration-tests/data/book.opf
+++ b/core/integration-tests/data/book.opf
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<package xmlns:opf="http://www.idpf.org/2007/opf" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="id">
+  <metadata>
+    <dc:rights>Public domain in the USA.</dc:rights>
+    <dc:identifier id="id">http://www.gutenberg.org/11</dc:identifier>
+    <meta property="file-as" refines="#author_0">Carroll, Lewis</meta>
+    <meta property="role" refines="#author_0" scheme="marc:relators">aut</meta>
+    <dc:title>Alice's Adventures in Wonderland - Test OPF</dc:title>
+    <dc:language>en</dc:language>
+    <dc:subject>Fantasy fiction</dc:subject>
+    <dc:subject>Children's stories</dc:subject>
+    <dc:subject>Imaginary places -- Juvenile fiction</dc:subject>
+    <dc:subject>Alice (Fictitious character from Carroll) -- Juvenile fiction</dc:subject>
+    <dc:date>2008-06-27</dc:date>
+    <meta property="dcterms:modified">2023-04-01T07:32:49Z</meta>
+    <dc:source>https://www.gutenberg.org/files/11/11-h/11-h.htm</dc:source>
+    <meta name="cover" content="id-3324512750020140212"/>
+  </metadata>
+</package>

--- a/core/src/db/entity/metadata/media_metadata.rs
+++ b/core/src/db/entity/metadata/media_metadata.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use merge::Merge;
 use pdf::{
 	object::InfoDict,
 	primitive::{Dictionary, PdfString},
@@ -27,9 +28,10 @@ const NAIVE_DATE_FORMATS: [&str; 2] = ["%Y-%m-%d", "%m-%d-%Y"];
 // NOTE: alias is used primarily to support ComicInfo.xml files, as that metadata
 // is formatted in PascalCase
 /// Struct representing the metadata for a processed file.
-#[derive(Debug, Clone, Serialize, Deserialize, Type, Default, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, Type, Default, ToSchema, Merge)]
 pub struct MediaMetadata {
 	/// The metadata of the media.
+	#[merge(skip)]
 	#[serde(skip_deserializing, skip_serializing)]
 	pub id: String,
 	/// The title of the media.

--- a/core/src/filesystem/media/format/epub.rs
+++ b/core/src/filesystem/media/format/epub.rs
@@ -127,11 +127,12 @@ impl FileProcessor for EpubProcessor {
 						}
 					},
 					Event::Text(e) => {
-						let text = e.unescape().unwrap().to_string();
-						opf_metadata
-							.entry(current_tag.clone())
-							.or_default()
-							.push(text);
+						if let Ok(text) = e.unescape() {
+							opf_metadata
+								.entry(current_tag.clone())
+								.or_default()
+								.push(text.to_string());
+						}
 					},
 					Event::Eof => {
 						break;

--- a/core/src/filesystem/media/format/epub.rs
+++ b/core/src/filesystem/media/format/epub.rs
@@ -1,3 +1,4 @@
+use merge::Merge;
 use quick_xml::{events::Event, Reader};
 use std::{collections::HashMap, fs::File, io::BufReader, path::PathBuf};
 
@@ -146,44 +147,7 @@ impl FileProcessor for EpubProcessor {
 			let mut combined_metadata = opf_metadata.clone();
 
 			combined_metadata.id = opf_metadata.id;
-			combined_metadata.title = opf_metadata.title.or(embedded_metadata.title);
-			combined_metadata.series = opf_metadata.series.or(embedded_metadata.series);
-			combined_metadata.number = opf_metadata.number.or(embedded_metadata.number);
-			combined_metadata.volume = opf_metadata.volume.or(embedded_metadata.volume);
-			combined_metadata.summary =
-				opf_metadata.summary.or(embedded_metadata.summary);
-			combined_metadata.notes = opf_metadata.notes.or(embedded_metadata.notes);
-			combined_metadata.age_rating =
-				opf_metadata.age_rating.or(embedded_metadata.age_rating);
-			combined_metadata.genre = opf_metadata.genre.or(embedded_metadata.genre);
-			combined_metadata.year = opf_metadata.year.or(embedded_metadata.year);
-			combined_metadata.month = opf_metadata.month.or(embedded_metadata.month);
-			combined_metadata.day = opf_metadata.day.or(embedded_metadata.day);
-			combined_metadata.writers =
-				opf_metadata.writers.or(embedded_metadata.writers);
-			combined_metadata.pencillers =
-				opf_metadata.pencillers.or(embedded_metadata.pencillers);
-			combined_metadata.inkers = opf_metadata.inkers.or(embedded_metadata.inkers);
-			combined_metadata.colorists =
-				opf_metadata.colorists.or(embedded_metadata.colorists);
-			combined_metadata.letterers =
-				opf_metadata.letterers.or(embedded_metadata.letterers);
-			combined_metadata.cover_artists = opf_metadata
-				.cover_artists
-				.or(embedded_metadata.cover_artists);
-			combined_metadata.editors =
-				opf_metadata.editors.or(embedded_metadata.editors);
-			combined_metadata.publisher =
-				opf_metadata.publisher.or(embedded_metadata.publisher);
-			combined_metadata.links = opf_metadata.links.or(embedded_metadata.links);
-			combined_metadata.characters =
-				opf_metadata.characters.or(embedded_metadata.characters);
-			combined_metadata.teams = opf_metadata.teams.or(embedded_metadata.teams);
-			combined_metadata.page_count =
-				opf_metadata.page_count.or(embedded_metadata.page_count);
-			combined_metadata.page_dimensions = opf_metadata
-				.page_dimensions
-				.or(embedded_metadata.page_dimensions);
+			combined_metadata.merge(embedded_metadata);
 
 			return Ok(Some(combined_metadata));
 		}


### PR DESCRIPTION
This is a potential solution to #593 

I am not proud of the MediaMetadata merge but it works.

This only solves the situation where the opf file has the same name as the epub.

Open to suggestions for better solutions.