### PR TITLE
✨ Auto Scaling Option + bug fix for double paged width scaling

### DIFF
--- a/core/src/db/entity/common.rs
+++ b/core/src/db/entity/common.rs
@@ -88,6 +88,8 @@ pub enum ReadingImageScaleFit {
 	Height,
 	#[serde(rename = "width")]
 	Width,
+	#[serde(rename = "auto")]
+	Auto,
 	#[serde(rename = "none", alias = "original")]
 	None,
 }
@@ -99,6 +101,7 @@ impl FromStr for ReadingImageScaleFit {
 		match s {
 			"height" => Ok(ReadingImageScaleFit::Height),
 			"width" => Ok(ReadingImageScaleFit::Width),
+			"auto" => Ok(ReadingImageScaleFit::Auto),
 			"none" | "original" => Ok(ReadingImageScaleFit::None),
 			_ => Err(format!("\"{s}\" is not a valid image scale fit")),
 		}
@@ -110,6 +113,7 @@ impl fmt::Display for ReadingImageScaleFit {
 		match self {
 			ReadingImageScaleFit::Height => write!(f, "height"),
 			ReadingImageScaleFit::Width => write!(f, "width"),
+			ReadingImageScaleFit::Auto => write!(f, "auto"),
 			ReadingImageScaleFit::None => write!(f, "none"),
 		}
 	}

--- a/core/src/filesystem/scanner/library_watcher.rs
+++ b/core/src/filesystem/scanner/library_watcher.rs
@@ -419,7 +419,7 @@ mod tests {
 			.is_ok());
 
 		// Wait for the background thread to trigger the flush
-		tokio::time::sleep(Duration::from_millis(20)).await;
+		tokio::time::sleep(Duration::from_millis(100)).await;
 		let (id, path) = mock_objs.jobs_receiver.try_recv().expect("Expected a job");
 		assert_eq!(id, "42");
 		assert_eq!(path, tmp_dir.to_string_lossy().to_string());

--- a/packages/browser/src/components/library/createOrUpdate/schema.ts
+++ b/packages/browser/src/components/library/createOrUpdate/schema.ts
@@ -63,7 +63,7 @@ export const buildSchema = (existingLibraries: Library[], library?: Library) =>
 		convert_rar_to_zip: z.boolean().default(false),
 		default_reading_dir: z.enum(['ltr', 'rtl']).default('ltr').optional(),
 		default_reading_image_scale_fit: z
-			.enum(['height', 'width', 'none'])
+			.enum(['auto', 'height', 'width', 'none'])
 			.default('height')
 			.optional(),
 		default_reading_mode: z

--- a/packages/browser/src/components/library/createOrUpdate/sections/DefaultReadingSettings.tsx
+++ b/packages/browser/src/components/library/createOrUpdate/sections/DefaultReadingSettings.tsx
@@ -16,6 +16,7 @@ export default function DefaultReadingSettings() {
 					<Label>{t(getKey('imageScaling.label'))}</Label>
 					<NativeSelect
 						options={[
+							{ label: 'Auto', value: 'auto' },
 							{ label: 'Height', value: 'height' },
 							{ label: 'Width', value: 'width' },
 							{ label: 'Original', value: 'none' },

--- a/packages/browser/src/components/readers/imageBased/container/ImageScalingSelect.tsx
+++ b/packages/browser/src/components/readers/imageBased/container/ImageScalingSelect.tsx
@@ -31,6 +31,7 @@ export default function ImageScalingSelect({ value, onChange }: Props) {
 				id="image-scaling-fit"
 				size="sm"
 				options={[
+					{ label: 'Auto', value: 'auto' },
 					{ label: 'Height', value: 'height' },
 					{ label: 'Width', value: 'width' },
 					{ label: 'Original', value: 'none' },
@@ -44,4 +45,4 @@ export default function ImageScalingSelect({ value, onChange }: Props) {
 }
 
 const isBookImageScalingFit = (value: string): value is BookImageScalingFit =>
-	['height', 'width', 'none'].includes(value)
+	['height', 'width', 'auto', 'none'].includes(value)

--- a/packages/browser/src/components/readers/imageBased/container/__tests__/ImageScalingSelect.test.tsx
+++ b/packages/browser/src/components/readers/imageBased/container/__tests__/ImageScalingSelect.test.tsx
@@ -25,7 +25,7 @@ describe('ImageScalingSelect', () => {
 		const onChange = jest.fn()
 		render(<ImageScalingSelect value="height" onChange={onChange} />)
 
-		const validOptions = ['height', 'width', 'none']
+		const validOptions = ['height', 'width', 'auto', 'none']
 		for (const option of validOptions) {
 			fireEvent.change(screen.getByLabelText('Image scaling'), { target: { value: option } })
 			expect(onChange).toHaveBeenCalledWith(option)

--- a/packages/browser/src/components/readers/imageBased/paged/PageSet.tsx
+++ b/packages/browser/src/components/readers/imageBased/paged/PageSet.tsx
@@ -83,7 +83,7 @@ const _Page = ({
 	return (
 		<EntityImage
 			key={`page-${page}-scaled-${scaleToFit}`}
-			className='z-30'
+			className="z-30"
 			style={style}
 			src={getPageUrl(page)}
 			onLoad={({ height, width }) => {

--- a/packages/browser/src/components/readers/imageBased/paged/PageSet.tsx
+++ b/packages/browser/src/components/readers/imageBased/paged/PageSet.tsx
@@ -44,9 +44,10 @@ const PageSet = forwardRef<HTMLDivElement, Props>(
 				className="flex h-full justify-center"
 				style={{
 					filter: `brightness(${brightness * 100}%)`,
+					minWidth: imageScaling.scaleToFit === 'width' ? '100%' : '',
 				}}
 			>
-				{currentSet.map((idx) => (
+				{currentSet.map((idx, i) => (
 					<Page
 						key={`page-${idx + 1}`}
 						page={idx + 1}
@@ -54,6 +55,10 @@ const PageSet = forwardRef<HTMLDivElement, Props>(
 						onPageClick={onPageClick}
 						upsertDimensions={upsertDimensions}
 						imageScaling={imageScaling}
+						style={{
+							// objectPosition helps position pages correctly for 'auto'
+							objectPosition: currentSet.length === 2 ? (i === 0 ? 'right' : 'left') : 'center',
+						}}
 					/>
 				))}
 			</div>
@@ -68,6 +73,7 @@ type PageProps = Omit<Props, 'displayedPages' | 'currentPage'> & {
 	page: number
 	upsertDimensions: (page: number, dimensions: ImagePageDimensionRef) => void
 	imageScaling: BookImageScaling
+	style?: React.CSSProperties
 }
 
 // TODO(readers): consider exporting/relocating and sharing with the continuous reader(s)
@@ -77,6 +83,7 @@ const _Page = ({
 	onPageClick,
 	upsertDimensions,
 	imageScaling: { scaleToFit },
+	style,
 }: PageProps) => {
 	return (
 		<EntityImage
@@ -92,7 +99,11 @@ const _Page = ({
 				{
 					'mx-auto my-0 w-full object-contain': scaleToFit === 'width',
 				},
+				{
+					'm-auto h-full max-h-screen w-full object-contain': scaleToFit === 'auto',
+				},
 			)}
+			style={style}
 			src={getPageUrl(page)}
 			onLoad={({ height, width }) => {
 				upsertDimensions(page, {

--- a/packages/browser/src/components/readers/imageBased/paged/PageSet.tsx
+++ b/packages/browser/src/components/readers/imageBased/paged/PageSet.tsx
@@ -143,7 +143,7 @@ const styles = {
 			// no min height
 			// no max height
 			height: '100%',
-			objectFit: 'cover', // different fit
+			objectFit: 'contain',
 		} as React.CSSProperties,
 	},
 
@@ -174,8 +174,17 @@ const styles = {
 			// no width
 			// no height
 			justifyContent: 'center',
+			alignItems: 'center', // add vertical alignment
 		} as React.CSSProperties,
 
-		image: { objectFit: 'contain' } as React.CSSProperties,
+		image: {
+			// no min width
+			// no max width
+			width: 'max-content',
+			// no min height
+			// no max height
+			height: 'max-content',
+			objectFit: 'contain',
+		} as React.CSSProperties,
 	},
 }

--- a/packages/browser/src/components/readers/imageBased/paged/PageSet.tsx
+++ b/packages/browser/src/components/readers/imageBased/paged/PageSet.tsx
@@ -83,6 +83,7 @@ const _Page = ({
 	return (
 		<EntityImage
 			key={`page-${page}-scaled-${scaleToFit}`}
+			className='z-30'
 			style={style}
 			src={getPageUrl(page)}
 			onLoad={({ height, width }) => {

--- a/packages/browser/src/components/readers/imageBased/paged/PageSet.tsx
+++ b/packages/browser/src/components/readers/imageBased/paged/PageSet.tsx
@@ -1,5 +1,4 @@
 import { BookImageScaling } from '@stump/client'
-import { cn } from '@stump/components'
 import React, { forwardRef, useCallback, useMemo } from 'react'
 
 import { EntityImage } from '@/components/entity'
@@ -41,13 +40,12 @@ const PageSet = forwardRef<HTMLDivElement, Props>(
 		return (
 			<div
 				ref={ref}
-				className="flex h-full justify-center"
 				style={{
+					...styles[imageScaling.scaleToFit].imagesHolder,
 					filter: `brightness(${brightness * 100}%)`,
-					minWidth: imageScaling.scaleToFit === 'width' ? '100%' : '',
 				}}
 			>
-				{currentSet.map((idx, i) => (
+				{currentSet.map((idx) => (
 					<Page
 						key={`page-${idx + 1}`}
 						page={idx + 1}
@@ -55,10 +53,7 @@ const PageSet = forwardRef<HTMLDivElement, Props>(
 						onPageClick={onPageClick}
 						upsertDimensions={upsertDimensions}
 						imageScaling={imageScaling}
-						style={{
-							// objectPosition helps position pages correctly for 'auto'
-							objectPosition: currentSet.length === 2 ? (i === 0 ? 'right' : 'left') : 'center',
-						}}
+						style={styles[imageScaling.scaleToFit].image}
 					/>
 				))}
 			</div>
@@ -88,21 +83,6 @@ const _Page = ({
 	return (
 		<EntityImage
 			key={`page-${page}-scaled-${scaleToFit}`}
-			className={cn(
-				'z-30 select-none',
-				{
-					'mx-auto my-0 w-auto self-center': scaleToFit === 'none',
-				},
-				{
-					'm-auto h-full max-h-screen w-auto object-cover': scaleToFit === 'height',
-				},
-				{
-					'mx-auto my-0 w-full object-contain': scaleToFit === 'width',
-				},
-				{
-					'm-auto h-full max-h-screen w-full object-contain': scaleToFit === 'auto',
-				},
-			)}
 			style={style}
 			src={getPageUrl(page)}
 			onLoad={({ height, width }) => {
@@ -121,3 +101,80 @@ const _Page = ({
 	)
 }
 const Page = React.memo(_Page)
+
+/**
+ * Styles for the image and page set holder
+ */
+const styles = {
+	auto: {
+		imagesHolder: {
+			display: 'flex',
+			flexDirection: 'row',
+			// no width
+			height: '100vh',
+			justifyContent: 'center',
+		} as React.CSSProperties,
+
+		image: {
+			minWidth: '0%',
+			maxWidth: '100%',
+			minHeight: '0%',
+			// no width
+			maxHeight: '100%',
+			height: '100%',
+			objectFit: 'contain',
+		} as React.CSSProperties,
+	},
+
+	height: {
+		imagesHolder: {
+			display: 'flex',
+			flexDirection: 'row',
+			// no width
+			height: '100vh',
+			justifyContent: 'center',
+		} as React.CSSProperties,
+
+		image: {
+			// no min width
+			// no max width
+			// no width
+			// no min height
+			// no max height
+			height: '100%',
+			objectFit: 'cover', // different fit
+		} as React.CSSProperties,
+	},
+
+	width: {
+		imagesHolder: {
+			display: 'flex',
+			flexDirection: 'row',
+			// no height
+			width: '100vw',
+			justifyContent: 'center',
+		} as React.CSSProperties,
+
+		image: {
+			minWidth: '0%',
+			maxWidth: '100%',
+			width: '100%',
+			minHeight: '0%',
+			maxHeight: '100%',
+			// no height
+			objectFit: 'contain',
+		} as React.CSSProperties,
+	},
+
+	none: {
+		imagesHolder: {
+			display: 'flex',
+			flexDirection: 'row',
+			// no width
+			// no height
+			justifyContent: 'center',
+		} as React.CSSProperties,
+
+		image: { objectFit: 'contain' } as React.CSSProperties,
+	},
+}

--- a/packages/browser/src/components/readers/imageBased/paged/PagedReader.tsx
+++ b/packages/browser/src/components/readers/imageBased/paged/PagedReader.tsx
@@ -262,6 +262,7 @@ function PagedReader({ currentPage, media, onPageChange, getPageUrl }: PagedRead
 				display: 'flex',
 				justifyContent: 'center',
 				margin: 'auto',
+				width: '100%',
 			}}
 		>
 			{!showToolBar && tapSidesToNavigate && (

--- a/packages/browser/src/components/readers/imageBased/paged/PagedReader.tsx
+++ b/packages/browser/src/components/readers/imageBased/paged/PagedReader.tsx
@@ -258,13 +258,17 @@ function PagedReader({ currentPage, media, onPageChange, getPageUrl }: PagedRead
 	 */
 	useHotkeys('right, left, space, escape', (_, handler) => hotKeyHandler(handler))
 
+	const unconstrainedWidth =
+		imageScaling.scaleToFit === 'height' || imageScaling.scaleToFit === 'none'
+
 	return (
 		<div
 			style={{
 				display: 'flex',
 				justifyContent: 'center',
 				margin: 'auto',
-				width: '100%',
+				minWidth: '100%',
+				width: unconstrainedWidth ? 'max-content' : '100%',
 			}}
 		>
 			{!showToolBar && tapSidesToNavigate && (

--- a/packages/browser/src/components/readers/imageBased/paged/PagedReader.tsx
+++ b/packages/browser/src/components/readers/imageBased/paged/PagedReader.tsx
@@ -257,7 +257,13 @@ function PagedReader({ currentPage, media, onPageChange, getPageUrl }: PagedRead
 	useHotkeys('right, left, space, escape', (_, handler) => hotKeyHandler(handler))
 
 	return (
-		<div className="relative flex h-full w-full items-center justify-center">
+		<div
+			style={{
+				display: 'flex',
+				justifyContent: 'center',
+				margin: 'auto',
+			}}
+		>
 			{!showToolBar && tapSidesToNavigate && (
 				<SideBarControl
 					fixed={fixSideNavigation}
@@ -306,8 +312,8 @@ function SideBarControl({ onClick, position, fixed }: SideBarControlProps) {
 	return (
 		<div
 			className={clsx(
-				'z-50 h-[300%] shrink-0 border border-transparent transition-all duration-300',
-				'active:border-edge-subtle active:bg-background-surface active:bg-opacity-50',
+				'z-50 mt-[-50vh] h-[150vh] shrink-0 border border-transparent transition-all duration-300',
+				'active: border-edge-subtle active:bg-background-surface active:bg-opacity-50',
 				fixed ? 'fixed w-[10%]' : 'relative mx-[-3%] flex flex-1 flex-grow',
 				{ 'right-0': position === 'right' },
 				{ 'left-0': position === 'left' },

--- a/packages/browser/src/components/readers/imageBased/paged/PagedReader.tsx
+++ b/packages/browser/src/components/readers/imageBased/paged/PagedReader.tsx
@@ -313,7 +313,7 @@ function SideBarControl({ onClick, position, fixed }: SideBarControlProps) {
 		<div
 			className={clsx(
 				'z-50 mt-[-50vh] h-[150vh] shrink-0 border border-transparent transition-all duration-300',
-				'active: border-edge-subtle active:bg-background-surface active:bg-opacity-50',
+				'active:border-edge-subtle active:bg-background-surface active:bg-opacity-50',
 				fixed ? 'fixed w-[10%]' : 'relative mx-[-3%] flex flex-1 flex-grow',
 				{ 'right-0': position === 'right' },
 				{ 'left-0': position === 'left' },

--- a/packages/browser/src/components/readers/imageBased/paged/PagedReader.tsx
+++ b/packages/browser/src/components/readers/imageBased/paged/PagedReader.tsx
@@ -84,6 +84,8 @@ function PagedReader({ currentPage, media, onPageChange, getPageUrl }: PagedRead
 			let startX = 0
 			let startY = 0
 			const handlePointerDown = (event: PointerEvent) => {
+				if (event.button === 2) return
+
 				startX = event.clientX
 				startY = event.clientY
 

--- a/packages/client/src/stores/reader.ts
+++ b/packages/client/src/stores/reader.ts
@@ -2,7 +2,7 @@ import type { ReadingDirection, ReadingMode } from '@stump/sdk'
 import { create } from 'zustand'
 import { createJSONStorage, devtools, persist, StateStorage } from 'zustand/middleware'
 
-export type BookImageScalingFit = 'width' | 'height' | 'none'
+export type BookImageScalingFit = 'auto' | 'width' | 'height' | 'none'
 export type BookImageScaling = {
 	scaleToFit: BookImageScalingFit
 }

--- a/packages/sdk/src/types/generated.ts
+++ b/packages/sdk/src/types/generated.ts
@@ -136,7 +136,7 @@ export type ReadingDirection = "ltr" | "rtl"
 
 export type ReadingMode = "paged" | "continuous:vertical" | "continuous:horizontal"
 
-export type ReadingImageScaleFit = "height" | "width" | "none"
+export type ReadingImageScaleFit = "height" | "width" | "auto" | "none"
 
 export type FileStatus = "UNKNOWN" | "READY" | "UNSUPPORTED" | "ERROR" | "MISSING"
 


### PR DESCRIPTION
Adds image scaling option 'auto' (always keeps page(s) within the browser window). I did not modify the scrolling reader file though. I did not set it as the default but maybe it should be. It's also in library settings so non-default is not that big of a deal.

Also fixed width scaling issue to actually use the full width when viewing pages that are low resolution.

I hope the code is okay. ~~I saw one issue where a page snapped to the left when narrowing the browser enough to go from 2 pages to 1, but I could never get it to happen again.~~ (edit: changed the code so likely doesn't apply)

There is also an issue where on ~~'auto' and~~ (edit: new code fixed this) 'width' if both pages in double page mode have different resolutions they will show up with different physical sizes, this was already happening for 'width' before these proposed changes, but imo it's the book's fault and I can't find a nice fix without breaking stuff. Height doesn't have that problem so use that if it is annoying.