### PR TITLE
:green_heart: Fix invalid debian tag

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 # PDFium Stage
 # ------------------------------------------------------------------------------
 
-FROM debian:buster-slim AS pdfium
+FROM debian:bookworm-slim AS pdfium
 
 # Update and install curl and tar
 RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
@@ -95,7 +95,6 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,id=${TARGETARCH} \
 # Final Stage
 # ------------------------------------------------------------------------------
 
-# FROM debian:buster-slim
 FROM gcr.io/distroless/cc-debian12:debug
 
 RUN [ "/busybox/ln", "-s", "/busybox/sh", "/bin/sh" ]


### PR DESCRIPTION
It seems the one I was pulling is no longer available. See https://github.com/stumpapp/stump/actions/runs/16252421277/job/45883900370?pr=672