### PR TITLE
:bug: Fix incorrect thumbnail names

### DIFF
--- a/apps/server/src/routers/api/v1/library.rs
+++ b/apps/server/src/routers/api/v1/library.rs
@@ -700,6 +700,7 @@ async fn patch_library_thumbnail(
 			image_options,
 			core_config: ctx.config.as_ref().clone(),
 			force_regen: true,
+			filename: Some(id.clone()),
 		},
 	)
 	.await?;

--- a/apps/server/src/routers/api/v1/media/thumbnails.rs
+++ b/apps/server/src/routers/api/v1/media/thumbnails.rs
@@ -211,6 +211,7 @@ pub(crate) async fn patch_media_thumbnail(
 			image_options,
 			core_config: ctx.config.as_ref().clone(),
 			force_regen: true,
+			filename: Some(media.id.clone()),
 		},
 	)
 	.await?;

--- a/apps/server/src/routers/api/v1/series.rs
+++ b/apps/server/src/routers/api/v1/series.rs
@@ -559,9 +559,11 @@ async fn patch_series_thumbnail(
 			image_options,
 			core_config: ctx.config.as_ref().clone(),
 			force_regen: true,
+			filename: media.series_id.clone(),
 		},
 	)
 	.await?;
+	tracing::debug!(?path_buf, "Generated thumbnail for series");
 
 	Ok(ImageResponse::from((
 		ContentType::from(format),

--- a/core/src/filesystem/image/thumbnail/generate.rs
+++ b/core/src/filesystem/image/thumbnail/generate.rs
@@ -33,6 +33,7 @@ pub struct GenerateThumbnailOptions {
 	pub image_options: ImageProcessorOptions,
 	pub core_config: StumpConfig,
 	pub force_regen: bool,
+	pub filename: Option<String>,
 }
 
 /// A type alias for whether a thumbnail was generated or not during the generation process. This is
@@ -74,10 +75,11 @@ pub async fn generate_book_thumbnail(
 		image_options,
 		core_config,
 		force_regen,
+		filename,
 	}: GenerateThumbnailOptions,
 ) -> Result<GenerateOutput, ThumbnailGenerateError> {
 	let book_path = book.path.clone();
-	let file_name = book.id.clone();
+	let file_name = filename.unwrap_or_else(|| book.id.clone());
 
 	let file_path = core_config.get_thumbnails_dir().join(format!(
 		"{}.{}",

--- a/core/src/filesystem/image/thumbnail/generation_job.rs
+++ b/core/src/filesystem/image/thumbnail/generation_job.rs
@@ -207,6 +207,7 @@ impl JobExt for ThumbnailGenerationJob {
 						image_options: self.options.clone(),
 						core_config: ctx.config.as_ref().clone(),
 						force_regen: self.params.force_regenerate,
+						filename: None, // Each book will use its ID as the filename
 					},
 					|position| {
 						ctx.report_progress(JobProgress::subtask_position(

--- a/packages/browser/src/components/entity/EntityCard.tsx
+++ b/packages/browser/src/components/entity/EntityCard.tsx
@@ -135,6 +135,7 @@ export default function EntityCard({
 						console.error('Failed to load image:', e)
 						setIsImageFailed(true)
 					}}
+					data-testid="entity-card-image"
 				/>
 			)
 		} else {

--- a/packages/browser/src/components/thumbnail/EditThumbnailDropdown.tsx
+++ b/packages/browser/src/components/thumbnail/EditThumbnailDropdown.tsx
@@ -35,7 +35,7 @@ export default function EditThumbnailDropdown({ label, onChooseSelector, onUploa
 				align="start"
 				contentWrapperClassName="w-18"
 				trigger={
-					<Button size="md" className="border border-edge" variant="outline">
+					<Button size="md" className="border border-edge">
 						{label || t(withLocaleKey('label'))}
 						<ChevronDown className="ml-2 h-4 w-4" />
 					</Button>

--- a/packages/sdk/src/controllers/series-api.ts
+++ b/packages/sdk/src/controllers/series-api.ts
@@ -111,7 +111,7 @@ export class SeriesAPI extends APIBase {
 	 * Patch the thumbnail of a series
 	 */
 	async patchThumbnail(id: string, payload: PatchSeriesThumbnail): Promise<void> {
-		this.axios.patch(this.thumbnailURL(id), payload)
+		return this.axios.patch(this.thumbnailURL(id), payload)
 	}
 
 	/**


### PR DESCRIPTION
Fixes #619

The root of the issue was a regression introduced by #442, the filename was always using the book and not the actual entity (e.g., a series ID). The secondary issue of the browser cache still remains, albeit improved. After patching a thumbnail I send a `GET` to the thumbnail with cache headers aimed at busting the cache, which seems to fix the issue of having to disable the entire browser cache and refresh but still requires a refresh before you see the image.