### PR TITLE
🐛 Fix image reader bugs

### DIFF
--- a/packages/browser/src/components/readers/imageBased/ImageBasedReader.tsx
+++ b/packages/browser/src/components/readers/imageBased/ImageBasedReader.tsx
@@ -103,13 +103,18 @@ export default function ImageBasedReader({
 	const pageSets = useMemo(() => {
 		const autoButOff = doublePageBehavior === 'auto' && deviceOrientation === 'portrait'
 		const modeForceOff = readingMode === 'continuous:vertical'
+		let sets: number[][] = []
+
 		if (doublePageBehavior === 'off' || autoButOff || modeForceOff) {
-			return Array.from({ length: pages }, (_, i) => [i])
+			sets = Array.from({ length: pages }, (_, i) => [i])
+		} else {
+			sets = generatePageSets({ imageSizes: pageDimensions, pages: pages })
 		}
-		const sets = generatePageSets({ imageSizes: pageDimensions, pages: pages })
+
 		if (readingDirection === 'rtl') {
-			return sets.reverse()
+			return [...sets.map((set) => [...set].reverse())].reverse()
 		}
+
 		return sets
 	}, [doublePageBehavior, pages, pageDimensions, deviceOrientation, readingMode, readingDirection])
 

--- a/packages/browser/src/components/readers/imageBased/container/ControlButton.tsx
+++ b/packages/browser/src/components/readers/imageBased/container/ControlButton.tsx
@@ -1,15 +1,13 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
-import { IconButton } from '@stump/components'
+import { cn, IconButton } from '@stump/components'
 import { ComponentProps, forwardRef } from 'react'
 
 const ControlButton = forwardRef<HTMLButtonElement, ComponentProps<typeof IconButton>>(
 	({ className, ...props }, ref) => {
 		return (
 			<IconButton
-				variant="ghost"
+				variant="ghost-on-black"
 				size="xs"
-				className="hover:bg-background-surface-hover"
+				className={cn('hover:bg-fill-on-black focus:ring-offset-black', className)}
 				ref={ref}
 				pressEffect={false}
 				{...props}

--- a/packages/browser/src/components/readers/imageBased/container/ControlsOverlay.tsx
+++ b/packages/browser/src/components/readers/imageBased/container/ControlsOverlay.tsx
@@ -46,6 +46,7 @@ const transition = {
 			duration: 0.2,
 			ease: 'easeInOut',
 		},
+		display: 'none',
 	},
 	visible: {
 		opacity: 1,
@@ -53,5 +54,6 @@ const transition = {
 			duration: 0.2,
 			ease: 'easeInOut',
 		},
+		display: 'flex',
 	},
 }

--- a/packages/browser/src/components/readers/imageBased/container/ReaderFooter.tsx
+++ b/packages/browser/src/components/readers/imageBased/container/ReaderFooter.tsx
@@ -152,7 +152,7 @@ export default function ReaderFooter() {
 			<div className="flex w-full flex-col gap-2 px-4 pb-4">
 				<ProgressBar
 					size="sm"
-					value={40}
+					value={currentPage}
 					max={book.pages}
 					className="bg-[#898d94]"
 					indicatorClassName="bg-[#f5f3ef]"

--- a/packages/browser/src/components/readers/imageBased/container/ReaderHeader.tsx
+++ b/packages/browser/src/components/readers/imageBased/container/ReaderHeader.tsx
@@ -37,7 +37,7 @@ export default function ReaderHeader() {
 			<div className="flex w-full items-center justify-between">
 				<div className="flex items-center space-x-4">
 					<Link
-						className="text-foreground-on-black hover:text-foreground-on-black/80 flex items-center"
+						className="flex items-center text-foreground-on-black hover:text-foreground-on-black/80"
 						title="Go to media overview"
 						to={paths.bookOverview(id)}
 					>

--- a/packages/browser/src/components/readers/imageBased/container/ReaderHeader.tsx
+++ b/packages/browser/src/components/readers/imageBased/container/ReaderHeader.tsx
@@ -37,7 +37,7 @@ export default function ReaderHeader() {
 			<div className="flex w-full items-center justify-between">
 				<div className="flex items-center space-x-4">
 					<Link
-						className="flex items-center"
+						className="text-foreground-on-black hover:text-foreground-on-black/80 flex items-center"
 						title="Go to media overview"
 						to={paths.bookOverview(id)}
 					>
@@ -45,7 +45,7 @@ export default function ReaderHeader() {
 					</Link>
 				</div>
 
-				<Text>{title}</Text>
+				<Text className="text-foreground-on-black">{title}</Text>
 
 				<div className="flex items-center space-x-2">
 					{isFullscreenAvailable && (

--- a/packages/browser/src/components/readers/imageBased/container/TimerMenu.tsx
+++ b/packages/browser/src/components/readers/imageBased/container/TimerMenu.tsx
@@ -16,7 +16,7 @@ export default function TimerMenu() {
 	return (
 		<Dropdown>
 			<Dropdown.Trigger asChild>
-				<ControlButton>
+				<ControlButton className="text-foreground-on-black">
 					<Clock className="h-4 w-4" />
 				</ControlButton>
 			</Dropdown.Trigger>

--- a/packages/browser/src/scenes/book/reader/BookReaderScene.tsx
+++ b/packages/browser/src/scenes/book/reader/BookReaderScene.tsx
@@ -14,6 +14,7 @@ export default function BookReaderSceneContainer() {
 
 	const { media } = useMediaByIdQuery(id || '', {
 		params: {
+			load_series: true,
 			load_library: true,
 		},
 		suspense: true,

--- a/packages/browser/src/scenes/book/reader/useBookPreferences.ts
+++ b/packages/browser/src/scenes/book/reader/useBookPreferences.ts
@@ -60,15 +60,17 @@ export function useBookPreferences({ book }: Params): Return {
 	}
 }
 
-const defaultsFromLibraryConfig = (libraryConfig?: LibraryConfig): BookPreferences =>
+const defaultsFromLibraryConfig = (libraryConfig?: LibraryConfig): Partial<BookPreferences> =>
 	({
 		brightness: 1,
-		imageScaling: {
-			scaleToFit: libraryConfig?.default_reading_image_scale_fit || 'height',
-		},
-		readingDirection: libraryConfig?.default_reading_dir || 'ltr',
-		readingMode: libraryConfig?.default_reading_mode || 'paged',
-	}) as BookPreferences
+		imageScaling: libraryConfig?.default_reading_image_scale_fit
+			? {
+					scaleToFit: libraryConfig?.default_reading_image_scale_fit,
+				}
+			: undefined,
+		readingDirection: libraryConfig?.default_reading_dir,
+		readingMode: libraryConfig?.default_reading_mode,
+	}) as Partial<BookPreferences>
 
 const settingsAsBookPreferences = (settings: ReaderSettings): BookPreferences => ({
 	brightness: settings.brightness,

--- a/packages/components/src/button/Button.tsx
+++ b/packages/components/src/button/Button.tsx
@@ -22,6 +22,8 @@ export const BUTTON_VARIANTS = {
 		'bg-background-surface hover:bg-background-surface-hover text-foreground focus:ring-edge-brand',
 	ghost:
 		'bg-transparent hover:bg-background-surface-hover text-foreground-subtle data-[state=open]:bg-transparent',
+	'ghost-on-black':
+		'bg-transparent hover:bg-background-surface-hover text-foreground-on-black data-[state=open]:bg-transparent',
 	link: 'bg-transparent dark:bg-transparent underline-offset-4 hover:underline text-gray-900 dark:text-gray-100 hover:bg-transparent dark:hover:bg-transparent',
 	outline: 'bg-transparent border border-edge-subtle hover:bg-background-surface text-foreground',
 	primary:

--- a/packages/components/themes/autumn.ts
+++ b/packages/components/themes/autumn.ts
@@ -51,6 +51,10 @@ export const autumn = {
 			hover: '#FFB70326',
 			secondary: '#FFB70326',
 		},
+		'on-black': {
+			DEFAULT: '#242628',
+			muted: '#242628',
+		},
 	},
 	foreground: {
 		DEFAULT: '#F7F0E4',
@@ -58,6 +62,10 @@ export const autumn = {
 		disabled: '#A29A8D',
 		muted: '#A29A8D',
 		'on-inverse': '#2C1A12',
+		'on-black': {
+			DEFAULT: '#F7F0E4',
+			muted: '#A29A8D',
+		},
 		subtle: '#E5DCC5',
 	},
 	sidebar: {

--- a/packages/components/themes/cosmic.ts
+++ b/packages/components/themes/cosmic.ts
@@ -55,6 +55,10 @@ export const cosmic = {
 			hover: '#F5AC39',
 			secondary: '#F39C1226',
 		},
+		'on-black': {
+			DEFAULT: '#242628',
+			muted: '#242628',
+		},
 	},
 	foreground: {
 		DEFAULT: '#F4F2FF',
@@ -62,6 +66,10 @@ export const cosmic = {
 		disabled: '#A29BCC',
 		muted: '#A29BCC',
 		'on-inverse': '#1C0F45',
+		'on-black': {
+			DEFAULT: '#F4F2FF',
+			muted: '#A29BCC',
+		},
 		subtle: '#D1C5E5',
 	},
 	sidebar: {

--- a/packages/components/themes/dark.ts
+++ b/packages/components/themes/dark.ts
@@ -51,14 +51,22 @@ export const dark = {
 			hover: '#F7AE32',
 			secondary: '#F59E0B26',
 		},
+		'on-black': {
+			DEFAULT: '#242628',
+			muted: '#242628',
+		},
 	},
 	foreground: {
 		DEFAULT: '#F5F3EF',
 		brand: '#C48259',
 		disabled: '#898D94',
 		muted: '#898D94',
-		'on-inverse': '#161719',
 		subtle: '#E9EAEB',
+		'on-inverse': '#161719',
+		'on-black': {
+			DEFAULT: '#E9EAEB',
+			muted: '#B0B3B7',
+		},
 	},
 	sidebar: {
 		DEFAULT: '#151517',

--- a/packages/components/themes/light.ts
+++ b/packages/components/themes/light.ts
@@ -52,15 +52,22 @@ export const light = {
 			hover: '#C07C08',
 			secondary: '#F59E0B26',
 		},
+		'on-black': {
+			DEFAULT: '#242628',
+			muted: '#242628',
+		},
 	},
 	foreground: {
 		DEFAULT: '#000000',
 		brand: '#C48259',
 		disabled: '#93979D',
-
 		muted: '#414347',
 		// #5B5F65 OR #7D828A
 		'on-inverse': dark.foreground.DEFAULT,
+		'on-black': {
+			DEFAULT: '#E9EAEB',
+			muted: '#B0B3B7',
+		},
 		subtle: '#26272A',
 	},
 	sidebar: {

--- a/packages/components/themes/ocean.ts
+++ b/packages/components/themes/ocean.ts
@@ -51,6 +51,10 @@ export const ocean = {
 			hover: '#FF8C00',
 			secondary: '#F77F0026',
 		},
+		'on-black': {
+			DEFAULT: '#242628',
+			muted: '#242628',
+		},
 	},
 	foreground: {
 		DEFAULT: '#EDF2F4',
@@ -58,6 +62,10 @@ export const ocean = {
 		disabled: '#94A1AC',
 		muted: '#94A1AC',
 		'on-inverse': '#0B3D4D',
+		'on-black': {
+			DEFAULT: '#EDF2F4',
+			muted: '#B0B3B7',
+		},
 		subtle: '#D9E4EA',
 	},
 	sidebar: {

--- a/packages/components/themes/pumpkin.ts
+++ b/packages/components/themes/pumpkin.ts
@@ -47,6 +47,10 @@ export const pumpkin: StumpTheme = {
 		// DEFAULT: '#DE9887',
 		// muted: '#883926',
 		// subtle: '#F84D11',
+		'on-black': {
+			DEFAULT: '#F0C4AE',
+			muted: '#E7A17F',
+		},
 	},
 	sidebar: {
 		DEFAULT: '#090909',

--- a/packages/components/themes/types.ts
+++ b/packages/components/themes/types.ts
@@ -33,6 +33,12 @@ type SecondaryVariant = {
 	secondary: string
 } & DefaultVariant
 
+type OnBlackVariant = {
+	'on-black': {
+		muted: string
+	} & DefaultVariant
+}
+
 export const colorVariant = ['info', 'success', 'warning', 'danger', 'brand'] as const
 
 type Border = Record<(typeof colorVariant)[number], string> & {
@@ -102,7 +108,8 @@ type Foreground = {
 	 */
 	'on-inverse': string
 } & DefaultVariant &
-	DisabledVariant
+	DisabledVariant &
+	OnBlackVariant
 
 // TODO: add secondary fill variant
 /**
@@ -110,7 +117,8 @@ type Foreground = {
  * follows the standard color variants of 'info', 'success', 'warning', 'danger', and 'brand'
  */
 type Color = Record<(typeof colorVariant)[number], SecondaryVariant & HoverVariant> &
-	DisabledVariant
+	DisabledVariant &
+	OnBlackVariant
 
 /**
  * The primary type which represents the color tokens for the Stump UI. These are translated for use as


### PR DESCRIPTION
Resolves https://github.com/stumpapp/stump/issues/684
Resolves https://github.com/stumpapp/stump/issues/685

This PR fixes a few bugs all at once, but I isolated each in a separate commit. I'll likely retain each, instead of squashing, to keep a better record of what was fixed in the eventual changelog:

- The vertical scroll reader can now _actually_ scroll lol The control overlay was eating the scroll event, which prevented scroll from working
- The progress bar in the image reader foot now actually displays the percentage, not a fixed value
- I tried to improve the contrast for the buttons in the reader header for all themes, but am open to feedback if we feel they need further tweaking
- The library defaults should now be considered when resolving a book's preference bundle. The query did not correctly request the library info from the server, so it was missing from the response and therefore not being considered in that resolution step
- I corrected the logic which attempted to invert the page sets when in RTL reading