### PR TITLE
:bug: Actually scan opf when getting metadata

### DIFF
--- a/core/src/filesystem/media/format/epub.rs
+++ b/core/src/filesystem/media/format/epub.rs
@@ -166,8 +166,11 @@ impl FileProcessor for EpubProcessor {
 		let epub_file = Self::open(path)?;
 
 		let pages = epub_file.get_num_pages() as i32;
-		// Note: The metadata is already parsed by the EPUB library, so might as well use it
-		let metadata = MediaMetadata::from(epub_file.metadata);
+		// Get metadata from epub file or opf if it exists
+		let metadata = match Self::process_metadata(path) {
+			Ok(Some(m)) => m,
+			_ => MediaMetadata::from(epub_file.metadata),
+		};
 		let ProcessedFileHashes {
 			hash,
 			koreader_hash,

--- a/core/src/filesystem/media/format/epub.rs
+++ b/core/src/filesystem/media/format/epub.rs
@@ -162,12 +162,14 @@ impl FileProcessor for EpubProcessor {
 	) -> Result<ProcessedFile, FileError> {
 		tracing::debug!(?path, "processing epub");
 
+		let metadata = Self::process_metadata(path);
+
 		let path_buf = PathBuf::from(path);
 		let epub_file = Self::open(path)?;
 
 		let pages = epub_file.get_num_pages() as i32;
-		// Get metadata from epub file or opf if it exists
-		let metadata = match Self::process_metadata(path) {
+		// Get metadata from epub file if process_metadata failed
+		let metadata = match metadata {
 			Ok(Some(m)) => m,
 			_ => MediaMetadata::from(epub_file.metadata),
 		};


### PR DESCRIPTION
#607 Did not actually implement the feature as `process_metadata` was never called by `process`