### PR TITLE
:adhesive_bandage: Fix request method for updating job scheduler

### DIFF
--- a/packages/sdk/src/controllers/job-api.ts
+++ b/packages/sdk/src/controllers/job-api.ts
@@ -65,7 +65,7 @@ export class JobAPI extends APIBase {
 	 * Update the config for the job scheduler
 	 */
 	async updateSchedulerConfig(config: UpdateSchedulerConfig): Promise<JobSchedulerConfig> {
-		const { data: updatedConfig } = await this.axios.put<JobSchedulerConfig>(
+		const { data: updatedConfig } = await this.axios.post<JobSchedulerConfig>(
 			jobURL('scheduler-config'),
 			config,
 		)


### PR DESCRIPTION
It should have been `POST`, the SDK was sending `PUT`s