### PR TITLE
✨ Add toggle to separate the page that follows the cover

### DIFF
--- a/packages/browser/src/components/readers/imageBased/ImageBasedReader.tsx
+++ b/packages/browser/src/components/readers/imageBased/ImageBasedReader.tsx
@@ -80,6 +80,7 @@ export default function ImageBasedReader({
 			readingMode,
 			readingDirection,
 			trackElapsedTime,
+			secondPageSeparate,
 		},
 		setSettings,
 	} = useBookPreferences({ book: media })
@@ -113,7 +114,11 @@ export default function ImageBasedReader({
 		if (doublePageBehavior === 'off' || autoButOff || modeForceOff) {
 			sets = Array.from({ length: pages }, (_, i) => [i])
 		} else {
-			sets = generatePageSets({ imageSizes: pageDimensions, pages: pages })
+			sets = generatePageSets({
+				imageSizes: pageDimensions,
+				pages: pages,
+				secondPageSeparate: secondPageSeparate,
+			})
 		}
 
 		if (readingDirection === 'rtl') {
@@ -121,7 +126,15 @@ export default function ImageBasedReader({
 		}
 
 		return sets
-	}, [doublePageBehavior, pages, pageDimensions, deviceOrientation, readingMode, readingDirection])
+	}, [
+		doublePageBehavior,
+		pages,
+		pageDimensions,
+		deviceOrientation,
+		readingMode,
+		readingDirection,
+		secondPageSeparate,
+	])
 
 	const { updateReadProgress } = useUpdateMediaProgress(media.id, {
 		retry: (attempts) => attempts < 3,

--- a/packages/browser/src/components/readers/imageBased/container/ReaderSettings.tsx
+++ b/packages/browser/src/components/readers/imageBased/container/ReaderSettings.tsx
@@ -131,6 +131,16 @@ export default function ReaderSettings({ forBook, currentPage }: Props) {
 				<Label className="text-xs font-medium uppercase text-foreground-muted">Preferences</Label>
 
 				<Label className="flex items-center justify-between px-1 pt-4">
+					<span>Separate second page</span>
+					<RawSwitch
+						primaryRing
+						variant="primary"
+						checked={activeSettings.secondPageSeparate}
+						onCheckedChange={(checked) => onPreferenceChange({ secondPageSeparate: checked })}
+					/>
+				</Label>
+
+				<Label className="flex items-center justify-between px-1 pt-4">
 					<span>Tap sides to navigate</span>
 					<RawSwitch
 						primaryRing

--- a/packages/browser/src/scenes/book/reader/useBookPreferences.ts
+++ b/packages/browser/src/scenes/book/reader/useBookPreferences.ts
@@ -83,6 +83,7 @@ const settingsAsBookPreferences = (settings: ReaderSettings): BookPreferences =>
 	trackElapsedTime: settings.trackElapsedTime,
 	doublePageBehavior: settings.doublePageBehavior,
 	fontFamily: settings.fontFamily,
+	secondPageSeparate: settings.secondPageSeparate,
 })
 
 const buildPreferences = (

--- a/packages/client/src/stores/reader.ts
+++ b/packages/client/src/stores/reader.ts
@@ -61,6 +61,10 @@ export type BookPreferences = {
 	 * Whether or not to track elapsed time for the book
 	 */
 	trackElapsedTime: boolean
+	/**
+	 * Whether or not the page 2 should be displayed separately. This will have no effect if the book is not image-based
+	 */
+	secondPageSeparate: boolean
 }
 
 /**
@@ -132,6 +136,7 @@ export const DEFAULT_BOOK_PREFERENCES = {
 		scaleToFit: 'height',
 	},
 	doublePageBehavior: 'auto',
+	secondPageSeparate: false,
 	trackElapsedTime: true,
 	tapSidesToNavigate: true,
 } as const

--- a/packages/sdk/src/utils/__tests__/reader.test.ts
+++ b/packages/sdk/src/utils/__tests__/reader.test.ts
@@ -20,14 +20,37 @@ describe('reader utils', () => {
 		}
 
 		describe('exception cases', () => {
+			it('should keep the second page in its own set only when secondPageSeparate is true', () => {
+				const imageSizesSecondPageTest: Record<number, ImageBasedBookPageRef> = {
+					...imageSizes,
+					3: { height: 1000, width: 800, ratio: 0.8 },
+					5: { height: 1000, width: 800, ratio: 0.8 },
+					6: { height: 800, width: 1000, ratio: 1.25 },
+				}
+
+				const setsTrue = generatePageSets({
+					imageSizes: imageSizesSecondPageTest,
+					pages: 7,
+					secondPageSeparate: true,
+				})
+				expect(setsTrue).toEqual([[0], [1], [2, 3], [4, 5], [6]])
+
+				const setsFalse = generatePageSets({
+					imageSizes: imageSizesSecondPageTest,
+					pages: 7,
+					secondPageSeparate: false,
+				})
+				expect(setsFalse).toEqual([[0], [1, 2], [3, 4], [5], [6]])
+			})
+
 			it('should always keep the first page in its own set', () => {
-				const sets = generatePageSets({ imageSizes, pages: 5 })
+				const sets = generatePageSets({ imageSizes, pages: 5, secondPageSeparate: false })
 				expect(sets[0]).toEqual([0])
 			})
 
 			it('should always keep the last page in its own set', () => {
 				// Portrait page at the end
-				let sets = generatePageSets({ imageSizes, pages: 5 })
+				let sets = generatePageSets({ imageSizes, pages: 5, secondPageSeparate: false })
 				expect(sets[sets.length - 1]).toEqual([4])
 
 				// Landscape page at the end
@@ -37,6 +60,7 @@ describe('reader utils', () => {
 						4: { height: 800, width: 1000, ratio: 1.25 },
 					},
 					pages: 5,
+					secondPageSeparate: false,
 				})
 				expect(sets[sets.length - 1]).toEqual([4])
 
@@ -47,6 +71,7 @@ describe('reader utils', () => {
 						ratio: 0.8,
 					})).reduce((acc, curr, idx) => ({ ...acc, [idx]: curr }), {}),
 					pages: 19,
+					secondPageSeparate: false,
 				})
 				expect(sets[sets.length - 1]).toEqual([18])
 
@@ -57,6 +82,7 @@ describe('reader utils', () => {
 						ratio: 0.8,
 					})).reduce((acc, curr, idx) => ({ ...acc, [idx]: curr }), {}),
 					pages: 20,
+					secondPageSeparate: false,
 				})
 				expect(sets[sets.length - 1]).toEqual([19])
 			})
@@ -72,6 +98,7 @@ describe('reader utils', () => {
 						9: { height: 1000, width: 800, ratio: 0.8 },
 					},
 					pages: 10,
+					secondPageSeparate: false,
 				})
 
 				// Index 3, 5, 6 are landscape pages, 4 is not but surrounded by landscape pages
@@ -84,7 +111,7 @@ describe('reader utils', () => {
 				0: { height: 1000, width: 800, ratio: 0.8 },
 				1: { height: 1000, width: 800, ratio: 0.9 }, // Mismatched ratio
 			}
-			generatePageSets({ imageSizes: imageSizesWithMismatch, pages: 2 })
+			generatePageSets({ imageSizes: imageSizesWithMismatch, pages: 2, secondPageSeparate: false })
 			expect(console.warn).toHaveBeenCalledWith(
 				expect.stringContaining('Image size ratio mismatch for page 2'),
 				expect.objectContaining({ width: 800, height: 1000 }),

--- a/packages/sdk/src/utils/reader.ts
+++ b/packages/sdk/src/utils/reader.ts
@@ -7,9 +7,14 @@ export type ImageBasedBookPageRef = {
 export type GeneratePageSetsParams = {
 	imageSizes: Record<number, ImageBasedBookPageRef>
 	pages: number
+	secondPageSeparate?: boolean
 }
 
-export const generatePageSets = ({ imageSizes, pages }: GeneratePageSetsParams): number[][] => {
+export const generatePageSets = ({
+	imageSizes,
+	pages,
+	secondPageSeparate = false,
+}: GeneratePageSetsParams): number[][] => {
 	const sets: number[][] = []
 
 	const landscapePages = Object.keys(imageSizes).reduce(
@@ -45,6 +50,11 @@ export const generatePageSets = ({ imageSizes, pages }: GeneratePageSetsParams):
 
 	let currentSet: number[] = []
 	for (let i = 0; i < pages; i++) {
+		if (secondPageSeparate && i === 1) {
+			sets.push([1])
+			visitedSet.add(1)
+			continue
+		}
 		if (visitedSet.has(i)) {
 			continue // Skip already processed pages
 		}


### PR DESCRIPTION
Solves #693 by adding a toggle that separates the second page. 

Useful for books where the title page is the second page and not the inside cover.