### PR TITLE
:construction: Migrate book management and thumbnail selectors

### DIFF
--- a/crates/graphql/schema.graphql
+++ b/crates/graphql/schema.graphql
@@ -1159,7 +1159,7 @@ type Mutation {
 	analyzeMedia(id: ID!): Boolean!
 	convertMedia(id: ID!): Boolean!
 	"""
-	Update the thumbnail for a library. This will replace the existing thumbnail with the the one
+	Update the thumbnail for a book. This will replace the existing thumbnail with the the one
 	associated with the provided input (book). If the book does not have a thumbnail, one
 	will be generated based on the library's thumbnail configuration.
 	"""
@@ -1251,6 +1251,12 @@ type Mutation {
 	"""
 	deleteReadingList(id: String!): ReadingList!
 	analyzeSeries(id: ID!): Boolean!
+	"""
+	Update the thumbnail for a series. This will replace the existing thumbnail with the the one
+	associated with the provided input (book). If the book does not have a thumbnail, one
+	will be generated based on the library's thumbnail configuration.
+	"""
+	updateSeriesThumbnail(id: ID!, input: UpdateThumbnailInput!): Series!
 	markSeriesAsComplete(id: ID!): Series!
 	scanSeries(id: ID!): Boolean!
 	"""
@@ -1270,6 +1276,7 @@ type Mutation {
 	uploadBooks(input: UploadBooksInput!): Boolean!
 	uploadSeries(input: UploadSeriesInput!): Boolean!
 	uploadLibraryThumbnail(id: ID!, file: Upload!): Library!
+	uploadSeriesThumbnail(id: ID!, file: Upload!): Series!
 	uploadMediaThumbnail(id: ID!, file: Upload!): Media!
 	deleteLoginActivity: Int!
 	createUser(input: CreateUserInput!): User!

--- a/crates/graphql/schema.graphql
+++ b/crates/graphql/schema.graphql
@@ -1158,6 +1158,12 @@ type Mutation {
 	deleteBookmark(epubcfi: String!): Bookmark!
 	analyzeMedia(id: ID!): Boolean!
 	convertMedia(id: ID!): Boolean!
+	"""
+	Update the thumbnail for a library. This will replace the existing thumbnail with the the one
+	associated with the provided input (book). If the book does not have a thumbnail, one
+	will be generated based on the library's thumbnail configuration.
+	"""
+	updateMediaThumbnail(id: ID!, input: PageBasedThumbnailInput!): Media!
 	deleteMediaProgress(id: ID!): Media!
 	updateMediaProgress(id: ID!, page: Int, elapsedSeconds: Int): ReadingProgressOutput!
 	markMediaAsComplete(id: ID!, isComplete: Boolean!, page: Int): FinishedReadingSessionModel
@@ -1190,7 +1196,7 @@ type Mutation {
 	associated with the provided input (book). If the book does not have a thumbnail, one
 	will be generated based on the library's thumbnail configuration.
 	"""
-	updateLibraryThumbnail(id: ID!, input: UpdateLibraryThumbnailInput!): Library!
+	updateLibraryThumbnail(id: ID!, input: UpdateThumbnailInput!): Library!
 	"""
 	Exclude users from a library, preventing them from seeing the library in the UI. This operates as a
 	full replacement of the excluded users list, so any users not included in the provided list will be
@@ -1264,6 +1270,7 @@ type Mutation {
 	uploadBooks(input: UploadBooksInput!): Boolean!
 	uploadSeries(input: UploadSeriesInput!): Boolean!
 	uploadLibraryThumbnail(id: ID!, file: Upload!): Library!
+	uploadMediaThumbnail(id: ID!, file: Upload!): Media!
 	deleteLoginActivity: Int!
 	createUser(input: CreateUserInput!): User!
 	updateViewer(input: UpdateUserInput!): User!
@@ -1400,6 +1407,13 @@ enum OrderDirection {
 "A struct containing the various analyses of a book in Stump, e.g., page dimensions."
 type PageAnalysis {
 	dimensions: [PageDimension!]!
+}
+
+input PageBasedThumbnailInput {
+	"The page to pull inside the media file for generating the thumbnail"
+	page: Int!
+	"A flag indicating whether the page is zero based (i.e. 0 is the first page)"
+	isZeroBased: Boolean = null
 }
 
 """
@@ -2117,12 +2131,12 @@ input UpdateBookClubInput {
 	emoji: String
 }
 
-input UpdateLibraryThumbnailInput {
+input UpdateThumbnailInput {
 	"The ID of the media inside the series to fetch"
 	mediaId: String!
-	"The page of the media to use for the thumbnail"
+	"The page to pull inside the media file for generating the thumbnail"
 	page: Int!
-	"A flag indicating whether the page is zero based"
+	"A flag indicating whether the page is zero based (i.e. 0 is the first page)"
 	isZeroBased: Boolean = null
 }
 

--- a/crates/graphql/src/input/library.rs
+++ b/crates/graphql/src/input/library.rs
@@ -108,27 +108,3 @@ impl LibraryConfigInput {
 		}
 	}
 }
-
-// TODO: Support using a series thumbnail?
-#[derive(Debug, Default, InputObject)]
-pub struct UpdateLibraryThumbnailInput {
-	/// The ID of the media inside the series to fetch
-	pub media_id: String,
-	/// The page of the media to use for the thumbnail
-	page: i32,
-	#[graphql(default)]
-	/// A flag indicating whether the page is zero based
-	is_zero_based: Option<bool>,
-}
-
-impl UpdateLibraryThumbnailInput {
-	pub fn page(&self) -> i32 {
-		self.is_zero_based.map_or(self.page, |is_zero_based| {
-			if is_zero_based {
-				self.page + 1
-			} else {
-				self.page
-			}
-		})
-	}
-}

--- a/crates/graphql/src/input/mod.rs
+++ b/crates/graphql/src/input/mod.rs
@@ -10,4 +10,5 @@ pub mod reading_list;
 pub mod scheduled_job_config;
 pub mod smart_list_view;
 pub mod smart_lists;
+pub mod thumbnail;
 pub mod user;

--- a/crates/graphql/src/input/thumbnail.rs
+++ b/crates/graphql/src/input/thumbnail.rs
@@ -1,0 +1,30 @@
+use async_graphql::InputObject;
+
+#[derive(Debug, Default, InputObject)]
+pub struct PageBasedThumbnailInput {
+	/// The page to pull inside the media file for generating the thumbnail
+	page: i32,
+	#[graphql(default)]
+	/// A flag indicating whether the page is zero based (i.e. 0 is the first page)
+	is_zero_based: Option<bool>,
+}
+
+impl PageBasedThumbnailInput {
+	pub fn page(&self) -> i32 {
+		self.is_zero_based.map_or(self.page, |is_zero_based| {
+			if is_zero_based {
+				self.page + 1
+			} else {
+				self.page
+			}
+		})
+	}
+}
+
+#[derive(Debug, Default, InputObject)]
+pub struct UpdateThumbnailInput {
+	/// The ID of the media inside the series to fetch
+	pub media_id: String,
+	#[graphql(flatten)]
+	pub params: PageBasedThumbnailInput,
+}

--- a/crates/graphql/src/mutation/library.rs
+++ b/crates/graphql/src/mutation/library.rs
@@ -28,7 +28,7 @@ use crate::{
 	data::{CoreContext, RequestContext},
 	error_message,
 	guard::PermissionGuard,
-	input::library::{CreateOrUpdateLibraryInput, UpdateLibraryThumbnailInput},
+	input::{library::CreateOrUpdateLibraryInput, thumbnail::UpdateThumbnailInput},
 	object::library::Library,
 };
 
@@ -468,7 +468,7 @@ impl LibraryMutation {
 		&self,
 		ctx: &Context<'_>,
 		id: ID,
-		input: UpdateLibraryThumbnailInput,
+		input: UpdateThumbnailInput,
 	) -> Result<Library> {
 		let core = ctx.data::<CoreContext>()?;
 		let RequestContext { user, .. } = ctx.data::<RequestContext>()?;
@@ -480,7 +480,7 @@ impl LibraryMutation {
 			.await?
 			.ok_or("Library not found")?;
 
-		let page = input.page();
+		let page = input.params.page();
 
 		// TODO: Does it really matter to enforce the book belongs to library? I
 		// have omitted it for now, but v1 API did that

--- a/crates/graphql/src/mutation/library.rs
+++ b/crates/graphql/src/mutation/library.rs
@@ -482,8 +482,6 @@ impl LibraryMutation {
 
 		let page = input.params.page();
 
-		// TODO: Does it really matter to enforce the book belongs to library? I
-		// have omitted it for now, but v1 API did that
 		let book = media::Entity::find_for_user(user)
 			.filter(media::Column::Id.eq(input.media_id))
 			.one(core.conn.as_ref())

--- a/crates/graphql/src/mutation/media.rs
+++ b/crates/graphql/src/mutation/media.rs
@@ -74,9 +74,7 @@ impl MediaMutation {
 		Err("Not implemented".into())
 	}
 
-	// TODO(graphql): (thumbnail API remains RESTful). This serves as a reminder, it won't live here
-
-	/// Update the thumbnail for a library. This will replace the existing thumbnail with the the one
+	/// Update the thumbnail for a book. This will replace the existing thumbnail with the the one
 	/// associated with the provided input (book). If the book does not have a thumbnail, one
 	/// will be generated based on the library's thumbnail configuration.
 	#[graphql(guard = "PermissionGuard::one(UserPermission::EditLibrary)")]

--- a/crates/graphql/src/mutation/media.rs
+++ b/crates/graphql/src/mutation/media.rs
@@ -1,13 +1,25 @@
 use async_graphql::{Context, Object, Result, ID};
-use models::entity::{finished_reading_session, media, reading_session, user::AuthUser};
-use sea_orm::{
-	prelude::*, sea_query::OnConflict, DatabaseTransaction, QuerySelect, Set,
-	TransactionTrait,
+use models::{
+	entity::{
+		finished_reading_session, library, library_config, media, reading_session,
+		series, user::AuthUser,
+	},
+	shared::enums::UserPermission,
 };
-use stump_core::filesystem::media::analyze_media_job::AnalyzeMediaJob;
+use sea_orm::{
+	prelude::*,
+	sea_query::{OnConflict, Query},
+	DatabaseTransaction, QuerySelect, Set, TransactionTrait,
+};
+use stump_core::filesystem::{
+	image::{generate_book_thumbnail, GenerateThumbnailOptions},
+	media::analyze_media_job::AnalyzeMediaJob,
+};
 
 use crate::{
 	data::{CoreContext, RequestContext},
+	guard::PermissionGuard,
+	input::thumbnail::PageBasedThumbnailInput,
 	mutation::epub::ReadingProgressOutput,
 	object::media::Media,
 };
@@ -63,6 +75,74 @@ impl MediaMutation {
 	}
 
 	// TODO(graphql): (thumbnail API remains RESTful). This serves as a reminder, it won't live here
+
+	/// Update the thumbnail for a library. This will replace the existing thumbnail with the the one
+	/// associated with the provided input (book). If the book does not have a thumbnail, one
+	/// will be generated based on the library's thumbnail configuration.
+	#[graphql(guard = "PermissionGuard::one(UserPermission::EditLibrary)")]
+	async fn update_media_thumbnail(
+		&self,
+		ctx: &Context<'_>,
+		id: ID,
+		input: PageBasedThumbnailInput,
+	) -> Result<Media> {
+		let core = ctx.data::<CoreContext>()?;
+		let RequestContext { user, .. } = ctx.data::<RequestContext>()?;
+
+		let book = media::ModelWithMetadata::find_for_user(user)
+			.filter(media::Column::Id.eq(id.to_string()))
+			.into_model::<media::ModelWithMetadata>()
+			.one(core.conn.as_ref())
+			.await?
+			.ok_or("Book not found")?;
+
+		let series_id = book
+			.media
+			.series_id
+			.clone()
+			.ok_or("Series ID not set on book")?;
+
+		let (_library, config) = library::Entity::find_for_user(user)
+			.filter(
+				library::Column::Id.in_subquery(
+					Query::select()
+						.column(series::Column::LibraryId)
+						.from(series::Entity)
+						.and_where(series::Column::Id.eq(series_id))
+						.to_owned(),
+				),
+			)
+			.find_also_related(library_config::Entity)
+			.one(core.conn.as_ref())
+			.await?
+			.ok_or("Associated library for book not found")?;
+
+		let page = input.page();
+
+		if book.media.extension == "epub" && page > 1 {
+			return Err("Cannot set thumbnail from EPUB chapter".into());
+		}
+
+		let image_options = config
+			.ok_or("Library config not found")?
+			.thumbnail_config
+			.unwrap_or_default()
+			.with_page(page);
+
+		let (_, path_buf, _) = generate_book_thumbnail(
+			&book.media.clone().into(),
+			GenerateThumbnailOptions {
+				image_options,
+				core_config: core.config.as_ref().clone(),
+				force_regen: true,
+				filename: Some(id.to_string()),
+			},
+		)
+		.await?;
+		tracing::debug!(path = ?path_buf, "Generated book thumbnail");
+
+		Ok(book.into())
+	}
 
 	async fn delete_media_progress(&self, ctx: &Context<'_>, id: ID) -> Result<Media> {
 		let RequestContext { user, .. } = ctx.data::<RequestContext>()?;

--- a/crates/graphql/src/mutation/series.rs
+++ b/crates/graphql/src/mutation/series.rs
@@ -1,13 +1,19 @@
 use async_graphql::{Context, Object, Result, ID};
-use models::{entity::series, shared::enums::UserPermission};
-use sea_orm::prelude::*;
+use models::{
+	entity::{library, library_config, media, series},
+	shared::enums::UserPermission,
+};
+use sea_orm::{prelude::*, sea_query::Query};
 use stump_core::filesystem::{
-	media::analyze_media_job::AnalyzeMediaJob, scanner::SeriesScanJob,
+	image::{generate_book_thumbnail, GenerateThumbnailOptions},
+	media::analyze_media_job::AnalyzeMediaJob,
+	scanner::SeriesScanJob,
 };
 
 use crate::{
 	data::{CoreContext, RequestContext},
 	guard::PermissionGuard,
+	input::thumbnail::UpdateThumbnailInput,
 	object::series::Series,
 };
 
@@ -34,7 +40,74 @@ impl SeriesMutation {
 		Ok(true)
 	}
 
-	// TODO(graphql): (thumbnail API remains RESTful). This serves as a reminder, it won't live here
+	/// Update the thumbnail for a series. This will replace the existing thumbnail with the the one
+	/// associated with the provided input (book). If the book does not have a thumbnail, one
+	/// will be generated based on the library's thumbnail configuration.
+	#[graphql(guard = "PermissionGuard::one(UserPermission::EditLibrary)")]
+	async fn update_series_thumbnail(
+		&self,
+		ctx: &Context<'_>,
+		id: ID,
+		input: UpdateThumbnailInput,
+	) -> Result<Series> {
+		let core = ctx.data::<CoreContext>()?;
+		let RequestContext { user, .. } = ctx.data::<RequestContext>()?;
+
+		let series = series::ModelWithMetadata::find_for_user(user)
+			.filter(series::Column::Id.eq(id.to_string()))
+			.into_model::<series::ModelWithMetadata>()
+			.one(core.conn.as_ref())
+			.await?
+			.ok_or("Series not found")?;
+		let series_id = series.series.id.clone();
+
+		let (_library, config) = library::Entity::find_for_user(user)
+			.filter(
+				library::Column::Id.in_subquery(
+					Query::select()
+						.column(series::Column::LibraryId)
+						.from(series::Entity)
+						.and_where(series::Column::Id.eq(series_id))
+						.to_owned(),
+				),
+			)
+			.find_also_related(library_config::Entity)
+			.one(core.conn.as_ref())
+			.await?
+			.ok_or("Associated library for series not found")?;
+
+		let book = media::Entity::find_for_user(user)
+			.filter(media::Column::Id.eq(input.media_id.to_string()))
+			.one(core.conn.as_ref())
+			.await?
+			.ok_or("Media not found")?;
+
+		let page = input.params.page();
+
+		if book.extension == "epub" && page > 1 {
+			return Err("Cannot set thumbnail from EPUB chapter".into());
+		}
+
+		let image_options = config
+			.ok_or("Library config not found")?
+			.thumbnail_config
+			.unwrap_or_default()
+			.with_page(page);
+
+		let (_, path_buf, _) = generate_book_thumbnail(
+			&book.clone().into(),
+			GenerateThumbnailOptions {
+				image_options,
+				core_config: core.config.as_ref().clone(),
+				force_regen: true,
+				filename: Some(id.to_string()),
+			},
+		)
+		.await?;
+		tracing::debug!(path = ?path_buf, "Generated series thumbnail");
+
+		Ok(series.into())
+	}
 
 	// TODO(graphql): Implement mark_series_as_complete
 	async fn mark_series_as_complete(&self, ctx: &Context<'_>, id: ID) -> Result<Series> {

--- a/crates/graphql/src/mutation/upload.rs
+++ b/crates/graphql/src/mutation/upload.rs
@@ -7,7 +7,7 @@ use async_graphql::{
 	Context, Error, InputObject, Object, Result, Upload, UploadValue, ID,
 };
 use models::{
-	entity::{library, media},
+	entity::{library, media, series},
 	shared::enums::UserPermission,
 };
 use sea_orm::{prelude::*, QuerySelect};
@@ -22,7 +22,7 @@ use zip::{read::ZipFile, ZipArchive};
 use crate::{
 	data::{CoreContext, RequestContext},
 	guard::{OptionalFeature, OptionalFeatureGuard, PermissionGuard},
-	object::{library::Library, media::Media},
+	object::{library::Library, media::Media, series::Series},
 };
 
 #[derive(Default)]
@@ -167,6 +167,9 @@ impl UploadMutation {
 		Ok(true)
 	}
 
+	// TODO(graphql): There is a LOT of duplication here, and only subtle differences wrt the queries.
+	// I think we can refactor this into some utility function(s) that take the model type and the ID as parameters
+
 	#[graphql(
 		guard = "OptionalFeatureGuard::new(OptionalFeature::Upload).and(PermissionGuard::new(&[UserPermission::UploadFile, UserPermission::EditLibrary]))"
 	)]
@@ -219,6 +222,64 @@ impl UploadMutation {
 		tracing::debug!(?path_buf, "Placed library thumbnail");
 
 		Ok(library.into())
+	}
+
+	#[graphql(
+		guard = "OptionalFeatureGuard::new(OptionalFeature::Upload).and(PermissionGuard::new(&[UserPermission::UploadFile, UserPermission::EditLibrary]))"
+	)]
+	async fn upload_series_thumbnail(
+		&self,
+		ctx: &Context<'_>,
+		id: ID,
+		file: Upload,
+	) -> Result<Series> {
+		let RequestContext { user, .. } = ctx.data()?;
+		let core = ctx.data::<CoreContext>()?;
+		let conn = core.conn.as_ref();
+
+		let series = series::ModelWithMetadata::find_for_user(user)
+			.filter(series::Column::Id.eq(id.to_string()))
+			.into_model::<series::ModelWithMetadata>()
+			.one(core.conn.as_ref())
+			.await?
+			.ok_or("Series not found")?;
+
+		let value = file.value(ctx)?;
+
+		enforce_max_size(&value, core.config.max_file_upload_size)?;
+		enforce_valid_content_type(&value)?;
+
+		let mut image_buf = Vec::new();
+		let mut file = value.content;
+		file.read_to_end(&mut image_buf)?;
+
+		let extension = Path::new(&value.filename)
+			.extension()
+			.and_then(|ext| ext.to_str())
+			.map(str::to_ascii_lowercase)
+			.ok_or("Expected file to have an extension")?;
+
+		// Note: I chose to *safely* attempt the removal as to not block the upload, however after some
+		// user testing I'd like to see if this becomes a problem. We'll see!
+		match remove_thumbnails(
+			&[series.series.id.clone()],
+			&core.config.get_thumbnails_dir(),
+		)
+		.await
+		{
+			Ok(count) => tracing::info!("Removed {} thumbnails!", count),
+			Err(e) => tracing::error!(
+				?e,
+				"Failed to remove existing series thumbnail before replacing!"
+			),
+		}
+
+		let path_buf =
+			place_thumbnail(&series.series.id, &extension, &image_buf, &core.config)
+				.await?;
+		tracing::debug!(?path_buf, "Placed series thumbnail");
+
+		Ok(series.into())
 	}
 
 	#[graphql(

--- a/crates/graphql/src/mutation/upload.rs
+++ b/crates/graphql/src/mutation/upload.rs
@@ -6,7 +6,10 @@ use std::{
 use async_graphql::{
 	Context, Error, InputObject, Object, Result, Upload, UploadValue, ID,
 };
-use models::{entity::library, shared::enums::UserPermission};
+use models::{
+	entity::{library, media},
+	shared::enums::UserPermission,
+};
 use sea_orm::{prelude::*, QuerySelect};
 use stump_core::filesystem::{
 	image::{place_thumbnail, remove_thumbnails},
@@ -19,7 +22,7 @@ use zip::{read::ZipFile, ZipArchive};
 use crate::{
 	data::{CoreContext, RequestContext},
 	guard::{OptionalFeature, OptionalFeatureGuard, PermissionGuard},
-	object::library::Library,
+	object::{library::Library, media::Media},
 };
 
 #[derive(Default)]
@@ -185,35 +188,13 @@ impl UploadMutation {
 			.ok_or("Library not found")?;
 
 		let value = file.value(ctx)?;
-		match value.size() {
-			Ok(size) if size as usize > core.config.max_file_upload_size => {
-				return Err(format!(
-					"File size exceeds maximum upload size of {} bytes",
-					core.config.max_file_upload_size
-				)
-				.into());
-			},
-			Err(e) => {
-				tracing::error!(?e, "Error getting file size");
-				return Err(format!("Error getting file size: {e}").into());
-			},
-			_ => {},
-		}
+
+		enforce_max_size(&value, core.config.max_file_upload_size)?;
+		enforce_valid_content_type(&value)?;
 
 		let mut image_buf = Vec::new();
 		let mut file = value.content;
 		file.read_to_end(&mut image_buf)?;
-
-		let content_type = value
-			.content_type
-			.clone()
-			.as_deref()
-			.map(ContentType::from)
-			.ok_or("Could not verify content of file".to_string())?;
-
-		if !content_type.is_image() {
-			return Err("Uploaded file is not an image".into());
-		}
 
 		let extension = Path::new(&value.filename)
 			.extension()
@@ -239,6 +220,91 @@ impl UploadMutation {
 
 		Ok(library.into())
 	}
+
+	#[graphql(
+		guard = "OptionalFeatureGuard::new(OptionalFeature::Upload).and(PermissionGuard::new(&[UserPermission::UploadFile, UserPermission::EditLibrary]))"
+	)]
+	async fn upload_media_thumbnail(
+		&self,
+		ctx: &Context<'_>,
+		id: ID,
+		file: Upload,
+	) -> Result<Media> {
+		let RequestContext { user, .. } = ctx.data()?;
+		let core = ctx.data::<CoreContext>()?;
+
+		let book = media::ModelWithMetadata::find_for_user(user)
+			.filter(media::Column::Id.eq(id.to_string()))
+			.into_model::<media::ModelWithMetadata>()
+			.one(core.conn.as_ref())
+			.await?
+			.ok_or("Book not found")?;
+
+		let value = file.value(ctx)?;
+
+		enforce_max_size(&value, core.config.max_file_upload_size)?;
+		enforce_valid_content_type(&value)?;
+
+		let mut image_buf = Vec::new();
+		let mut file = value.content;
+		file.read_to_end(&mut image_buf)?;
+
+		let extension = Path::new(&value.filename)
+			.extension()
+			.and_then(|ext| ext.to_str())
+			.map(str::to_ascii_lowercase)
+			.ok_or("Expected file to have an extension")?;
+
+		// Note: I chose to *safely* attempt the removal as to not block the upload, however after some
+		// user testing I'd like to see if this becomes a problem. We'll see!
+		let removal_result = remove_thumbnails(
+			&[book.media.id.clone()],
+			&core.config.get_thumbnails_dir(),
+		)
+		.await;
+		match removal_result {
+			Ok(count) => tracing::info!("Removed {} thumbnails!", count),
+			Err(e) => tracing::error!(
+				?e,
+				"Failed to remove existing book thumbnail before replacing!"
+			),
+		}
+
+		let path_buf =
+			place_thumbnail(&book.media.id, &extension, &image_buf, &core.config).await?;
+		tracing::debug!(?path_buf, "Placed book thumbnail");
+
+		Ok(book.into())
+	}
+}
+
+fn enforce_max_size(value: &UploadValue, max_size: usize) -> Result<()> {
+	match value.size() {
+		Ok(size) if size as usize > max_size => Err(format!(
+			"File size exceeds maximum upload size of {max_size} bytes"
+		)
+		.into()),
+		Err(e) => {
+			tracing::error!(?e, "Error getting file size");
+			Err(format!("Error getting file size: {e}").into())
+		},
+		_ => Ok(()),
+	}
+}
+
+fn enforce_valid_content_type(value: &UploadValue) -> Result<()> {
+	let content_type = value
+		.content_type
+		.clone()
+		.as_deref()
+		.map(ContentType::from)
+		.ok_or("Could not verify content of file".to_string())?;
+
+	if !content_type.is_image() {
+		return Err("Uploaded file is not an image".into());
+	}
+
+	Ok(())
 }
 
 /// A helper function to copy a tempfile from a multipart to a provided path

--- a/database/models/src/entity/media.rs
+++ b/database/models/src/entity/media.rs
@@ -260,6 +260,12 @@ pub struct MediaThumbSelect {
 	pub series_id: String,
 }
 
+impl MediaThumbSelect {
+	pub fn columns() -> Vec<Column> {
+		vec![Column::Id, Column::Path, Column::SeriesId]
+	}
+}
+
 #[derive(Debug, FromQueryResult)]
 pub struct MediaNameCmpSelect {
 	pub name: String,

--- a/migration.todo
+++ b/migration.todo
@@ -1,6 +1,6 @@
 Backend / Core:
-- [ ] Typed GraphQL filter objects
-- [ ] Dynamic GraphQL ordering (e.g., `media(order_by: { title: ASC })`)
+- [x] Typed GraphQL filter objects
+- [x] Dynamic GraphQL ordering (e.g., `media(order_by: { title: ASC })`)
 - [ ] Finalize and test intial migration
 - [x] Unify `RequestContext` between REST and GraphQL APIs
   - [x] Port all middleware to work with updated types/structs/etc
@@ -10,16 +10,16 @@ Backend / Core:
   - [x] library
 - [x] Move all the deserializer utils (e.g., age_rating_deserializer)
 - [ ] Remove sse and ws from REST, move to GraphQL
-  - [ ] Port SSE to GraphQL
+  - [x] Port SSE to GraphQL
   - [ ] Remove SSE from REST
   - [x] Remove WS from REST
 - [ ] Port other remaining RESTful APIs:
-  - [ ] smart-lists
+  - [x] smart-lists
   - [ ] notifier
-  - [ ] emailer
+  - [x] emailer
   - [ ] config
-  - [ ] api_key
-  - [ ] user
+  - [x] api_key
+  - [x] user
   - [x] OPDS
     - [x] OPDS 1.2
     - [x] OPDS 2.0

--- a/packages/browser/src/scenes/library/tabs/settings/options/thumbnails/LibraryThumbnailSelector.tsx
+++ b/packages/browser/src/scenes/library/tabs/settings/options/thumbnails/LibraryThumbnailSelector.tsx
@@ -14,7 +14,7 @@ import LibrarySeriesGrid, { SelectedSeries } from '../../LibrarySeriesGrid'
 // TODO: Redesign this ugly shit
 
 const updateMutation = graphql(`
-	mutation LibraryThumbnailSelectorUpdate($id: ID!, $input: UpdateLibraryThumbnailInput!) {
+	mutation LibraryThumbnailSelectorUpdate($id: ID!, $input: UpdateThumbnailInput!) {
 		updateLibraryThumbnail(id: $id, input: $input) {
 			id
 			thumbnail {

--- a/packages/browser/src/scenes/series/tabs/settings/SeriesSettingsScene.tsx
+++ b/packages/browser/src/scenes/series/tabs/settings/SeriesSettingsScene.tsx
@@ -1,18 +1,54 @@
-import { useSDK } from '@stump/client'
+import { useGraphQLMutation, useSDK, useSuspenseGraphQL } from '@stump/client'
 import { Alert, Button } from '@stump/components'
+import { graphql } from '@stump/graphql'
 import { Construction } from 'lucide-react'
+import { useCallback, useEffect } from 'react'
+import { useNavigate } from 'react-router'
 
 import { SceneContainer } from '@/components/container'
+import paths from '@/paths'
 
 import { useSeriesContext } from '../../context'
 import SeriesThumbnailSelector from './SeriesThumbnailSelector'
+
+const query = graphql(`
+	query SeriesSettingsScene($id: ID!) {
+		seriesById(id: $id) {
+			...SeriesThumbnailSelector
+		}
+	}
+`)
+
+const analyzeMutation = graphql(`
+	mutation SeriesSettingsSceneAnalyze($id: ID!) {
+		analyzeSeries(id: $id)
+	}
+`)
 
 export default function SeriesSettingsScene() {
 	const { sdk } = useSDK()
 	const { series } = useSeriesContext()
 
-	function handleAnalyze() {
-		sdk.series.analyze(series.id)
+	const navigate = useNavigate()
+
+	const {
+		data: { seriesById: fragment },
+	} = useSuspenseGraphQL(query, sdk.cacheKey('seriesById', [series.id, 'settings']), {
+		id: series.id ?? '',
+	})
+
+	const { data, mutate: analyze, isPending } = useGraphQLMutation(analyzeMutation)
+
+	const handleAnalyze = useCallback(() => analyze({ id: series.id }), [analyze, series.id])
+
+	useEffect(() => {
+		if (!fragment) {
+			navigate(paths.notFound())
+		}
+	}, [fragment, navigate])
+
+	if (!fragment) {
+		return null
 	}
 
 	return (
@@ -24,11 +60,17 @@ export default function SeriesSettingsScene() {
 					</Alert.Content>
 				</Alert>
 
-				<Button size="md" variant="primary" onClick={handleAnalyze}>
-					Analyze Media
+				<Button
+					title={data ? 'Analysis already in progress' : 'Analyze this series'}
+					size="md"
+					variant="primary"
+					onClick={handleAnalyze}
+					disabled={!!data || isPending}
+				>
+					Analyze Series
 				</Button>
 
-				{/* <SeriesThumbnailSelector series={series} /> */}
+				<SeriesThumbnailSelector fragment={fragment} />
 			</div>
 		</SceneContainer>
 	)

--- a/packages/graphql/src/client/gql.ts
+++ b/packages/graphql/src/client/gql.ts
@@ -86,6 +86,11 @@ type Documents = {
     "\n\tquery SeriesLibrayLink($id: ID!) {\n\t\tlibraryById(id: $id) {\n\t\t\tid\n\t\t\tname\n\t\t}\n\t}\n": typeof types.SeriesLibrayLinkDocument,
     "\n\tquery SeriesBooksScene(\n\t\t$filter: MediaFilterInput!\n\t\t$orderBy: [MediaOrderBy!]!\n\t\t$pagination: Pagination!\n\t) {\n\t\tmedia(filter: $filter, orderBy: $orderBy, pagination: $pagination) {\n\t\t\tnodes {\n\t\t\t\tid\n\t\t\t\t...BookCard\n\t\t\t\t...BookMetadata\n\t\t\t}\n\t\t\tpageInfo {\n\t\t\t\t__typename\n\t\t\t\t... on OffsetPaginationInfo {\n\t\t\t\t\tcurrentPage\n\t\t\t\t\ttotalPages\n\t\t\t\t\tpageSize\n\t\t\t\t\tpageOffset\n\t\t\t\t\tzeroBased\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n": typeof types.SeriesBooksSceneDocument,
     "\n\tquery SeriesBookGrid($id: String!, $pagination: Pagination) {\n\t\tmedia(filter: { seriesId: { eq: $id } }, pagination: $pagination) {\n\t\t\tnodes {\n\t\t\t\tid\n\t\t\t\tthumbnail {\n\t\t\t\t\turl\n\t\t\t\t}\n\t\t\t\tpages\n\t\t\t}\n\t\t\tpageInfo {\n\t\t\t\t__typename\n\t\t\t\t... on CursorPaginationInfo {\n\t\t\t\t\tcurrentCursor\n\t\t\t\t\tnextCursor\n\t\t\t\t\tlimit\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n": typeof types.SeriesBookGridDocument,
+    "\n\tquery SeriesSettingsScene($id: ID!) {\n\t\tseriesById(id: $id) {\n\t\t\t...SeriesThumbnailSelector\n\t\t}\n\t}\n": typeof types.SeriesSettingsSceneDocument,
+    "\n\tmutation SeriesSettingsSceneAnalyze($id: ID!) {\n\t\tanalyzeSeries(id: $id)\n\t}\n": typeof types.SeriesSettingsSceneAnalyzeDocument,
+    "\n\tfragment SeriesThumbnailSelector on Series {\n\t\tid\n\t\tthumbnail {\n\t\t\turl\n\t\t}\n\t}\n": typeof types.SeriesThumbnailSelectorFragmentDoc,
+    "\n\tmutation SeriesThumbnailSelectorUpdate($id: ID!, $input: UpdateThumbnailInput!) {\n\t\tupdateSeriesThumbnail(id: $id, input: $input) {\n\t\t\tid\n\t\t\tthumbnail {\n\t\t\t\turl\n\t\t\t}\n\t\t}\n\t}\n": typeof types.SeriesThumbnailSelectorUpdateDocument,
+    "\n\tmutation SeriesThumbnailSelectorUpload($id: ID!, $file: Upload!) {\n\t\tuploadSeriesThumbnail(id: $id, file: $file) {\n\t\t\tid\n\t\t\tthumbnail {\n\t\t\t\turl\n\t\t\t}\n\t\t}\n\t}\n": typeof types.SeriesThumbnailSelectorUploadDocument,
     "\n\tquery APIKeyTable {\n\t\tapiKeys {\n\t\t\tid\n\t\t\tname\n\t\t\tpermissions {\n\t\t\t\t__typename\n\t\t\t\t... on UserPermissionStruct {\n\t\t\t\t\tvalue\n\t\t\t\t}\n\t\t\t}\n\t\t\tlastUsedAt\n\t\t\texpiresAt\n\t\t\tcreatedAt\n\t\t}\n\t}\n": typeof types.ApiKeyTableDocument,
     "\n\tmutation CreateAPIKeyModal($input: ApikeyInput!) {\n\t\tcreateApiKey(input: $input) {\n\t\t\tapiKey {\n\t\t\t\tid\n\t\t\t}\n\t\t\tsecret\n\t\t}\n\t}\n": typeof types.CreateApiKeyModalDocument,
     "\n\tmutation DeleteAPIKeyConfirmModal($id: Int!) {\n\t\tdeleteApiKey(id: $id) {\n\t\t\tid\n\t\t}\n\t}\n": typeof types.DeleteApiKeyConfirmModalDocument,
@@ -212,6 +217,11 @@ const documents: Documents = {
     "\n\tquery SeriesLibrayLink($id: ID!) {\n\t\tlibraryById(id: $id) {\n\t\t\tid\n\t\t\tname\n\t\t}\n\t}\n": types.SeriesLibrayLinkDocument,
     "\n\tquery SeriesBooksScene(\n\t\t$filter: MediaFilterInput!\n\t\t$orderBy: [MediaOrderBy!]!\n\t\t$pagination: Pagination!\n\t) {\n\t\tmedia(filter: $filter, orderBy: $orderBy, pagination: $pagination) {\n\t\t\tnodes {\n\t\t\t\tid\n\t\t\t\t...BookCard\n\t\t\t\t...BookMetadata\n\t\t\t}\n\t\t\tpageInfo {\n\t\t\t\t__typename\n\t\t\t\t... on OffsetPaginationInfo {\n\t\t\t\t\tcurrentPage\n\t\t\t\t\ttotalPages\n\t\t\t\t\tpageSize\n\t\t\t\t\tpageOffset\n\t\t\t\t\tzeroBased\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n": types.SeriesBooksSceneDocument,
     "\n\tquery SeriesBookGrid($id: String!, $pagination: Pagination) {\n\t\tmedia(filter: { seriesId: { eq: $id } }, pagination: $pagination) {\n\t\t\tnodes {\n\t\t\t\tid\n\t\t\t\tthumbnail {\n\t\t\t\t\turl\n\t\t\t\t}\n\t\t\t\tpages\n\t\t\t}\n\t\t\tpageInfo {\n\t\t\t\t__typename\n\t\t\t\t... on CursorPaginationInfo {\n\t\t\t\t\tcurrentCursor\n\t\t\t\t\tnextCursor\n\t\t\t\t\tlimit\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n": types.SeriesBookGridDocument,
+    "\n\tquery SeriesSettingsScene($id: ID!) {\n\t\tseriesById(id: $id) {\n\t\t\t...SeriesThumbnailSelector\n\t\t}\n\t}\n": types.SeriesSettingsSceneDocument,
+    "\n\tmutation SeriesSettingsSceneAnalyze($id: ID!) {\n\t\tanalyzeSeries(id: $id)\n\t}\n": types.SeriesSettingsSceneAnalyzeDocument,
+    "\n\tfragment SeriesThumbnailSelector on Series {\n\t\tid\n\t\tthumbnail {\n\t\t\turl\n\t\t}\n\t}\n": types.SeriesThumbnailSelectorFragmentDoc,
+    "\n\tmutation SeriesThumbnailSelectorUpdate($id: ID!, $input: UpdateThumbnailInput!) {\n\t\tupdateSeriesThumbnail(id: $id, input: $input) {\n\t\t\tid\n\t\t\tthumbnail {\n\t\t\t\turl\n\t\t\t}\n\t\t}\n\t}\n": types.SeriesThumbnailSelectorUpdateDocument,
+    "\n\tmutation SeriesThumbnailSelectorUpload($id: ID!, $file: Upload!) {\n\t\tuploadSeriesThumbnail(id: $id, file: $file) {\n\t\t\tid\n\t\t\tthumbnail {\n\t\t\t\turl\n\t\t\t}\n\t\t}\n\t}\n": types.SeriesThumbnailSelectorUploadDocument,
     "\n\tquery APIKeyTable {\n\t\tapiKeys {\n\t\t\tid\n\t\t\tname\n\t\t\tpermissions {\n\t\t\t\t__typename\n\t\t\t\t... on UserPermissionStruct {\n\t\t\t\t\tvalue\n\t\t\t\t}\n\t\t\t}\n\t\t\tlastUsedAt\n\t\t\texpiresAt\n\t\t\tcreatedAt\n\t\t}\n\t}\n": types.ApiKeyTableDocument,
     "\n\tmutation CreateAPIKeyModal($input: ApikeyInput!) {\n\t\tcreateApiKey(input: $input) {\n\t\t\tapiKey {\n\t\t\t\tid\n\t\t\t}\n\t\t\tsecret\n\t\t}\n\t}\n": types.CreateApiKeyModalDocument,
     "\n\tmutation DeleteAPIKeyConfirmModal($id: Int!) {\n\t\tdeleteApiKey(id: $id) {\n\t\t\tid\n\t\t}\n\t}\n": types.DeleteApiKeyConfirmModalDocument,
@@ -551,6 +561,26 @@ export function graphql(source: "\n\tquery SeriesBooksScene(\n\t\t$filter: Media
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(source: "\n\tquery SeriesBookGrid($id: String!, $pagination: Pagination) {\n\t\tmedia(filter: { seriesId: { eq: $id } }, pagination: $pagination) {\n\t\t\tnodes {\n\t\t\t\tid\n\t\t\t\tthumbnail {\n\t\t\t\t\turl\n\t\t\t\t}\n\t\t\t\tpages\n\t\t\t}\n\t\t\tpageInfo {\n\t\t\t\t__typename\n\t\t\t\t... on CursorPaginationInfo {\n\t\t\t\t\tcurrentCursor\n\t\t\t\t\tnextCursor\n\t\t\t\t\tlimit\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n"): typeof import('./graphql').SeriesBookGridDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n\tquery SeriesSettingsScene($id: ID!) {\n\t\tseriesById(id: $id) {\n\t\t\t...SeriesThumbnailSelector\n\t\t}\n\t}\n"): typeof import('./graphql').SeriesSettingsSceneDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n\tmutation SeriesSettingsSceneAnalyze($id: ID!) {\n\t\tanalyzeSeries(id: $id)\n\t}\n"): typeof import('./graphql').SeriesSettingsSceneAnalyzeDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n\tfragment SeriesThumbnailSelector on Series {\n\t\tid\n\t\tthumbnail {\n\t\t\turl\n\t\t}\n\t}\n"): typeof import('./graphql').SeriesThumbnailSelectorFragmentDoc;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n\tmutation SeriesThumbnailSelectorUpdate($id: ID!, $input: UpdateThumbnailInput!) {\n\t\tupdateSeriesThumbnail(id: $id, input: $input) {\n\t\t\tid\n\t\t\tthumbnail {\n\t\t\t\turl\n\t\t\t}\n\t\t}\n\t}\n"): typeof import('./graphql').SeriesThumbnailSelectorUpdateDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n\tmutation SeriesThumbnailSelectorUpload($id: ID!, $file: Upload!) {\n\t\tuploadSeriesThumbnail(id: $id, file: $file) {\n\t\t\tid\n\t\t\tthumbnail {\n\t\t\t\turl\n\t\t\t}\n\t\t}\n\t}\n"): typeof import('./graphql').SeriesThumbnailSelectorUploadDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/graphql/src/client/gql.ts
+++ b/packages/graphql/src/client/gql.ts
@@ -49,6 +49,7 @@ type Documents = {
     "\n\tquery BookReaderScene($id: ID!) {\n\t\tmediaById(id: $id) {\n\t\t\tid\n\t\t\tresolvedName\n\t\t\tpages\n\t\t\textension\n\t\t\treadProgress {\n\t\t\t\tpercentageCompleted\n\t\t\t\tepubcfi\n\t\t\t\tpage\n\t\t\t\telapsedSeconds\n\t\t\t}\n\t\t\tlibraryConfig {\n\t\t\t\tdefaultReadingImageScaleFit\n\t\t\t\tdefaultReadingMode\n\t\t\t\tdefaultReadingDir\n\t\t\t}\n\t\t\tmetadata {\n\t\t\t\tpageAnalysis {\n\t\t\t\t\tdimensions {\n\t\t\t\t\t\theight\n\t\t\t\t\t\twidth\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n": typeof types.BookReaderSceneDocument,
     "\n\tmutation UpdateReadProgress($id: ID!, $page: Int!, $elapsedSeconds: Int!) {\n\t\tupdateMediaProgress(id: $id, page: $page, elapsedSeconds: $elapsedSeconds) {\n\t\t\t__typename\n\t\t}\n\t}\n": typeof types.UpdateReadProgressDocument,
     "\n\tquery BookManagementScene($id: ID!) {\n\t\tmediaById(id: $id) {\n\t\t\tid\n\t\t\tresolvedName\n\t\t\tlibrary {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t}\n\t\t\tseries {\n\t\t\t\tid\n\t\t\t\tresolvedName\n\t\t\t}\n\t\t\t...BookThumbnailSelector\n\t\t}\n\t}\n": typeof types.BookManagementSceneDocument,
+    "\n\tmutation BookManagementSceneAnalyze($id: ID!) {\n\t\tanalyzeMedia(id: $id)\n\t}\n": typeof types.BookManagementSceneAnalyzeDocument,
     "\n\tfragment BookThumbnailSelector on Media {\n\t\tid\n\t\tthumbnail {\n\t\t\turl\n\t\t}\n\t\tpages\n\t}\n": typeof types.BookThumbnailSelectorFragmentDoc,
     "\n\tmutation BookThumbnailSelectorUpdate($id: ID!, $input: PageBasedThumbnailInput!) {\n\t\tupdateMediaThumbnail(id: $id, input: $input) {\n\t\t\tid\n\t\t\tthumbnail {\n\t\t\t\turl\n\t\t\t}\n\t\t}\n\t}\n": typeof types.BookThumbnailSelectorUpdateDocument,
     "\n\tmutation BookThumbnailSelectorUpload($id: ID!, $file: Upload!) {\n\t\tuploadMediaThumbnail(id: $id, file: $file) {\n\t\t\tid\n\t\t\tthumbnail {\n\t\t\t\turl\n\t\t\t}\n\t\t}\n\t}\n": typeof types.BookThumbnailSelectorUploadDocument,
@@ -174,6 +175,7 @@ const documents: Documents = {
     "\n\tquery BookReaderScene($id: ID!) {\n\t\tmediaById(id: $id) {\n\t\t\tid\n\t\t\tresolvedName\n\t\t\tpages\n\t\t\textension\n\t\t\treadProgress {\n\t\t\t\tpercentageCompleted\n\t\t\t\tepubcfi\n\t\t\t\tpage\n\t\t\t\telapsedSeconds\n\t\t\t}\n\t\t\tlibraryConfig {\n\t\t\t\tdefaultReadingImageScaleFit\n\t\t\t\tdefaultReadingMode\n\t\t\t\tdefaultReadingDir\n\t\t\t}\n\t\t\tmetadata {\n\t\t\t\tpageAnalysis {\n\t\t\t\t\tdimensions {\n\t\t\t\t\t\theight\n\t\t\t\t\t\twidth\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n": types.BookReaderSceneDocument,
     "\n\tmutation UpdateReadProgress($id: ID!, $page: Int!, $elapsedSeconds: Int!) {\n\t\tupdateMediaProgress(id: $id, page: $page, elapsedSeconds: $elapsedSeconds) {\n\t\t\t__typename\n\t\t}\n\t}\n": types.UpdateReadProgressDocument,
     "\n\tquery BookManagementScene($id: ID!) {\n\t\tmediaById(id: $id) {\n\t\t\tid\n\t\t\tresolvedName\n\t\t\tlibrary {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t}\n\t\t\tseries {\n\t\t\t\tid\n\t\t\t\tresolvedName\n\t\t\t}\n\t\t\t...BookThumbnailSelector\n\t\t}\n\t}\n": types.BookManagementSceneDocument,
+    "\n\tmutation BookManagementSceneAnalyze($id: ID!) {\n\t\tanalyzeMedia(id: $id)\n\t}\n": types.BookManagementSceneAnalyzeDocument,
     "\n\tfragment BookThumbnailSelector on Media {\n\t\tid\n\t\tthumbnail {\n\t\t\turl\n\t\t}\n\t\tpages\n\t}\n": types.BookThumbnailSelectorFragmentDoc,
     "\n\tmutation BookThumbnailSelectorUpdate($id: ID!, $input: PageBasedThumbnailInput!) {\n\t\tupdateMediaThumbnail(id: $id, input: $input) {\n\t\t\tid\n\t\t\tthumbnail {\n\t\t\t\turl\n\t\t\t}\n\t\t}\n\t}\n": types.BookThumbnailSelectorUpdateDocument,
     "\n\tmutation BookThumbnailSelectorUpload($id: ID!, $file: Upload!) {\n\t\tuploadMediaThumbnail(id: $id, file: $file) {\n\t\t\tid\n\t\t\tthumbnail {\n\t\t\t\turl\n\t\t\t}\n\t\t}\n\t}\n": types.BookThumbnailSelectorUploadDocument,
@@ -401,6 +403,10 @@ export function graphql(source: "\n\tmutation UpdateReadProgress($id: ID!, $page
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(source: "\n\tquery BookManagementScene($id: ID!) {\n\t\tmediaById(id: $id) {\n\t\t\tid\n\t\t\tresolvedName\n\t\t\tlibrary {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t}\n\t\t\tseries {\n\t\t\t\tid\n\t\t\t\tresolvedName\n\t\t\t}\n\t\t\t...BookThumbnailSelector\n\t\t}\n\t}\n"): typeof import('./graphql').BookManagementSceneDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n\tmutation BookManagementSceneAnalyze($id: ID!) {\n\t\tanalyzeMedia(id: $id)\n\t}\n"): typeof import('./graphql').BookManagementSceneAnalyzeDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/graphql/src/client/gql.ts
+++ b/packages/graphql/src/client/gql.ts
@@ -48,6 +48,10 @@ type Documents = {
     "\n\tmutation SendEmailAttachment($id: ID!, $sendTo: [EmailerSendTo!]!) {\n\t\tsendAttachmentEmail(input: { mediaIds: [$id], sendTo: $sendTo }) {\n\t\t\tsentCount\n\t\t\terrors\n\t\t}\n\t}\n": typeof types.SendEmailAttachmentDocument,
     "\n\tquery BookReaderScene($id: ID!) {\n\t\tmediaById(id: $id) {\n\t\t\tid\n\t\t\tresolvedName\n\t\t\tpages\n\t\t\textension\n\t\t\treadProgress {\n\t\t\t\tpercentageCompleted\n\t\t\t\tepubcfi\n\t\t\t\tpage\n\t\t\t\telapsedSeconds\n\t\t\t}\n\t\t\tlibraryConfig {\n\t\t\t\tdefaultReadingImageScaleFit\n\t\t\t\tdefaultReadingMode\n\t\t\t\tdefaultReadingDir\n\t\t\t}\n\t\t\tmetadata {\n\t\t\t\tpageAnalysis {\n\t\t\t\t\tdimensions {\n\t\t\t\t\t\theight\n\t\t\t\t\t\twidth\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n": typeof types.BookReaderSceneDocument,
     "\n\tmutation UpdateReadProgress($id: ID!, $page: Int!, $elapsedSeconds: Int!) {\n\t\tupdateMediaProgress(id: $id, page: $page, elapsedSeconds: $elapsedSeconds) {\n\t\t\t__typename\n\t\t}\n\t}\n": typeof types.UpdateReadProgressDocument,
+    "\n\tquery BookManagementScene($id: ID!) {\n\t\tmediaById(id: $id) {\n\t\t\tid\n\t\t\tresolvedName\n\t\t\tlibrary {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t}\n\t\t\tseries {\n\t\t\t\tid\n\t\t\t\tresolvedName\n\t\t\t}\n\t\t\t...BookThumbnailSelector\n\t\t}\n\t}\n": typeof types.BookManagementSceneDocument,
+    "\n\tfragment BookThumbnailSelector on Media {\n\t\tid\n\t\tthumbnail {\n\t\t\turl\n\t\t}\n\t\tpages\n\t}\n": typeof types.BookThumbnailSelectorFragmentDoc,
+    "\n\tmutation BookThumbnailSelectorUpdate($id: ID!, $input: PageBasedThumbnailInput!) {\n\t\tupdateMediaThumbnail(id: $id, input: $input) {\n\t\t\tid\n\t\t\tthumbnail {\n\t\t\t\turl\n\t\t\t}\n\t\t}\n\t}\n": typeof types.BookThumbnailSelectorUpdateDocument,
+    "\n\tmutation BookThumbnailSelectorUpload($id: ID!, $file: Upload!) {\n\t\tuploadMediaThumbnail(id: $id, file: $file) {\n\t\t\tid\n\t\t\tthumbnail {\n\t\t\t\turl\n\t\t\t}\n\t\t}\n\t}\n": typeof types.BookThumbnailSelectorUploadDocument,
     "\n\tquery BookSearchScene(\n\t\t$filter: MediaFilterInput!\n\t\t$orderBy: [MediaOrderBy!]!\n\t\t$pagination: Pagination!\n\t) {\n\t\tmedia(filter: $filter, orderBy: $orderBy, pagination: $pagination) {\n\t\t\tnodes {\n\t\t\t\tid\n\t\t\t\t...BookCard\n\t\t\t\t...BookMetadata\n\t\t\t}\n\t\t\tpageInfo {\n\t\t\t\t__typename\n\t\t\t\t... on OffsetPaginationInfo {\n\t\t\t\t\tcurrentPage\n\t\t\t\t\ttotalPages\n\t\t\t\t\tpageSize\n\t\t\t\t\tpageOffset\n\t\t\t\t\tzeroBased\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n": typeof types.BookSearchSceneDocument,
     "\n\tquery CreateLibrarySceneExistingLibraries {\n\t\tlibraries(pagination: { none: { unpaginated: true } }) {\n\t\t\tnodes {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t\tpath\n\t\t\t}\n\t\t}\n\t}\n": typeof types.CreateLibrarySceneExistingLibrariesDocument,
     "\n\tmutation CreateLibrarySceneCreateLibrary($input: CreateOrUpdateLibraryInput!) {\n\t\tcreateLibrary(input: $input) {\n\t\t\tid\n\t\t}\n\t}\n": typeof types.CreateLibrarySceneCreateLibraryDocument,
@@ -74,7 +78,7 @@ type Documents = {
     "\n\tquery ScanHistoryTable($id: ID!) {\n\t\tlibraryById(id: $id) {\n\t\t\tid\n\t\t\tscanHistory {\n\t\t\t\tid\n\t\t\t\tjobId\n\t\t\t\ttimestamp\n\t\t\t\toptions\n\t\t\t}\n\t\t}\n\t}\n": typeof types.ScanHistoryTableDocument,
     "\n\tquery ScanRecordInspectorJobs($id: ID!, $loadLogs: Boolean!) {\n\t\tjobById(id: $id) {\n\t\t\tid\n\t\t\toutputData {\n\t\t\t\t__typename\n\t\t\t\t... on LibraryScanOutput {\n\t\t\t\t\ttotalFiles\n\t\t\t\t\ttotalDirectories\n\t\t\t\t\tignoredFiles\n\t\t\t\t\tskippedFiles\n\t\t\t\t\tignoredDirectories\n\t\t\t\t\tcreatedMedia\n\t\t\t\t\tupdatedMedia\n\t\t\t\t\tcreatedSeries\n\t\t\t\t\tupdatedSeries\n\t\t\t\t}\n\t\t\t}\n\t\t\tlogs @include(if: $loadLogs) {\n\t\t\t\tid\n\t\t\t}\n\t\t}\n\t}\n": typeof types.ScanRecordInspectorJobsDocument,
     "\n\tmutation DeleteLibraryThumbnails($id: ID!) {\n\t\tdeleteLibraryThumbnails(id: $id)\n\t}\n": typeof types.DeleteLibraryThumbnailsDocument,
-    "\n\tmutation LibraryThumbnailSelectorUpdate($id: ID!, $input: UpdateLibraryThumbnailInput!) {\n\t\tupdateLibraryThumbnail(id: $id, input: $input) {\n\t\t\tid\n\t\t\tthumbnail {\n\t\t\t\turl\n\t\t\t}\n\t\t}\n\t}\n": typeof types.LibraryThumbnailSelectorUpdateDocument,
+    "\n\tmutation LibraryThumbnailSelectorUpdate($id: ID!, $input: UpdateThumbnailInput!) {\n\t\tupdateLibraryThumbnail(id: $id, input: $input) {\n\t\t\tid\n\t\t\tthumbnail {\n\t\t\t\turl\n\t\t\t}\n\t\t}\n\t}\n": typeof types.LibraryThumbnailSelectorUpdateDocument,
     "\n\tmutation LibraryThumbnailSelectorUpload($id: ID!, $file: Upload!) {\n\t\tuploadLibraryThumbnail(id: $id, file: $file) {\n\t\t\tid\n\t\t\tthumbnail {\n\t\t\t\turl\n\t\t\t}\n\t\t}\n\t}\n": typeof types.LibraryThumbnailSelectorUploadDocument,
     "\n\tmutation RegenerateThumbnails($id: ID!, $forceRegenerate: Boolean!) {\n\t\tgenerateLibraryThumbnails(id: $id, forceRegenerate: $forceRegenerate)\n\t}\n": typeof types.RegenerateThumbnailsDocument,
     "\n\tquery SeriesLayout($id: ID!) {\n\t\tseriesById(id: $id) {\n\t\t\tid\n\t\t\tpath\n\t\t\tlibrary {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t}\n\t\t\tresolvedName\n\t\t\tresolvedDescription\n\t\t\ttags {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t}\n\t\t}\n\t}\n": typeof types.SeriesLayoutDocument,
@@ -169,6 +173,10 @@ const documents: Documents = {
     "\n\tmutation SendEmailAttachment($id: ID!, $sendTo: [EmailerSendTo!]!) {\n\t\tsendAttachmentEmail(input: { mediaIds: [$id], sendTo: $sendTo }) {\n\t\t\tsentCount\n\t\t\terrors\n\t\t}\n\t}\n": types.SendEmailAttachmentDocument,
     "\n\tquery BookReaderScene($id: ID!) {\n\t\tmediaById(id: $id) {\n\t\t\tid\n\t\t\tresolvedName\n\t\t\tpages\n\t\t\textension\n\t\t\treadProgress {\n\t\t\t\tpercentageCompleted\n\t\t\t\tepubcfi\n\t\t\t\tpage\n\t\t\t\telapsedSeconds\n\t\t\t}\n\t\t\tlibraryConfig {\n\t\t\t\tdefaultReadingImageScaleFit\n\t\t\t\tdefaultReadingMode\n\t\t\t\tdefaultReadingDir\n\t\t\t}\n\t\t\tmetadata {\n\t\t\t\tpageAnalysis {\n\t\t\t\t\tdimensions {\n\t\t\t\t\t\theight\n\t\t\t\t\t\twidth\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n": types.BookReaderSceneDocument,
     "\n\tmutation UpdateReadProgress($id: ID!, $page: Int!, $elapsedSeconds: Int!) {\n\t\tupdateMediaProgress(id: $id, page: $page, elapsedSeconds: $elapsedSeconds) {\n\t\t\t__typename\n\t\t}\n\t}\n": types.UpdateReadProgressDocument,
+    "\n\tquery BookManagementScene($id: ID!) {\n\t\tmediaById(id: $id) {\n\t\t\tid\n\t\t\tresolvedName\n\t\t\tlibrary {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t}\n\t\t\tseries {\n\t\t\t\tid\n\t\t\t\tresolvedName\n\t\t\t}\n\t\t\t...BookThumbnailSelector\n\t\t}\n\t}\n": types.BookManagementSceneDocument,
+    "\n\tfragment BookThumbnailSelector on Media {\n\t\tid\n\t\tthumbnail {\n\t\t\turl\n\t\t}\n\t\tpages\n\t}\n": types.BookThumbnailSelectorFragmentDoc,
+    "\n\tmutation BookThumbnailSelectorUpdate($id: ID!, $input: PageBasedThumbnailInput!) {\n\t\tupdateMediaThumbnail(id: $id, input: $input) {\n\t\t\tid\n\t\t\tthumbnail {\n\t\t\t\turl\n\t\t\t}\n\t\t}\n\t}\n": types.BookThumbnailSelectorUpdateDocument,
+    "\n\tmutation BookThumbnailSelectorUpload($id: ID!, $file: Upload!) {\n\t\tuploadMediaThumbnail(id: $id, file: $file) {\n\t\t\tid\n\t\t\tthumbnail {\n\t\t\t\turl\n\t\t\t}\n\t\t}\n\t}\n": types.BookThumbnailSelectorUploadDocument,
     "\n\tquery BookSearchScene(\n\t\t$filter: MediaFilterInput!\n\t\t$orderBy: [MediaOrderBy!]!\n\t\t$pagination: Pagination!\n\t) {\n\t\tmedia(filter: $filter, orderBy: $orderBy, pagination: $pagination) {\n\t\t\tnodes {\n\t\t\t\tid\n\t\t\t\t...BookCard\n\t\t\t\t...BookMetadata\n\t\t\t}\n\t\t\tpageInfo {\n\t\t\t\t__typename\n\t\t\t\t... on OffsetPaginationInfo {\n\t\t\t\t\tcurrentPage\n\t\t\t\t\ttotalPages\n\t\t\t\t\tpageSize\n\t\t\t\t\tpageOffset\n\t\t\t\t\tzeroBased\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n": types.BookSearchSceneDocument,
     "\n\tquery CreateLibrarySceneExistingLibraries {\n\t\tlibraries(pagination: { none: { unpaginated: true } }) {\n\t\t\tnodes {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t\tpath\n\t\t\t}\n\t\t}\n\t}\n": types.CreateLibrarySceneExistingLibrariesDocument,
     "\n\tmutation CreateLibrarySceneCreateLibrary($input: CreateOrUpdateLibraryInput!) {\n\t\tcreateLibrary(input: $input) {\n\t\t\tid\n\t\t}\n\t}\n": types.CreateLibrarySceneCreateLibraryDocument,
@@ -195,7 +203,7 @@ const documents: Documents = {
     "\n\tquery ScanHistoryTable($id: ID!) {\n\t\tlibraryById(id: $id) {\n\t\t\tid\n\t\t\tscanHistory {\n\t\t\t\tid\n\t\t\t\tjobId\n\t\t\t\ttimestamp\n\t\t\t\toptions\n\t\t\t}\n\t\t}\n\t}\n": types.ScanHistoryTableDocument,
     "\n\tquery ScanRecordInspectorJobs($id: ID!, $loadLogs: Boolean!) {\n\t\tjobById(id: $id) {\n\t\t\tid\n\t\t\toutputData {\n\t\t\t\t__typename\n\t\t\t\t... on LibraryScanOutput {\n\t\t\t\t\ttotalFiles\n\t\t\t\t\ttotalDirectories\n\t\t\t\t\tignoredFiles\n\t\t\t\t\tskippedFiles\n\t\t\t\t\tignoredDirectories\n\t\t\t\t\tcreatedMedia\n\t\t\t\t\tupdatedMedia\n\t\t\t\t\tcreatedSeries\n\t\t\t\t\tupdatedSeries\n\t\t\t\t}\n\t\t\t}\n\t\t\tlogs @include(if: $loadLogs) {\n\t\t\t\tid\n\t\t\t}\n\t\t}\n\t}\n": types.ScanRecordInspectorJobsDocument,
     "\n\tmutation DeleteLibraryThumbnails($id: ID!) {\n\t\tdeleteLibraryThumbnails(id: $id)\n\t}\n": types.DeleteLibraryThumbnailsDocument,
-    "\n\tmutation LibraryThumbnailSelectorUpdate($id: ID!, $input: UpdateLibraryThumbnailInput!) {\n\t\tupdateLibraryThumbnail(id: $id, input: $input) {\n\t\t\tid\n\t\t\tthumbnail {\n\t\t\t\turl\n\t\t\t}\n\t\t}\n\t}\n": types.LibraryThumbnailSelectorUpdateDocument,
+    "\n\tmutation LibraryThumbnailSelectorUpdate($id: ID!, $input: UpdateThumbnailInput!) {\n\t\tupdateLibraryThumbnail(id: $id, input: $input) {\n\t\t\tid\n\t\t\tthumbnail {\n\t\t\t\turl\n\t\t\t}\n\t\t}\n\t}\n": types.LibraryThumbnailSelectorUpdateDocument,
     "\n\tmutation LibraryThumbnailSelectorUpload($id: ID!, $file: Upload!) {\n\t\tuploadLibraryThumbnail(id: $id, file: $file) {\n\t\t\tid\n\t\t\tthumbnail {\n\t\t\t\turl\n\t\t\t}\n\t\t}\n\t}\n": types.LibraryThumbnailSelectorUploadDocument,
     "\n\tmutation RegenerateThumbnails($id: ID!, $forceRegenerate: Boolean!) {\n\t\tgenerateLibraryThumbnails(id: $id, forceRegenerate: $forceRegenerate)\n\t}\n": types.RegenerateThumbnailsDocument,
     "\n\tquery SeriesLayout($id: ID!) {\n\t\tseriesById(id: $id) {\n\t\t\tid\n\t\t\tpath\n\t\t\tlibrary {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t}\n\t\t\tresolvedName\n\t\t\tresolvedDescription\n\t\t\ttags {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t}\n\t\t}\n\t}\n": types.SeriesLayoutDocument,
@@ -392,6 +400,22 @@ export function graphql(source: "\n\tmutation UpdateReadProgress($id: ID!, $page
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
+export function graphql(source: "\n\tquery BookManagementScene($id: ID!) {\n\t\tmediaById(id: $id) {\n\t\t\tid\n\t\t\tresolvedName\n\t\t\tlibrary {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t}\n\t\t\tseries {\n\t\t\t\tid\n\t\t\t\tresolvedName\n\t\t\t}\n\t\t\t...BookThumbnailSelector\n\t\t}\n\t}\n"): typeof import('./graphql').BookManagementSceneDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n\tfragment BookThumbnailSelector on Media {\n\t\tid\n\t\tthumbnail {\n\t\t\turl\n\t\t}\n\t\tpages\n\t}\n"): typeof import('./graphql').BookThumbnailSelectorFragmentDoc;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n\tmutation BookThumbnailSelectorUpdate($id: ID!, $input: PageBasedThumbnailInput!) {\n\t\tupdateMediaThumbnail(id: $id, input: $input) {\n\t\t\tid\n\t\t\tthumbnail {\n\t\t\t\turl\n\t\t\t}\n\t\t}\n\t}\n"): typeof import('./graphql').BookThumbnailSelectorUpdateDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n\tmutation BookThumbnailSelectorUpload($id: ID!, $file: Upload!) {\n\t\tuploadMediaThumbnail(id: $id, file: $file) {\n\t\t\tid\n\t\t\tthumbnail {\n\t\t\t\turl\n\t\t\t}\n\t\t}\n\t}\n"): typeof import('./graphql').BookThumbnailSelectorUploadDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
 export function graphql(source: "\n\tquery BookSearchScene(\n\t\t$filter: MediaFilterInput!\n\t\t$orderBy: [MediaOrderBy!]!\n\t\t$pagination: Pagination!\n\t) {\n\t\tmedia(filter: $filter, orderBy: $orderBy, pagination: $pagination) {\n\t\t\tnodes {\n\t\t\t\tid\n\t\t\t\t...BookCard\n\t\t\t\t...BookMetadata\n\t\t\t}\n\t\t\tpageInfo {\n\t\t\t\t__typename\n\t\t\t\t... on OffsetPaginationInfo {\n\t\t\t\t\tcurrentPage\n\t\t\t\t\ttotalPages\n\t\t\t\t\tpageSize\n\t\t\t\t\tpageOffset\n\t\t\t\t\tzeroBased\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n"): typeof import('./graphql').BookSearchSceneDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
@@ -496,7 +520,7 @@ export function graphql(source: "\n\tmutation DeleteLibraryThumbnails($id: ID!) 
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
-export function graphql(source: "\n\tmutation LibraryThumbnailSelectorUpdate($id: ID!, $input: UpdateLibraryThumbnailInput!) {\n\t\tupdateLibraryThumbnail(id: $id, input: $input) {\n\t\t\tid\n\t\t\tthumbnail {\n\t\t\t\turl\n\t\t\t}\n\t\t}\n\t}\n"): typeof import('./graphql').LibraryThumbnailSelectorUpdateDocument;
+export function graphql(source: "\n\tmutation LibraryThumbnailSelectorUpdate($id: ID!, $input: UpdateThumbnailInput!) {\n\t\tupdateLibraryThumbnail(id: $id, input: $input) {\n\t\t\tid\n\t\t\tthumbnail {\n\t\t\t\turl\n\t\t\t}\n\t\t}\n\t}\n"): typeof import('./graphql').LibraryThumbnailSelectorUpdateDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/graphql/src/client/graphql.ts
+++ b/packages/graphql/src/client/graphql.ts
@@ -3232,6 +3232,13 @@ export type BookManagementSceneQuery = { __typename?: 'Query', mediaById?: (
     & { ' $fragmentRefs'?: { 'BookThumbnailSelectorFragment': BookThumbnailSelectorFragment } }
   ) | null };
 
+export type BookManagementSceneAnalyzeMutationVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+
+export type BookManagementSceneAnalyzeMutation = { __typename?: 'Mutation', analyzeMedia: boolean };
+
 export type BookThumbnailSelectorFragment = { __typename?: 'Media', id: string, pages: number, thumbnail: { __typename?: 'ImageRef', url: string } } & { ' $fragmentName'?: 'BookThumbnailSelectorFragment' };
 
 export type BookThumbnailSelectorUpdateMutationVariables = Exact<{
@@ -4459,6 +4466,11 @@ export const BookManagementSceneDocument = new TypedDocumentString(`
   }
   pages
 }`) as unknown as TypedDocumentString<BookManagementSceneQuery, BookManagementSceneQueryVariables>;
+export const BookManagementSceneAnalyzeDocument = new TypedDocumentString(`
+    mutation BookManagementSceneAnalyze($id: ID!) {
+  analyzeMedia(id: $id)
+}
+    `) as unknown as TypedDocumentString<BookManagementSceneAnalyzeMutation, BookManagementSceneAnalyzeMutationVariables>;
 export const BookThumbnailSelectorUpdateDocument = new TypedDocumentString(`
     mutation BookThumbnailSelectorUpdate($id: ID!, $input: PageBasedThumbnailInput!) {
   updateMediaThumbnail(id: $id, input: $input) {

--- a/packages/graphql/src/client/graphql.ts
+++ b/packages/graphql/src/client/graphql.ts
@@ -1329,7 +1329,7 @@ export type Mutation = {
   updateLibraryThumbnail: Library;
   updateMediaProgress: ReadingProgressOutput;
   /**
-   * Update the thumbnail for a library. This will replace the existing thumbnail with the the one
+   * Update the thumbnail for a book. This will replace the existing thumbnail with the the one
    * associated with the provided input (book). If the book does not have a thumbnail, one
    * will be generated based on the library's thumbnail configuration.
    */
@@ -1346,6 +1346,12 @@ export type Mutation = {
    */
   updateReadingList: ReadingList;
   updateScheduledJobConfig: ScheduledJobConfig;
+  /**
+   * Update the thumbnail for a series. This will replace the existing thumbnail with the the one
+   * associated with the provided input (book). If the book does not have a thumbnail, one
+   * will be generated based on the library's thumbnail configuration.
+   */
+  updateSeriesThumbnail: Series;
   updateSmartList: SmartList;
   updateSmartListView: SmartListView;
   updateUser: User;
@@ -1356,6 +1362,7 @@ export type Mutation = {
   uploadLibraryThumbnail: Library;
   uploadMediaThumbnail: Media;
   uploadSeries: Scalars['Boolean']['output'];
+  uploadSeriesThumbnail: Series;
   /**
    * "Visit" a library, which will upsert a record of the user's last visit to the library.
    * This is used to inform the UI of the last library which was visited by the user
@@ -1720,6 +1727,12 @@ export type MutationUpdateScheduledJobConfigArgs = {
 };
 
 
+export type MutationUpdateSeriesThumbnailArgs = {
+  id: Scalars['ID']['input'];
+  input: UpdateThumbnailInput;
+};
+
+
 export type MutationUpdateSmartListArgs = {
   id: Scalars['ID']['input'];
   input: SaveSmartListInput;
@@ -1773,6 +1786,12 @@ export type MutationUploadMediaThumbnailArgs = {
 
 export type MutationUploadSeriesArgs = {
   input: UploadSeriesInput;
+};
+
+
+export type MutationUploadSeriesThumbnailArgs = {
+  file: Scalars['Upload']['input'];
+  id: Scalars['ID']['input'];
 };
 
 
@@ -3510,6 +3529,41 @@ export type SeriesBookGridQueryVariables = Exact<{
 
 export type SeriesBookGridQuery = { __typename?: 'Query', media: { __typename?: 'PaginatedMediaResponse', nodes: Array<{ __typename?: 'Media', id: string, pages: number, thumbnail: { __typename?: 'ImageRef', url: string } }>, pageInfo: { __typename: 'CursorPaginationInfo', currentCursor?: string | null, nextCursor?: string | null, limit: number } | { __typename: 'OffsetPaginationInfo' } } };
 
+export type SeriesSettingsSceneQueryVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+
+export type SeriesSettingsSceneQuery = { __typename?: 'Query', seriesById?: (
+    { __typename?: 'Series' }
+    & { ' $fragmentRefs'?: { 'SeriesThumbnailSelectorFragment': SeriesThumbnailSelectorFragment } }
+  ) | null };
+
+export type SeriesSettingsSceneAnalyzeMutationVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+
+export type SeriesSettingsSceneAnalyzeMutation = { __typename?: 'Mutation', analyzeSeries: boolean };
+
+export type SeriesThumbnailSelectorFragment = { __typename?: 'Series', id: string, thumbnail: { __typename?: 'ImageRef', url: string } } & { ' $fragmentName'?: 'SeriesThumbnailSelectorFragment' };
+
+export type SeriesThumbnailSelectorUpdateMutationVariables = Exact<{
+  id: Scalars['ID']['input'];
+  input: UpdateThumbnailInput;
+}>;
+
+
+export type SeriesThumbnailSelectorUpdateMutation = { __typename?: 'Mutation', updateSeriesThumbnail: { __typename?: 'Series', id: string, thumbnail: { __typename?: 'ImageRef', url: string } } };
+
+export type SeriesThumbnailSelectorUploadMutationVariables = Exact<{
+  id: Scalars['ID']['input'];
+  file: Scalars['Upload']['input'];
+}>;
+
+
+export type SeriesThumbnailSelectorUploadMutation = { __typename?: 'Mutation', uploadSeriesThumbnail: { __typename?: 'Series', id: string, thumbnail: { __typename?: 'ImageRef', url: string } } };
+
 export type ApiKeyTableQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -4001,6 +4055,14 @@ export const LibrarySettingsConfigFragmentDoc = new TypedDocumentString(`
   }
 }
     `, {"fragmentName":"LibrarySettingsConfig"}) as unknown as TypedDocumentString<LibrarySettingsConfigFragment, unknown>;
+export const SeriesThumbnailSelectorFragmentDoc = new TypedDocumentString(`
+    fragment SeriesThumbnailSelector on Series {
+  id
+  thumbnail {
+    url
+  }
+}
+    `, {"fragmentName":"SeriesThumbnailSelector"}) as unknown as TypedDocumentString<SeriesThumbnailSelectorFragment, unknown>;
 export const EmailerListItemFragmentDoc = new TypedDocumentString(`
     fragment EmailerListItem on Emailer {
   id
@@ -5082,6 +5144,43 @@ export const SeriesBookGridDocument = new TypedDocumentString(`
   }
 }
     `) as unknown as TypedDocumentString<SeriesBookGridQuery, SeriesBookGridQueryVariables>;
+export const SeriesSettingsSceneDocument = new TypedDocumentString(`
+    query SeriesSettingsScene($id: ID!) {
+  seriesById(id: $id) {
+    ...SeriesThumbnailSelector
+  }
+}
+    fragment SeriesThumbnailSelector on Series {
+  id
+  thumbnail {
+    url
+  }
+}`) as unknown as TypedDocumentString<SeriesSettingsSceneQuery, SeriesSettingsSceneQueryVariables>;
+export const SeriesSettingsSceneAnalyzeDocument = new TypedDocumentString(`
+    mutation SeriesSettingsSceneAnalyze($id: ID!) {
+  analyzeSeries(id: $id)
+}
+    `) as unknown as TypedDocumentString<SeriesSettingsSceneAnalyzeMutation, SeriesSettingsSceneAnalyzeMutationVariables>;
+export const SeriesThumbnailSelectorUpdateDocument = new TypedDocumentString(`
+    mutation SeriesThumbnailSelectorUpdate($id: ID!, $input: UpdateThumbnailInput!) {
+  updateSeriesThumbnail(id: $id, input: $input) {
+    id
+    thumbnail {
+      url
+    }
+  }
+}
+    `) as unknown as TypedDocumentString<SeriesThumbnailSelectorUpdateMutation, SeriesThumbnailSelectorUpdateMutationVariables>;
+export const SeriesThumbnailSelectorUploadDocument = new TypedDocumentString(`
+    mutation SeriesThumbnailSelectorUpload($id: ID!, $file: Upload!) {
+  uploadSeriesThumbnail(id: $id, file: $file) {
+    id
+    thumbnail {
+      url
+    }
+  }
+}
+    `) as unknown as TypedDocumentString<SeriesThumbnailSelectorUploadMutation, SeriesThumbnailSelectorUploadMutationVariables>;
 export const ApiKeyTableDocument = new TypedDocumentString(`
     query APIKeyTable {
   apiKeys {

--- a/packages/sdk/src/constants.ts
+++ b/packages/sdk/src/constants.ts
@@ -28,6 +28,7 @@ export const cacheKeys = {
 	getStats: 'getStats',
 	recentlyAddedMedia: 'recentlyAddedMedia',
 	media: 'media',
+	mediaById: 'mediaById',
 	apiKeys: 'apiKeys',
 	logs: 'logs',
 	jobs: 'jobs',


### PR DESCRIPTION
I still really hate the UI for the (barely implemented) book and series management pages, but I think that is a large effort for another day. This PR ports the pages to work with the new backend. I also refactored the thumbnail operations to have a bit more of a shared structure (e.g., reused input objects, functions, etc).