### PR TITLE
⬆️ Bump MSRV

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.81.0
+        toolchain: 1.85.0
         profile: minimal
         override: true
         components: rustfmt, clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [workspace.package]
 version = "0.0.10"
-rust-version = "1.81.0"
+rust-version = "1.85.0"
 
 [workspace.dependencies]
 alphanumeric-sort = "1.5.3"

--- a/apps/server/src/middleware/auth.rs
+++ b/apps/server/src/middleware/auth.rs
@@ -157,7 +157,7 @@ pub async fn auth_middleware(
 	let save_basic_session = req_headers
 		.get(STUMP_SAVE_BASIC_SESSION_HEADER)
 		.and_then(|header| header.to_str().ok())
-		.map_or(true, |header| header == "true");
+		.is_none_or(|header| header == "true");
 
 	let request_uri = req.extensions().get::<OriginalUri>().cloned().map_or_else(
 		|| req.uri().path().to_owned(),

--- a/core/src/db/entity/user/entity.rs
+++ b/core/src/db/entity/user/entity.rs
@@ -90,13 +90,6 @@ pub struct PartialUser {
 	// TODO: other "public-facing" fields which are opt-in social features (e.g. currently reading, etc.)
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Type, ToSchema)]
-#[serde(untagged)]
-pub enum UserProfile {
-	Full(User),
-	Partial(PartialUser),
-}
-
 impl From<User> for PartialUser {
 	fn from(user: User) -> PartialUser {
 		PartialUser {

--- a/core/src/filesystem/scanner/library_watcher.rs
+++ b/core/src/filesystem/scanner/library_watcher.rs
@@ -498,8 +498,7 @@ mod tests {
 		std::fs::create_dir_all(&tmp_dir).unwrap();
 		let libraries = create_test_libraries(tmp_dir.to_string_lossy().to_string());
 
-		let paths =
-			HashSet::from_iter(vec![PathBuf::from(tmp_dir.clone().join("new_file"))]);
+		let paths = HashSet::from_iter(vec![tmp_dir.clone().join("new_file")]);
 
 		let mut mock_objs = create_mock_library(libraries).await.unwrap();
 

--- a/core/src/opds/v2_0/group.rs
+++ b/core/src/opds/v2_0/group.rs
@@ -47,15 +47,13 @@ impl OPDSFeedGroupBuilder {
 			return Ok(());
 		}
 
-		let navigation_empty = self
-			.navigation
-			.as_ref()
-			.map_or(true, std::vec::Vec::is_empty);
+		let navigation_empty =
+			self.navigation.as_ref().is_none_or(std::vec::Vec::is_empty);
 
 		let publications_empty = self
 			.publications
 			.as_ref()
-			.map_or(true, std::vec::Vec::is_empty);
+			.is_none_or(std::vec::Vec::is_empty);
 
 		if navigation_empty && publications_empty {
 			return Err(OPDSV2Error::FeedValidationFailed(

--- a/crates/codegen/Cargo.toml
+++ b/crates/codegen/Cargo.toml
@@ -2,7 +2,6 @@
 name = "codegen"
 edition = "2021"
 version.workspace = true
-rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/email/Cargo.toml
+++ b/crates/email/Cargo.toml
@@ -2,8 +2,6 @@
 name = "email"
 edition = "2021"
 version.workspace = true
-rust-version.workspace = true
-
 
 [dependencies]
 handlebars = "5.1.0"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,7 +59,7 @@ RUN --mount=type=cache,target=/usr/local/yarn/.cache,id=${TARGETARCH} \
 # Cargo Build Stage
 # ------------------------------------------------------------------------------
 
-FROM rust:1.81-bookworm AS builder
+FROM rust:1.85-bookworm AS builder
 
 ARG GIT_REV
 ARG TARGETARCH


### PR DESCRIPTION
This PR bumps the minimum supported rust version (MSRV) to 1.85.0 and also fixes a couple of clippy lints that were added for that version.

Additionally, I went to fix a lint error by changing `UserProfile` in `core::db::entity::user` to use `Full(Box<User>)` instead and avoid bloating the size of the enum. However, I realized that the `UserProfile` isn't actually used anywhere, so I just removed it instead. Let me know if it has a future use planned and should be kept in.