### PR TITLE
:wrench: Add `NSAllowsArbitraryLoads` to info plist

### DIFF
--- a/apps/expo/app.config.ts
+++ b/apps/expo/app.config.ts
@@ -22,6 +22,9 @@ export default ({ config }: ConfigContext): ExpoConfig => {
 			},
 			infoPlist: {
 				ITSAppUsesNonExemptEncryption: false,
+				NSAppTransportSecurity: {
+					NSAllowsArbitraryLoads: true,
+				},
 			},
 		},
 		android: {


### PR DESCRIPTION
This PR makes it so that insecure URLs should be able to be reached on iOS