### PR TITLE
:adhesive_bandage: Fix missing error logs for book failures

### DIFF
--- a/core/src/filesystem/media/format/pdf.rs
+++ b/core/src/filesystem/media/format/pdf.rs
@@ -5,7 +5,7 @@ use std::{
 	path::{Path, PathBuf},
 };
 
-use pdf::file::FileOptions;
+use pdf::{file::FileOptions, object::ParseOptions};
 use pdfium_render::prelude::{PdfRenderConfig, Pdfium};
 
 use crate::{
@@ -84,7 +84,9 @@ impl FileProcessor for PdfProcessor {
 	}
 
 	fn process_metadata(path: &str) -> Result<Option<MediaMetadata>, FileError> {
-		let file = FileOptions::cached().open(path)?;
+		let file = FileOptions::cached()
+			.parse_options(ParseOptions::tolerant())
+			.open(path)?;
 
 		Ok(file.trailer.info_dict.map(MediaMetadata::from))
 	}
@@ -94,7 +96,9 @@ impl FileProcessor for PdfProcessor {
 		options: FileProcessorOptions,
 		_: &StumpConfig,
 	) -> Result<ProcessedFile, FileError> {
-		let file = FileOptions::cached().open(path)?;
+		let file = FileOptions::cached()
+			.parse_options(ParseOptions::tolerant())
+			.open(path)?;
 
 		let pages = file.pages().count() as i32;
 		// Note: The metadata is already parsed by the PDF library, so might as well use it

--- a/core/src/filesystem/scanner/utils.rs
+++ b/core/src/filesystem/scanner/utils.rs
@@ -704,7 +704,6 @@ pub(crate) async fn safely_build_and_insert_media(
 	}
 
 	let mut output = MediaOperationOutput::default();
-	let mut logs = vec![];
 
 	let semaphore = Arc::new(Semaphore::new(max_concurrency));
 	tracing::debug!(max_concurrency, "Semaphore created for media creation");
@@ -751,7 +750,7 @@ pub(crate) async fn safely_build_and_insert_media(
 			},
 			Err((error, path)) => {
 				tracing::error!(error = ?error, ?path, "Failed to build book");
-				logs.push(
+				output.logs.push(
 					JobExecuteLog::error(format!(
 						"Failed to build book: {:?}",
 						error.to_string()
@@ -767,7 +766,7 @@ pub(crate) async fn safely_build_and_insert_media(
 	}
 
 	let success_count = books.len();
-	let error_count = logs.len();
+	let error_count = output.logs.len();
 	tracing::debug!(
 		elapsed = ?start.elapsed(),
 		success_count, error_count,
@@ -805,7 +804,7 @@ pub(crate) async fn safely_build_and_insert_media(
 					task_count,
 				));
 				tracing::error!(error = ?e, ?path, "Failed to create media");
-				logs.push(
+				output.logs.push(
 					JobExecuteLog::error(format!(
 						"Failed to create media: {:?}",
 						e.to_string()
@@ -817,7 +816,7 @@ pub(crate) async fn safely_build_and_insert_media(
 	}
 
 	let success_count = output.created_media;
-	let error_count = logs.len() - error_count; // Subtract the errors from the previous step
+	let error_count = output.logs.len() - error_count; // Subtract the errors from the previous step
 	tracing::debug!(success_count, error_count, elapsed = ?start.elapsed(), "Inserted books into database");
 
 	Ok(output)


### PR DESCRIPTION
The logs were never added to the task output, and so never got written to the database. I've also adjusted the PDF parse config to be `tolerant` during processing