### PR TITLE
🩹 small improvements to web manifest PWA file

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
 				maximumFileSizeToCacheInBytes: 5 * 1024 * 1024, // 5MB
 			},
 			outDir: '../dist/assets/',
-			base: '/assets/',
+			base: '/',
 			// TODO(pwa): Add more manifest definitions for better overall experience
 			manifest: {
 				id: 'stump',
@@ -55,7 +55,7 @@ export default defineConfig({
 					},
 				],
 			},
-			manifestFilename: './manifest.webmanifest',
+			manifestFilename: 'assets/manifest.webmanifest',
 		}),
 	],
 	publicDir: '../../../packages/browser/public',


### PR DESCRIPTION
The initial web manifest file wasn't quite working for me after it was released so I took a stab at fixing things up. The two changes here are...

* make the 'base' parameter the root app page. This parameter gets set as the 'scope' of the manifest file which determines which routes are a part of your web app. With this being set to 'assets' the browser thought none of the actual app pages were part of the PWA and rendering browser controls.
* fix the asset file name. The '.' in the previous file name was creating a file path of '/assets/./manifest.webmanifest'. this path seemed to not resolve to anything. Setting a more explicit filename here leads to the manifest link the html resolving to '/assets/manifest.webmanifest' and does actually pull up the file when that path is requested.

