### PR TITLE
:pushpin: Pin `eslint-config-prettier` to `9.1.2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"@typescript-eslint/parser": "^8.10.0",
 		"concurrently": "^8.2.2",
 		"eslint": "^9.13.0",
-		"eslint-config-prettier": "^9.1.0",
+		"eslint-config-prettier": "=9.1.2",
 		"eslint-plugin-prettier": "^5.2.1",
 		"eslint-plugin-react": "^7.37.1",
 		"eslint-plugin-react-hooks": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11262,10 +11262,10 @@ eslint-config-next@^14.2.15:
     eslint-plugin-react "^7.33.2"
     eslint-plugin-react-hooks "^4.5.0 || 5.0.0-canary-7118f5dd7-20230705"
 
-eslint-config-prettier@^9.1.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz#31af3d94578645966c082fcb71a5846d3c94867f"
-  integrity sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==
+eslint-config-prettier@=9.1.2:
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-9.1.2.tgz#90deb4fa0259592df774b600dbd1d2249a78ce91"
+  integrity sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==
 
 eslint-import-resolver-node@^0.3.6, eslint-import-resolver-node@^0.3.9:
   version "0.3.9"


### PR DESCRIPTION
This is in response to an exploit. See https://github.com/prettier/eslint-config-prettier/issues/339 for additional details

Note that this really only affected folks running this from source on Windows machines: https://safedep.io/eslint-config-prettier-major-npm-supply-chain-hack/#what-is-the-impact