### PR TITLE
🐛 Fix flashing between pages

### DIFF
--- a/packages/browser/src/components/readers/imageBased/paged/PageSet.tsx
+++ b/packages/browser/src/components/readers/imageBased/paged/PageSet.tsx
@@ -16,7 +16,7 @@ const PageSet = forwardRef<HTMLDivElement, Props>(
 	({ currentPage, getPageUrl, onPageClick }, ref) => {
 		const { setDimensions, book, pageSets } = useImageBaseReaderContext()
 		const {
-			bookPreferences: { imageScaling, brightness },
+			bookPreferences: { imageScaling, brightness, readingDirection },
 		} = useBookPreferences({ book })
 
 		/**
@@ -32,10 +32,14 @@ const PageSet = forwardRef<HTMLDivElement, Props>(
 			[setDimensions],
 		)
 
-		const currentSet = useMemo(
-			() => pageSets.find((set) => set.includes(currentPage - 1)) || [currentPage - 1],
+		const currentSetIdx = useMemo(
+			() => pageSets.findIndex((set) => set.includes(currentPage - 1)),
 			[currentPage, pageSets],
 		)
+		const currentSet = pageSets[currentSetIdx] || [currentPage - 1]
+
+		const nextSetIdx = currentSetIdx + (readingDirection === 'ltr' ? 1 : -1)
+		const nextSet = pageSets[nextSetIdx] || []
 
 		return (
 			<div
@@ -54,6 +58,23 @@ const PageSet = forwardRef<HTMLDivElement, Props>(
 						upsertDimensions={upsertDimensions}
 						imageScaling={imageScaling}
 						style={styles[imageScaling.scaleToFit].image}
+					/>
+				))}
+				{nextSet.map((idx) => (
+					<Page
+						key={`page-${idx + 1}`}
+						page={idx + 1}
+						getPageUrl={getPageUrl}
+						onPageClick={() => {}}
+						upsertDimensions={() => {}}
+						imageScaling={imageScaling}
+						style={{
+							position: 'fixed',
+							maxWidth: 'max-content',
+							maxHeight: '100%',
+							zIndex: -1,
+							opacity: 0,
+						}}
 					/>
 				))}
 			</div>


### PR DESCRIPTION
When changing page on Firefox and Chrome, what happens very fast is: the current pages disappear, we're left with the background, then the new ones appear. This is made worse when the page is white and the background dark. Doesn't happen on Safari unless flicking through a book really fast (which is quite slow on Safari).

Not sure I like this fix, but I didn't want to remove the keys. This makes the next set of images render with zero opacity at the required size before turning the page, meaning they are ready to use immediately on page turn. Note this is only for the forwards direction, but I can easily add the other if needed.

Outcome in my testing: 

- Firefox: only flashes if flicking through a book really fast; normal reading pace should be fine
- Chrome: zero flashing ever even if flicking through a book really fast
- Safari: zero flashing ever even if flicking through a book really fast (again which is still slow)

---

By flicking through a book fast, I just mean holding the arrow key down.