### PR TITLE
✨ Add ctrl + scroll to zoom and middle click to pan for paged reader

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -20,6 +20,7 @@
 		"@dnd-kit/core": "^6.1.0",
 		"@dnd-kit/sortable": "^8.0.0",
 		"@hookform/resolvers": "^3.9.0",
+		"@panzoom/panzoom": "^4.6.0",
 		"@stump/client": "*",
 		"@stump/components": "*",
 		"@stump/i18n": "*",

--- a/packages/browser/src/components/readers/imageBased/paged/PagedReader.tsx
+++ b/packages/browser/src/components/readers/imageBased/paged/PagedReader.tsx
@@ -1,6 +1,7 @@
+import Panzoom from '@panzoom/panzoom'
 import type { Media } from '@stump/sdk'
 import clsx from 'clsx'
-import { memo, useCallback, useMemo, useRef } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { Hotkey } from 'react-hotkeys-hook/dist/types'
 import { useMediaMatch, useWindowSize } from 'rooks'
@@ -30,7 +31,7 @@ export type PagedReaderProps = {
  */
 function PagedReader({ currentPage, media, onPageChange, getPageUrl }: PagedReaderProps) {
 	const {
-		bookPreferences: { tapSidesToNavigate },
+		bookPreferences: { tapSidesToNavigate, imageScaling, secondPageSeparate, doublePageBehavior },
 		settings: { showToolBar },
 		setSettings,
 	} = useBookPreferences({ book: media })
@@ -46,6 +47,79 @@ function PagedReader({ currentPage, media, onPageChange, getPageUrl }: PagedRead
 	const isMobile = useMediaMatch('(max-width: 768px)')
 
 	const pageSetRef = useRef<HTMLDivElement | null>(null)
+	const panzoomRef = useRef<ReturnType<typeof Panzoom> | null>(null)
+
+	useEffect(() => {
+		const pageSetElement = pageSetRef.current
+		if (!pageSetElement) return
+
+		const parentElement = pageSetElement.parentElement
+		if (!parentElement) return
+
+		const createAndConfigurePanzoom = () => {
+			const viewportWidth = window.innerWidth
+			const panzoomElementWidth = pageSetElement.offsetWidth
+			const xOrigin = (1 - viewportWidth / (2 * panzoomElementWidth)) * 100
+
+			const origin = `${xOrigin}% 50%`
+
+			if (panzoomRef.current) {
+				panzoomRef.current.destroy()
+			}
+
+			const pz = Panzoom(pageSetElement, {
+				noBind: true, // Disable middle and left click panning
+				cursor: 'default',
+				minScale: 0.8,
+				maxScale: 2.5,
+				origin: origin,
+			})
+			panzoomRef.current = pz
+
+			const handleWheel = (event: WheelEvent) => {
+				if (event.ctrlKey) {
+					pz.zoomWithWheel(event)
+				}
+			}
+
+			// Re-enable panning with middle click
+			const handlePointerDown = (event: PointerEvent) => {
+				if (event.button === 1) {
+					pz.handleDown(event)
+					parentElement.style.cursor = 'move'
+					pageSetElement.style.cursor = 'move'
+					event.preventDefault()
+				}
+			}
+			const handlePointerUp = (event: PointerEvent) => {
+				if (event.button === 1) {
+					pz.handleUp(event)
+					parentElement.style.cursor = 'default'
+					pageSetElement.style.cursor = 'default'
+				}
+			}
+
+			parentElement.removeEventListener('wheel', handleWheel)
+			parentElement.removeEventListener('pointerdown', handlePointerDown)
+			document.removeEventListener('pointermove', pz.handleMove)
+			document.removeEventListener('pointerup', handlePointerUp)
+
+			parentElement.addEventListener('wheel', handleWheel)
+			parentElement.addEventListener('pointerdown', handlePointerDown)
+			document.addEventListener('pointermove', pz.handleMove)
+			document.addEventListener('pointerup', handlePointerUp)
+		}
+
+		createAndConfigurePanzoom()
+
+		window.addEventListener('resize', createAndConfigurePanzoom)
+
+		return () => {
+			window.removeEventListener('resize', createAndConfigurePanzoom)
+			// The others are already removed inside createAndConfigurePanzoom
+			panzoomRef.current?.destroy()
+		}
+	}, [currentPage, imageScaling, secondPageSeparate, doublePageBehavior])
 
 	const currentSet = useMemo(
 		() => pageSets.find((set) => set.includes(currentPage - 1)) || [currentPage - 1],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1249,20 +1249,7 @@
     "@babel/parser" "^7.25.9"
     "@babel/types" "^7.25.9"
 
-"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3":
-  version "7.26.5"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.26.5.tgz#6d0be3e772ff786456c1a37538208286f6e79021"
-  integrity sha512-rkOSPOw+AXbgtwUga3U4u8RpoK9FEFWBNAlTpcnkLFjL5CT+oyHNuUUC/xx6XefEJ16r38r8Bc/lfp6rYuHeJQ==
-  dependencies:
-    "@babel/code-frame" "^7.26.2"
-    "@babel/generator" "^7.26.5"
-    "@babel/parser" "^7.26.5"
-    "@babel/template" "^7.25.9"
-    "@babel/types" "^7.26.5"
-    debug "^4.3.1"
-    globals "^11.1.0"
-
-"@babel/traverse@^7.18.9", "@babel/traverse@^7.23.2", "@babel/traverse@^7.25.3", "@babel/traverse@^7.25.7", "@babel/traverse@^7.25.9", "@babel/traverse@^7.26.5":
+"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3", "@babel/traverse@^7.18.9", "@babel/traverse@^7.23.2", "@babel/traverse@^7.25.3", "@babel/traverse@^7.25.7", "@babel/traverse@^7.25.9", "@babel/traverse@^7.26.5":
   version "7.26.5"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.26.5.tgz#6d0be3e772ff786456c1a37538208286f6e79021"
   integrity sha512-rkOSPOw+AXbgtwUga3U4u8RpoK9FEFWBNAlTpcnkLFjL5CT+oyHNuUUC/xx6XefEJ16r38r8Bc/lfp6rYuHeJQ==
@@ -3372,6 +3359,11 @@
   integrity sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==
   dependencies:
     "@octokit/openapi-types" "^18.0.0"
+
+"@panzoom/panzoom@^4.6.0":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@panzoom/panzoom/-/panzoom-4.6.0.tgz#ab9cb71403ed46fc5ac32bb9186761cdbd4a8177"
+  integrity sha512-3KxkY1lNKFn98fW5ZFR6vV0YzsXj3I4EQDyFWSXME6/cic86eSS7VjuqIjrA3PEpySo0r5fFtlX8eYCt4JPUFQ==
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
@@ -7220,7 +7212,7 @@
     "@types/history" "^4.7.11"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@=18.3.12", "@types/react@>=16", "@types/react@^18.3.12":
+"@types/react@*", "@types/react@>=16", "@types/react@^18.3.12":
   version "18.3.12"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.12.tgz#99419f182ccd69151813b7ee24b792fe08774f60"
   integrity sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==
@@ -21274,16 +21266,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -21414,7 +21397,7 @@ stringify-object@3.3.0, stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -21434,13 +21417,6 @@ strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -23505,7 +23481,7 @@ workbox-window@7.3.0, workbox-window@^7.3.0:
     "@types/trusted-types" "^2.0.2"
     workbox-core "7.3.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -23518,15 +23494,6 @@ wrap-ansi@^6.0.1:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Adds a zoom ability with ctrl + scroll when using paged reader. I would've liked to make no holding any modifier keys to zoom as default, since it would allow zooming and page turning while only using mouse, no need to touch keyboard, but I didn't want to mess with the current expected functionality of scrolling on a landscape screen when using scaling setting 'width'. 

Also adds hold then drag middle click to pan. 

Solves #606 and maybe issue 1 in #679 but I think that was about having a permanent 75% zoom and this resets every page turn, but it fulfils the same desire to see content closer.

Note that it doesn't change any behaviour for tap sides to navigate, so after zooming in, you still click the same places as before, doesn't matter where you've moved the images it won't move the click location.