### PR TITLE
🐛 Fix reading progress resetting due to cached data

### DIFF
--- a/packages/browser/src/components/readers/epub/EpubJsReader.tsx
+++ b/packages/browser/src/components/readers/epub/EpubJsReader.tsx
@@ -302,15 +302,19 @@ export default function EpubJsReader({ id, initialCfi }: EpubJsReaderProps) {
 	}, [rendition, epubPreferences, theme])
 
 	/**
-	 * This effect is responsible for invalidating the in progress media query whenever
-	 * the epub reader is unmounted. This is so that the in progress media query will
-	 * refetch the updated progress information.
+	 * Invalidate the book query when a reader is unmounted so that the book overview
+	 * is updated with the latest read progress
 	 */
-	useEffect(() => {
-		return () => {
-			queryClient.invalidateQueries([sdk.media.keys.inProgress], { exact: false })
-		}
-	}, [sdk.media])
+	useEffect(
+		() => {
+			return () => {
+				queryClient.refetchQueries({ queryKey: [sdk.media.keys.getByID, id], exact: false })
+				queryClient.refetchQueries({ queryKey: [sdk.media.keys.inProgress], exact: false })
+			}
+		},
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[],
+	)
 
 	/**
 	 * A callback for when the reader should paginate forward. This will only run if the

--- a/packages/client/src/queries/epub.ts
+++ b/packages/client/src/queries/epub.ts
@@ -104,8 +104,10 @@ export function useEpub(id: string, _options?: EpubOptions, enabled?: boolean) {
 
 export function useEpubLazy(id: string) {
 	const { sdk } = useSDK()
-	const { data: epub, ...restReturn } = useQuery([sdk.epub.keys.getByID, id], () =>
-		sdk.epub.getByID(id),
+	const { data: epub, ...restReturn } = useQuery(
+		[sdk.epub.keys.getByID, id],
+		() => sdk.epub.getByID(id),
+		{ staleTime: 0, cacheTime: 0 },
 	)
 
 	return {

--- a/packages/client/src/queries/epub.ts
+++ b/packages/client/src/queries/epub.ts
@@ -104,10 +104,8 @@ export function useEpub(id: string, _options?: EpubOptions, enabled?: boolean) {
 
 export function useEpubLazy(id: string) {
 	const { sdk } = useSDK()
-	const { data: epub, ...restReturn } = useQuery(
-		[sdk.epub.keys.getByID, id],
-		() => sdk.epub.getByID(id),
-		{ staleTime: 0, cacheTime: 0 },
+	const { data: epub, ...restReturn } = useQuery([sdk.epub.keys.getByID, id], () =>
+		sdk.epub.getByID(id),
 	)
 
 	return {


### PR DESCRIPTION
when useQuery has a cache for a book entity, the first progress api request is triggered with outdated progress data.


Steps to Reproduce:
1.  Go to a book and click Continue Reading
2. Chapter one loads lets say
3. Open chapters modal and click on Chapter 2
4. Click the back arrow on the top left
5. Click Continue Reading again
6. repeat steps 2-5 and notice how the book loads alternating between chapter 1 and 2
-------

this PR removes cache from this query which is not ideal. open to suggestions! I tried using some properties that come back from useEpubLazy() but it was getting complicated same for invalidating the query cache.

Alternatively, we could prevent the very first progress api request after loading the book/entity since there should be no need for that first one. I havent thought that completely through.
