### PR TITLE
🐛 Fix epub reader footer page count on mobile

### DIFF
--- a/packages/browser/src/components/readers/epub/EpubReaderFooter.tsx
+++ b/packages/browser/src/components/readers/epub/EpubReaderFooter.tsx
@@ -12,7 +12,11 @@ export default function EpubReaderFooter() {
 	const { bookMeta } = useEpubReaderContext().readerMeta
 
 	const visiblePages = (bookMeta?.chapter.currentPage ?? []).filter(Boolean)
-	const pagesVisible = visiblePages.length
+	let pagesVisible = visiblePages.length
+	// if all pages visible are the same page then we're looking at one page at a time
+	if (visiblePages.every((page) => page === visiblePages[0])) {
+		pagesVisible = 1
+	}
 
 	const chapterPageCount = bookMeta?.chapter.totalPages || 1
 	const chapterName = bookMeta?.chapter.name || ''


### PR DESCRIPTION
On mobile the current page and total pages in the chapter on the footer were unreliable since it didn't take into account the fact that the `start.displayed.page` and `end.displayed.page` are the same.

#### Before
https://github.com/user-attachments/assets/631a0011-4f91-4645-aaec-c4286f4dbe67

#### After
https://github.com/user-attachments/assets/a4234f2c-e570-49b9-94e8-2245d4476110




I tested these changes on the `main` branch only. I'm having an issue working off of the `experimental` branch atm 😢 