### PR TITLE
🐛 Fix reading progress resetting due to cached data again

### DIFF
--- a/packages/browser/src/components/readers/epub/EpubJsReader.tsx
+++ b/packages/browser/src/components/readers/epub/EpubJsReader.tsx
@@ -306,6 +306,8 @@ export default function EpubJsReader({ id, initialCfi }: EpubJsReaderProps) {
 	useEffect(
 		() => {
 			return () => {
+				queryClient.cancelQueries({ queryKey: [sdk.media.keys.getByID, id], exact: false })
+				queryClient.cancelQueries({ queryKey: [sdk.media.keys.inProgress], exact: false })
 				queryClient.refetchQueries({ queryKey: [sdk.media.keys.getByID, id], exact: false })
 				queryClient.refetchQueries({ queryKey: [sdk.media.keys.inProgress], exact: false })
 			}


### PR DESCRIPTION
Finally had some time to look at this again! 

Following up on: https://github.com/stumpapp/stump/pull/615

Having both `cancelQueries` and `refetchQueries` ensures we invalidate the cache and refetch fresh data.