### PR TITLE
🩹 Switch to ProcessorError and asyncify thumbnail removal

### DIFF
--- a/apps/server/src/routers/api/v1/media/thumbnails.rs
+++ b/apps/server/src/routers/api/v1/media/thumbnails.rs
@@ -275,7 +275,7 @@ pub(crate) async fn replace_media_thumbnail(
 	// Note: I chose to *safely* attempt the removal as to not block the upload, however after some
 	// user testing I'd like to see if this becomes a problem. We'll see!
 	if let Err(e) =
-		remove_thumbnails(&[book_id.clone()], &ctx.config.get_thumbnails_dir())
+		remove_thumbnails(&[book_id.clone()], &ctx.config.get_thumbnails_dir()).await
 	{
 		tracing::error!(
 			?e,

--- a/apps/server/src/routers/api/v1/series.rs
+++ b/apps/server/src/routers/api/v1/series.rs
@@ -622,7 +622,8 @@ async fn replace_series_thumbnail(
 
 	// Note: I chose to *safely* attempt the removal as to not block the upload, however after some
 	// user testing I'd like to see if this becomes a problem. We'll see!
-	match remove_thumbnails(&[series_id.clone()], &ctx.config.get_thumbnails_dir()) {
+	match remove_thumbnails(&[series_id.clone()], &ctx.config.get_thumbnails_dir()).await
+	{
 		Ok(count) => tracing::info!("Removed {} thumbnails!", count),
 		Err(e) => tracing::error!(
 			?e,

--- a/core/src/filesystem/error.rs
+++ b/core/src/filesystem/error.rs
@@ -48,10 +48,12 @@ pub enum FileError {
 	ImageIoError(#[from] image::ImageError),
 	#[error("Failed to encode image to webp: {0}")]
 	WebpEncodeError(String),
-	#[error("An unknown error occurred: {0}")]
-	UnknownError(String),
 	#[error("Failed to read directory")]
 	DirectoryReadError,
+	#[error("Incorrect image processor for requested format")]
+	IncorrectProcessorError,
+	#[error("An unknown error occurred: {0}")]
+	UnknownError(String),
 }
 
 impl From<FileError> for CoreError {

--- a/core/src/filesystem/image/error.rs
+++ b/core/src/filesystem/image/error.rs
@@ -13,3 +13,9 @@ pub enum ProcessorError {
 	#[error("The processor configuration is invalid: {0}")]
 	InvalidConfiguration(String),
 }
+
+impl From<std::io::Error> for ProcessorError {
+	fn from(value: std::io::Error) -> Self {
+		Self::FileError(FileError::from(value))
+	}
+}

--- a/core/src/filesystem/image/generic.rs
+++ b/core/src/filesystem/image/generic.rs
@@ -202,10 +202,10 @@ mod tests {
 
 		let result = GenericImageProcessor::generate_from_path(&jpg_path, options);
 		assert!(result.is_err());
-		assert_eq!(
-			result.unwrap_err().to_string(),
-			"An unknown error occurred: Incorrect image processor for requested format."
-		);
+		assert!(matches!(
+			result.unwrap_err(),
+			ProcessorError::FileError(FileError::IncorrectProcessorError)
+		));
 	}
 
 	// PNG -> other

--- a/core/src/filesystem/image/generic.rs
+++ b/core/src/filesystem/image/generic.rs
@@ -4,7 +4,10 @@ use image::{imageops, GenericImageView, ImageFormat};
 
 use crate::filesystem::{image::process::resized_dimensions, FileError};
 
-use super::process::{self, ImageProcessor, ImageProcessorOptions};
+use super::{
+	process::{self, ImageProcessor, ImageProcessorOptions},
+	ProcessorError,
+};
 
 /// An image processor that works for the most common image types, primarily
 /// JPEG and PNG formats.
@@ -14,7 +17,7 @@ impl ImageProcessor for GenericImageProcessor {
 	fn generate(
 		buffer: &[u8],
 		options: ImageProcessorOptions,
-	) -> Result<Vec<u8>, FileError> {
+	) -> Result<Vec<u8>, ProcessorError> {
 		let mut image = image::load_from_memory(buffer)?;
 
 		if let Some(resize_options) = options.resize_options {
@@ -36,10 +39,7 @@ impl ImageProcessor for GenericImageProcessor {
 				Ok(ImageFormat::Jpeg)
 			},
 			process::ImageFormat::Png => Ok(ImageFormat::Png),
-			// TODO: change error kind
-			_ => Err(FileError::UnknownError(String::from(
-				"Incorrect image processor for requested format.",
-			))),
+			_ => Err(FileError::IncorrectProcessorError),
 		}?;
 
 		let mut buffer = Cursor::new(vec![]);
@@ -51,7 +51,7 @@ impl ImageProcessor for GenericImageProcessor {
 	fn generate_from_path(
 		path: &str,
 		options: ImageProcessorOptions,
-	) -> Result<Vec<u8>, FileError> {
+	) -> Result<Vec<u8>, ProcessorError> {
 		let bytes = fs::read(path)?;
 		Self::generate(&bytes, options)
 	}

--- a/core/src/filesystem/image/mod.rs
+++ b/core/src/filesystem/image/mod.rs
@@ -4,8 +4,6 @@ mod process;
 mod thumbnail;
 mod webp;
 
-// TODO: replace errors with ProcessorError throughout the module
-
 pub use self::webp::WebpProcessor;
 pub use error::ProcessorError;
 pub use generic::GenericImageProcessor;

--- a/core/src/filesystem/image/process.rs
+++ b/core/src/filesystem/image/process.rs
@@ -2,8 +2,6 @@ use serde::{Deserialize, Serialize};
 use specta::Type;
 use utoipa::ToSchema;
 
-use crate::filesystem::error::FileError;
-
 use super::ProcessorError;
 
 /// The resize mode to use when generating a thumbnail.
@@ -180,7 +178,6 @@ impl TryFrom<Vec<u8>> for ImageProcessorOptions {
 	}
 }
 
-// TODO: replace error with ProcessorError
 /// Trait defining a standard API for processing images throughout Stump.
 pub trait ImageProcessor {
 	/// Generate an image from a buffer. If options are provided,
@@ -188,13 +185,13 @@ pub trait ImageProcessor {
 	fn generate(
 		buffer: &[u8],
 		options: ImageProcessorOptions,
-	) -> Result<Vec<u8>, FileError>;
+	) -> Result<Vec<u8>, ProcessorError>;
 	/// Generate an image from a given path in the filesystem. If options are provided,
 	/// the image will be adjusted accordingly.
 	fn generate_from_path(
 		path: &str,
 		options: ImageProcessorOptions,
-	) -> Result<Vec<u8>, FileError>;
+	) -> Result<Vec<u8>, ProcessorError>;
 }
 
 pub fn resized_dimensions(

--- a/core/src/filesystem/image/thumbnail/generate.rs
+++ b/core/src/filesystem/image/thumbnail/generate.rs
@@ -8,9 +8,8 @@ use crate::{
 		get_page,
 		image::{
 			GenericImageProcessor, ImageFormat, ImageProcessor, ImageProcessorOptions,
-			WebpProcessor,
+			ProcessorError, WebpProcessor,
 		},
-		FileError,
 	},
 	prisma::media,
 };
@@ -21,7 +20,7 @@ pub enum ThumbnailGenerateError {
 	#[error("Could not write to disk: {0}")]
 	WriteFailed(#[from] std::io::Error),
 	#[error("{0}")]
-	FileError(#[from] FileError),
+	ProcessorError(#[from] ProcessorError),
 	#[error("Did not receive thumbnail generation result")]
 	ResultNeverReceived,
 	#[error("Something unexpected went wrong: {0}")]
@@ -50,7 +49,7 @@ fn do_generate_book_thumbnail(
 	file_name: &str,
 	config: &StumpConfig,
 	options: ImageProcessorOptions,
-) -> Result<GenerateOutput, FileError> {
+) -> Result<GenerateOutput, ProcessorError> {
 	let (_, page_data) = get_page(book_path, options.page.unwrap_or(1), config)?;
 	let ext = options.format.extension();
 

--- a/core/src/filesystem/image/thumbnail/utils.rs
+++ b/core/src/filesystem/image/thumbnail/utils.rs
@@ -27,7 +27,7 @@ pub async fn remove_thumbnails(
 	let mut read_dir = tokio::fs::read_dir(thumbnails_dir).await?;
 
 	// Asynchronously collect thumbnails
-	let mut found_thumbnails = Vec::new();
+	let mut found_thumbnails = Vec::with_capacity(id_list.len());
 	while let Some(entry) = read_dir.next_entry().await? {
 		let path = entry.path();
 		if let Some(filename) = path.file_name().and_then(|f| f.to_str()) {

--- a/core/src/filesystem/image/thumbnail/utils.rs
+++ b/core/src/filesystem/image/thumbnail/utils.rs
@@ -1,9 +1,9 @@
 use std::path::{Path, PathBuf};
 
-use crate::{config::StumpConfig, filesystem::FileError};
-use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 use tokio::fs;
 use tracing::{error, trace};
+
+use crate::{config::StumpConfig, filesystem::FileError};
 
 pub async fn place_thumbnail(
 	id: &str,
@@ -16,61 +16,44 @@ pub async fn place_thumbnail(
 	Ok(thumbnail_path)
 }
 
-pub const THUMBNAIL_CHUNK_SIZE: usize = 500;
+pub const THUMBNAIL_LOG_FREQUENCY: usize = 500;
 
-// TODO(perf): Async-ify
 /// Deletes thumbnails and returns the number deleted if successful, returns
 /// [`FileError`] otherwise.
-pub fn remove_thumbnails(
+pub async fn remove_thumbnails(
 	id_list: &[String],
 	thumbnails_dir: &Path,
 ) -> Result<u64, FileError> {
-	let found_thumbnails = thumbnails_dir
-		.read_dir()
-		.ok()
-		.map(|dir| dir.into_iter())
-		.map(|iter| {
-			iter.filter_map(|entry| {
-				entry.ok().and_then(|entry| {
-					let path = entry.path();
-					let file_name = path.file_name()?.to_str()?.to_string();
+	let mut read_dir = tokio::fs::read_dir(thumbnails_dir).await?;
 
-					if id_list.iter().any(|id| file_name.starts_with(id)) {
-						Some(path)
-					} else {
-						None
-					}
-				})
-			})
-		})
-		.map(|iter| iter.collect::<Vec<PathBuf>>())
-		.unwrap_or_default();
+	// Asynchronously collect thumbnails
+	let mut found_thumbnails = Vec::new();
+	while let Some(entry) = read_dir.next_entry().await? {
+		let path = entry.path();
+		if let Some(filename) = path.file_name().and_then(|f| f.to_str()) {
+			if id_list.iter().any(|id| filename.starts_with(id)) {
+				found_thumbnails.push(path);
+			}
+		}
+	}
 
 	let found_thumbnails_count = found_thumbnails.len();
 	tracing::debug!(found_thumbnails_count, "Found thumbnails to remove");
 
 	let mut deleted_thumbnails_count = 0;
 
-	for (idx, chunk) in found_thumbnails.chunks(THUMBNAIL_CHUNK_SIZE).enumerate() {
-		trace!(chunk = idx + 1, "Processing chunk for thumbnail removal");
-		let results = chunk
-			.into_par_iter()
-			.map(|path| {
-				std::fs::remove_file(path)?;
-				Ok(())
-			})
-			.filter_map(|res: Result<(), FileError>| {
-				if res.is_err() {
-					error!(error = ?res.err(), "Error deleting thumbnail!");
-					None
-				} else {
-					res.ok()
-				}
-			})
-			.collect::<Vec<()>>();
+	for (idx, path) in found_thumbnails.iter().enumerate() {
+		if idx % THUMBNAIL_LOG_FREQUENCY == 0 {
+			trace!("Processed {idx} thumbnails for removal.");
+		}
 
-		trace!(deleted_count = results.len(), "Deleted thumbnail batch");
-		deleted_thumbnails_count += results.len() as u64;
+		match tokio::fs::remove_file(path).await {
+			Ok(_) => deleted_thumbnails_count += 1,
+			Err(e) => {
+				error!(error = ?e, ?path, "Error deleting thumbnail!");
+				return Err(e.into());
+			},
+		};
 	}
 
 	Ok(deleted_thumbnails_count)

--- a/core/src/filesystem/image/webp.rs
+++ b/core/src/filesystem/image/webp.rs
@@ -3,9 +3,14 @@ use std::fs;
 use image::{imageops, DynamicImage, EncodableLayout, GenericImageView};
 use webp::Encoder;
 
-use crate::filesystem::{error::FileError, image::process::resized_dimensions};
-
-use super::process::{ImageProcessor, ImageProcessorOptions, ImageResizeOptions};
+use crate::filesystem::{
+	error::FileError,
+	image::process::resized_dimensions,
+	image::{
+		process::{ImageProcessor, ImageProcessorOptions, ImageResizeOptions},
+		ProcessorError,
+	},
+};
 
 pub struct WebpProcessor;
 
@@ -13,7 +18,7 @@ impl ImageProcessor for WebpProcessor {
 	fn generate(
 		buffer: &[u8],
 		options: ImageProcessorOptions,
-	) -> Result<Vec<u8>, FileError> {
+	) -> Result<Vec<u8>, ProcessorError> {
 		let mut image = image::load_from_memory(buffer)?;
 
 		if let Some(resize_options) = options.resize_options {
@@ -31,7 +36,7 @@ impl ImageProcessor for WebpProcessor {
 	fn generate_from_path(
 		path: &str,
 		options: ImageProcessorOptions,
-	) -> Result<Vec<u8>, FileError> {
+	) -> Result<Vec<u8>, ProcessorError> {
 		let bytes = fs::read(path)?;
 		Self::generate(&bytes, options)
 	}

--- a/core/src/filesystem/media/format/epub.rs
+++ b/core/src/filesystem/media/format/epub.rs
@@ -268,7 +268,7 @@ impl EpubProcessor {
 	///    returned.
 	pub fn get_cover(path: &str) -> Result<(ContentType, Vec<u8>), FileError> {
 		let mut epub_file = EpubDoc::new(path).map_err(|e| {
-			tracing::error!("Failed to open epub file: {}", e);
+			tracing::error!("Failed to open epub file: {e}");
 			FileError::EpubOpenError(e.to_string())
 		})?;
 
@@ -289,7 +289,7 @@ impl EpubProcessor {
 		}
 
 		let content = epub_file.get_current_with_epub_uris().map_err(|e| {
-			tracing::error!("Failed to get chapter from epub file: {}", e);
+			tracing::error!("Failed to get chapter from epub file: {e}");
 			FileError::EpubReadError(e.to_string())
 		})?;
 
@@ -314,7 +314,7 @@ impl EpubProcessor {
 		let mut epub_file = Self::open(path)?;
 
 		let (buf, mime) = epub_file.get_resource(resource_id).ok_or_else(|| {
-			tracing::error!("Failed to get resource: {}", resource_id);
+			tracing::error!("Failed to get resource: {resource_id}");
 			FileError::EpubReadError("Failed to get resource".to_string())
 		})?;
 

--- a/core/src/filesystem/media/format/pdf.rs
+++ b/core/src/filesystem/media/format/pdf.rs
@@ -38,7 +38,7 @@ impl FileProcessor for PdfProcessor {
 
 		if size < 10 {
 			tracing::warn!(path, size, "File is too small to sample!");
-			return Err(FileError::UnknownError(String::from(
+			return Err(FileError::PdfProcessingError(String::from(
 				"File is too small to sample!",
 			)));
 		}
@@ -102,10 +102,9 @@ impl FileProcessor for PdfProcessor {
 		let pdfium = PdfProcessor::renderer(&config.pdfium_path)?;
 
 		let document = pdfium.load_pdf_from_file(path, None)?;
-		let document_page =
-			document.pages().get((page - 1).try_into().map_err(
-				|e: TryFromIntError| FileError::UnknownError(e.to_string()),
-			)?)?;
+		let document_page = document.pages().get((page - 1).try_into().map_err(
+			|e: TryFromIntError| FileError::PdfProcessingError(e.to_string()),
+		)?)?;
 
 		let render_config = PdfRenderConfig::new();
 

--- a/core/src/job/mod.rs
+++ b/core/src/job/mod.rs
@@ -603,7 +603,7 @@ impl<J: JobExt> Executor for WrappedJob<J> {
 	fn should_requeue(&self) -> bool {
 		self.inner_job
 			.as_ref()
-			.map_or(false, |job| job.should_requeue(self.attempts))
+			.is_some_and(|job| job.should_requeue(self.attempts))
 	}
 
 	async fn execute(&mut self, ctx: WorkerCtx) -> Result<ExecutorOutput, JobError> {


### PR DESCRIPTION
This pull request addresses several todo items in core::filesystem::image.

First, it adjusts the `ImageProcessor` trait to use `ProcessorError` as requested in a todo. In the course of doing this, I added a new `FileError::IncorrectProcessorError` variant to avoid a few `FileError::UnknownError`s. This error type could also reasonably be made a `ProcessorError` if desired, but doing it this way matched the current implementation more closely.

Second, it makes the `remove_thumbnails` function async as requested in another todo. This was done pretty easily by switching to tokio::fs. One major change I made to this function when async-ifying it was eliminating chunking and the use of the rayon crate to attempt parallel deletion across each chunk. Admittedly, I do not have a large enough test library to get a perceptible speed difference between the two, so testing with a larger library would be good. 

I believe that this is reasonable because rayon is used for CPU-bound work, but this is going to be I/O bound. I also don't think the chunking was doing much - I am pretty sure each rayon thread would be spending most of its time waiting on disk I/O from other threads. [This stack overflow post](https://unix.stackexchange.com/questions/349535/parallelize-recursive-deletion-with-find) supports my intuition, but I'm open to hearing other thoughts here.