### PR TITLE
:bug: Fix book-level `tapSidesToNavigate` not overriding global

### DIFF
--- a/packages/browser/src/components/readers/imageBased/paged/PagedReader.tsx
+++ b/packages/browser/src/components/readers/imageBased/paged/PagedReader.tsx
@@ -30,7 +30,8 @@ export type PagedReaderProps = {
  */
 function PagedReader({ currentPage, media, onPageChange, getPageUrl }: PagedReaderProps) {
 	const {
-		settings: { showToolBar, tapSidesToNavigate },
+		bookPreferences: { tapSidesToNavigate },
+		settings: { showToolBar },
 		setSettings,
 	} = useBookPreferences({ book: media })
 

--- a/packages/browser/src/scenes/book/reader/useBookPreferences.ts
+++ b/packages/browser/src/scenes/book/reader/useBookPreferences.ts
@@ -39,7 +39,7 @@ export function useBookPreferences({ book }: Params): Return {
 
 	const bookPreferences = useMemo(
 		() => buildPreferences(storedBookPreferences ?? {}, settings, libraryConfig),
-		[storedBookPreferences, libraryConfig],
+		[storedBookPreferences, libraryConfig, settings],
 	)
 
 	const setBookPreferences = useCallback(
@@ -70,12 +70,23 @@ const defaultsFromLibraryConfig = (libraryConfig?: LibraryConfig): BookPreferenc
 		readingMode: libraryConfig?.default_reading_mode || 'paged',
 	}) as BookPreferences
 
+const settingsAsBookPreferences = (settings: ReaderSettings): BookPreferences => ({
+	brightness: settings.brightness,
+	imageScaling: settings.imageScaling,
+	readingDirection: settings.readingDirection,
+	readingMode: settings.readingMode,
+	tapSidesToNavigate: settings.tapSidesToNavigate,
+	fontSize: settings.fontSize,
+	lineHeight: settings.lineHeight,
+	trackElapsedTime: settings.trackElapsedTime,
+})
+
 const buildPreferences = (
 	preferences: Partial<BookPreferences>,
 	settings: ReaderSettings,
 	libraryConfig?: LibraryConfig,
 ): BookPreferences => ({
-	...settings,
+	...settingsAsBookPreferences(settings),
 	...defaultsFromLibraryConfig(libraryConfig),
 	...preferences,
 })


### PR DESCRIPTION
This is a small fix that correctly pulls `tapSidesToNavigate` from the book-level preferences. The manifestation of the bug makes it seem like taps aren't working because the global setting was disabled.

To work around it, you just need to enable the setting globally. This is not ideal, and defeats the purpose of having book-level preferences, but is a small fix that will go out with `nightly` and whenever I can roll another version