### PR TITLE
:recycle: Fix some lints and the benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ tokio = { version = "1.41.1", features = [
   "rt-multi-thread",
   # Allows handling shutdown signals (e.g., ctrl+c)
   "signal",
+  "macros"
 ] }
 toml = "0.8.19"
 tower-sessions = "0.14.0"

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -6,8 +6,8 @@ use crate::{
 	store::{
 		app_store::AppStoreExt,
 		secure_store::{
-			CredentialStoreTokenState, JwtTokenPair, SecureStore, SecureStoreError,
-			StoredCredentials, StoredTokens,
+			CredentialStoreTokenState, SecureStore, SecureStoreError, StoredCredentials,
+			StoredTokens,
 		},
 		AppStore, StoreError,
 	},

--- a/apps/desktop/src-tauri/src/store/secure_store.rs
+++ b/apps/desktop/src-tauri/src/store/secure_store.rs
@@ -249,11 +249,11 @@ mod tests {
 		store
 			.set_tokens(
 				"homeserver".to_string(),
-				JwtTokenPair {
+				StoredTokens::Jwt(JwtTokenPair {
 					access_token: "definitely-real-token".to_string(),
 					refresh_token: Some("definitely-real-refresh-token".to_string()),
 					expires_at: (Utc::now() + chrono::Duration::days(1)).into(),
-				},
+				}),
 			)
 			.expect("Failed to set token");
 
@@ -263,6 +263,10 @@ mod tests {
 			.expect("Failed to get token")
 			.expect("Token missing");
 
+		let tokens = match tokens {
+			StoredTokens::Jwt(tokens) => tokens,
+			_ => panic!("Unexpected token type"),
+		};
 		assert_eq!(tokens.access_token, "definitely-real-token");
 		assert_eq!(
 			tokens.refresh_token,
@@ -279,11 +283,11 @@ mod tests {
 		store
 			.set_tokens(
 				"homeserver".to_string(),
-				JwtTokenPair {
+				StoredTokens::Jwt(JwtTokenPair {
 					access_token: "definitely-real-token".to_string(),
 					refresh_token: Some("definitely-real-refresh-token".to_string()),
 					expires_at: (Utc::now() + chrono::Duration::days(1)).into(),
-				},
+				}),
 			)
 			.expect("Failed to set token");
 		// Delete the token
@@ -308,11 +312,11 @@ mod tests {
 		store
 			.set_tokens(
 				"homeserver".to_string(),
-				JwtTokenPair {
+				StoredTokens::Jwt(JwtTokenPair {
 					access_token: "definitely-real-token".to_string(),
 					refresh_token: Some("definitely-real-refresh-token".to_string()),
 					expires_at: (Utc::now() + chrono::Duration::days(1)).into(),
-				},
+				}),
 			)
 			.expect("Failed to set token");
 
@@ -322,11 +326,11 @@ mod tests {
 		new_store
 			.set_tokens(
 				"homeserver".to_string(),
-				JwtTokenPair {
+				StoredTokens::Jwt(JwtTokenPair {
 					access_token: "new-definitely-real-token".to_string(),
 					refresh_token: Some("new-definitely-real-refresh-token".to_string()),
 					expires_at: (Utc::now() + chrono::Duration::days(1)).into(),
-				},
+				}),
 			)
 			.expect("Failed to set token");
 
@@ -336,6 +340,11 @@ mod tests {
 			.get_tokens("homeserver".to_string())
 			.expect("Failed to get token")
 			.expect("Token missing");
+
+		let tokens = match tokens {
+			StoredTokens::Jwt(tokens) => tokens,
+			_ => panic!("Unexpected token type"),
+		};
 
 		assert_eq!(tokens.access_token, "new-definitely-real-token");
 		assert_eq!(
@@ -348,13 +357,15 @@ mod tests {
 	#[test]
 	fn test_create_entry() {
 		let mut store = SecureStore::default();
-		assert!(store.records.is_empty());
+		assert!(store.credentials_records.is_empty());
+		assert!(store.token_records.is_empty());
 
 		store
 			.create_entry("homeserver".to_string())
 			.expect("Failed to create entry");
 
-		assert_eq!(store.records.len(), 1);
+		assert!(store.credentials_records.is_empty());
+		assert!(store.token_records.is_empty());
 	}
 
 	#[ignore]
@@ -367,7 +378,8 @@ mod tests {
 
 		store.clear();
 
-		assert!(store.records.is_empty());
+		assert!(store.credentials_records.is_empty());
+		assert!(store.token_records.is_empty());
 	}
 
 	#[ignore]
@@ -376,6 +388,7 @@ mod tests {
 		let store = SecureStore::init(vec!["homeserver".to_string()])
 			.expect("Failed to init store");
 
-		assert_eq!(store.records.len(), 1);
+		assert!(store.credentials_records.is_empty());
+		assert!(store.token_records.is_empty());
 	}
 }

--- a/apps/server/src/errors.rs
+++ b/apps/server/src/errors.rs
@@ -147,10 +147,10 @@ impl APIError {
 			APIError::NotImplemented => StatusCode::NOT_IMPLEMENTED,
 			APIError::ServiceUnavailable(_) => StatusCode::SERVICE_UNAVAILABLE,
 			APIError::BadGateway(_) => StatusCode::BAD_GATEWAY,
-			APIError::DbError(error) => match error {
-				sea_orm::error::DbErr::RecordNotFound(_) => StatusCode::NOT_FOUND,
-				_ => StatusCode::INTERNAL_SERVER_ERROR,
+			APIError::DbError(sea_orm::error::DbErr::RecordNotFound(_)) => {
+				StatusCode::NOT_FOUND
 			},
+			APIError::DbError(_) => StatusCode::INTERNAL_SERVER_ERROR,
 			APIError::Redirect(_) => StatusCode::TEMPORARY_REDIRECT,
 			_ => StatusCode::INTERNAL_SERVER_ERROR,
 		}

--- a/apps/server/src/utils/time.rs
+++ b/apps/server/src/utils/time.rs
@@ -1,7 +1,5 @@
 use chrono::{DateTime, Utc};
 
-use crate::errors::{APIError, APIResult};
-
 /// Gets the current UTC time as a DateTime<Utc>. If the current environment is a test, this
 /// function will use [`tokio::time::Instant`] and calculate the current time from that. Ensure
 /// you are running the test within a tokio runtime with the `start_paused = true` annotation.
@@ -19,21 +17,6 @@ pub fn current_utc_time() -> DateTime<Utc> {
 	}
 }
 
-/// Attempts to parse a date from a string.
-pub fn string_to_date(date: String) -> APIResult<DateTime<Utc>> {
-	DateTime::parse_from_rfc3339(&date)
-		.map(|dt| dt.with_timezone(&Utc))
-		.map_err(|error| APIError::BadRequest(error.to_string()))
-}
-
-/// Attempts to parse a date from a string, returning the current UTC date if it fails.
-pub fn safe_string_to_date(date: String) -> DateTime<Utc> {
-	string_to_date(date).unwrap_or_else(|error| {
-		tracing::error!(?error, "Failed to parse date");
-		Utc::now()
-	})
-}
-
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -45,33 +28,5 @@ mod tests {
 		tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
 		let new_now = current_utc_time();
 		assert_eq!(new_now.timestamp(), now.timestamp());
-	}
-
-	#[test]
-	fn test_string_to_date() {
-		let date = "2021-01-01T00:00:00Z".to_string();
-		let result = string_to_date(date);
-		assert!(result.is_ok());
-	}
-
-	#[test]
-	fn test_string_to_date_invalid() {
-		let date = "2021-01-01T00:00:00".to_string();
-		let result = string_to_date(date);
-		assert!(result.is_err());
-	}
-
-	#[test]
-	fn test_safe_string_to_date() {
-		let date = "2021-01-01T00:00:00Z".to_string();
-		let result = safe_string_to_date(date);
-		assert!(result.timestamp() > 0);
-	}
-
-	#[test]
-	fn test_safe_string_to_date_invalid() {
-		let date = "2021-01-01T00:00:00".to_string();
-		let result = safe_string_to_date(date);
-		assert!(result.timestamp() > 0);
 	}
 }

--- a/core/src/database.rs
+++ b/core/src/database.rs
@@ -46,6 +46,12 @@ pub async fn connect(config: &StumpConfig) -> Result<DatabaseConnection, CoreErr
 	Ok(connection)
 }
 
+pub async fn connect_at(path: &str) -> Result<DatabaseConnection, CoreError> {
+	let connection = sea_orm::Database::connect(path).await?;
+	Migrator::up(&connection, None).await?;
+	Ok(connection)
+}
+
 #[derive(Deserialize, Serialize, Debug, Default)]
 pub struct CountQueryReturn {
 	pub count: i64,

--- a/core/src/filesystem/error.rs
+++ b/core/src/filesystem/error.rs
@@ -68,8 +68,6 @@ impl From<FileError> for CoreError {
 
 #[derive(Error, Debug)]
 pub enum ScanError {
-	#[error("A query error occurred: {0}")]
-	QueryError(String),
 	#[error("Unsupported file: {0}")]
 	UnsupportedFile(String),
 	#[error("Failed to build globset from invalid .stumpignore file: {0}")]

--- a/core/src/filesystem/image/mod.rs
+++ b/core/src/filesystem/image/mod.rs
@@ -11,7 +11,7 @@ use image::ImageFormat;
 use models::shared::image_processor_options::{
 	ScaledDimensionResize, SupportedImageFormat,
 };
-pub use process::ImageProcessor;
+pub use process::{ImageProcessor, ImageProcessorOptionsExt};
 pub use thumbnail::*;
 use tokio::{sync::oneshot, task::spawn_blocking};
 

--- a/core/src/filesystem/scanner/library_watcher.rs
+++ b/core/src/filesystem/scanner/library_watcher.rs
@@ -6,7 +6,7 @@ use crate::{
 use async_trait::async_trait;
 use models::entity::{library, library_config};
 use notify::{Event, RecommendedWatcher, Watcher};
-use sea_orm::{prelude::*, QuerySelect};
+use sea_orm::prelude::*;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/core/src/opds/v2_0/progression.rs
+++ b/core/src/opds/v2_0/progression.rs
@@ -49,7 +49,7 @@ impl OPDSProgression {
 					let title = "Ebook Progress".to_string();
 					// TODO: Use resource URL for href, e.g. OEBPS/chapter008.xhtml ?
 					let locations =
-						data.session.percentage_completed.map(|progression| {
+						data.session.percentage_completed.map(|_progression| {
 							vec![OPDSProgressionLocation {
 								fragments: Some(vec![cfi]),
 								total_progression: percentage_completed,

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -38,15 +38,3 @@ pub(crate) fn default_progress_spinner() -> ProgressBar {
 	);
 	progress
 }
-
-pub(crate) fn chain_optional_iter<T>(
-	required: impl IntoIterator<Item = T>,
-	optional: impl IntoIterator<Item = Option<T>>,
-) -> Vec<T> {
-	required
-		.into_iter()
-		.map(Some)
-		.chain(optional)
-		.flatten()
-		.collect()
-}

--- a/crates/graphql/src/filter/log.rs
+++ b/crates/graphql/src/filter/log.rs
@@ -1,6 +1,5 @@
 use async_graphql::InputObject;
 use models::entity::log;
-use sea_orm::prelude::*;
 
 use super::{apply_string_filter, IntoFilter, StringLikeFilter};
 

--- a/crates/graphql/src/filter/mod.rs
+++ b/crates/graphql/src/filter/mod.rs
@@ -2,9 +2,7 @@ use async_graphql::{InputObject, InputType, OneofObject};
 use filter_gen::IntoFilter;
 use models::shared::enums::{FileStatus, ReadingStatus};
 use sea_orm::{
-	prelude::{DateTimeWithTimeZone, *},
-	sea_query::ConditionExpression,
-	Condition, Value,
+	prelude::DateTimeWithTimeZone, sea_query::ConditionExpression, Condition, Value,
 };
 use serde::{Deserialize, Serialize};
 
@@ -172,7 +170,7 @@ mod tests {
 	use super::*;
 	use models::entity::media;
 	use pretty_assertions::assert_eq;
-	use sea_orm::{sea_query::SqliteQueryBuilder, QuerySelect, QueryTrait};
+	use sea_orm::{prelude::*, sea_query::SqliteQueryBuilder, QuerySelect, QueryTrait};
 
 	#[test]
 	fn test_string_like_any_of() {

--- a/crates/graphql/src/input/email_device.rs
+++ b/crates/graphql/src/input/email_device.rs
@@ -1,6 +1,6 @@
 use async_graphql::InputObject;
 use models::entity::registered_email_device;
-use sea_orm::{prelude::*, ActiveModelTrait, NotSet, Set};
+use sea_orm::{NotSet, Set};
 
 /// Input object for creating or updating an email device
 #[derive(InputObject)]

--- a/crates/graphql/src/input/smart_list_view.rs
+++ b/crates/graphql/src/input/smart_list_view.rs
@@ -19,8 +19,8 @@ pub struct SmartListViewColumn {
 	pub position: i32,
 }
 
-#[serde(rename_all = "camelCase")]
 #[derive(Debug, Clone, SimpleObject, InputObject, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 #[graphql(input_name = "SmartListViewConfigInput")]
 pub struct SmartListViewConfig {
 	pub book_columns: Vec<SmartListViewColumn>,

--- a/crates/graphql/src/input/smart_lists.rs
+++ b/crates/graphql/src/input/smart_lists.rs
@@ -40,6 +40,8 @@ pub enum SmartListGroupJoiner {
 	Not,
 }
 
+// TODO(sea-orm): Consider box-ing these
+#[allow(clippy::large_enum_variant)]
 #[derive(OneofObject, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum SmartListFilterInput {

--- a/crates/graphql/src/loader/favorite.rs
+++ b/crates/graphql/src/loader/favorite.rs
@@ -55,7 +55,7 @@ impl Loader<FavoriteMediaLoaderKey> for FavoritesLoader {
 				.find(|f| f.user_id == key.user_id && f.media_id == key.media_id)
 				.cloned();
 
-			if let Some(_) = favorite {
+			if favorite.is_some() {
 				result.insert(key.clone(), true);
 			}
 		}
@@ -105,7 +105,7 @@ impl Loader<FavoriteSeriesLoaderKey> for FavoritesLoader {
 				.find(|f| f.user_id == key.user_id && f.series_id == key.series_id)
 				.cloned();
 
-			if let Some(_) = favorite {
+			if favorite.is_some() {
 				result.insert(key.clone(), true);
 			}
 		}
@@ -155,7 +155,7 @@ impl Loader<FavoriteLibraryLoaderKey> for FavoritesLoader {
 				.find(|f| f.user_id == key.user_id && f.library_id == key.library_id)
 				.cloned();
 
-			if let Some(_) = favorite {
+			if favorite.is_some() {
 				result.insert(key.clone(), true);
 			}
 		}

--- a/crates/graphql/src/loader/library.rs
+++ b/crates/graphql/src/loader/library.rs
@@ -70,7 +70,7 @@ impl Loader<LibraryToMediaLoaderKey> for LibraryLoader {
 		// map the libraries which are related to the series IDs... So this actually
 		// won't work yet. It might just need to be a more complex join with a selection
 		// to get them into the map correctly
-		let models = library::Entity::find()
+		let _models = library::Entity::find()
 			.filter(
 				library::Column::Id.in_subquery(
 					Query::select()

--- a/crates/graphql/src/mutation/book_club_invitation.rs
+++ b/crates/graphql/src/mutation/book_club_invitation.rs
@@ -161,7 +161,6 @@ fn create_member_active_model(
 		role: Set(invitation.role),
 		hide_progress: Set(input.private_membership.unwrap_or(false)),
 		is_creator: Set(false),
-		..Default::default()
 	}
 }
 

--- a/crates/graphql/src/mutation/emailer/emailer.rs
+++ b/crates/graphql/src/mutation/emailer/emailer.rs
@@ -99,7 +99,7 @@ impl EmailerMutation {
 
 fn validate_send_permissions(
 	req_ctx: &AuthContext,
-	send_to: &Vec<EmailerSendTo>,
+	send_to: &[EmailerSendTo],
 ) -> Result<()> {
 	let is_sending_to_anonymous = send_to
 		.iter()

--- a/crates/graphql/src/mutation/emailer/mod.rs
+++ b/crates/graphql/src/mutation/emailer/mod.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::module_inception)]
 mod emailer;
 mod sender;
 

--- a/crates/graphql/src/mutation/emailer/sender.rs
+++ b/crates/graphql/src/mutation/emailer/sender.rs
@@ -338,7 +338,7 @@ async fn get_and_validate_recipients(
 async fn check_forbidden_recipients(
 	user: &AuthUser,
 	conn: &DatabaseConnection,
-	recipients: &Vec<String>,
+	recipients: &[String],
 ) -> Result<()> {
 	let forbidden_devices = registered_email_device::Entity::find()
 		.filter(registered_email_device::Column::Forbidden.eq(true))
@@ -924,7 +924,7 @@ mod tests {
 		let result = check_forbidden_recipients(
 			&user,
 			&conn,
-			&vec![
+			&[
 				"cslewis@gmail.com".to_string(),
 				"tolkien@gmail.com".to_string(),
 			],
@@ -945,7 +945,7 @@ mod tests {
 		let result = check_forbidden_recipients(
 			&user,
 			&conn,
-			&vec![
+			&[
 				"cslewis@gmail.com".to_string(),
 				"tolkien@gmail.com".to_string(),
 			],

--- a/crates/graphql/src/mutation/library.rs
+++ b/crates/graphql/src/mutation/library.rs
@@ -18,7 +18,7 @@ use sea_orm::{
 use stump_core::filesystem::{
 	image::{
 		generate_book_thumbnail, remove_thumbnails, GenerateThumbnailOptions,
-		ThumbnailGenerationJob, ThumbnailGenerationJobParams,
+		ImageProcessorOptionsExt, ThumbnailGenerationJob, ThumbnailGenerationJobParams,
 	},
 	scanner::{LibraryScanJob, ScanOptions},
 };
@@ -186,6 +186,14 @@ impl LibraryMutation {
 		let tags = input.tags.take();
 
 		let txn = core.conn.as_ref().begin().await?;
+
+		if let Some(thumbnail_config) = input
+			.config
+			.as_ref()
+			.and_then(|c| c.thumbnail_config.as_ref())
+		{
+			thumbnail_config.validate()?;
+		}
 
 		let (library, config) = input.into_active_model();
 

--- a/crates/graphql/src/mutation/media.rs
+++ b/crates/graphql/src/mutation/media.rs
@@ -1,4 +1,4 @@
-use async_graphql::{Context, Object, Result, SimpleObject, Union, ID};
+use async_graphql::{Context, Object, Result, Union, ID};
 use chrono::Utc;
 use models::{
 	entity::{

--- a/crates/graphql/src/mutation/reading_list.rs
+++ b/crates/graphql/src/mutation/reading_list.rs
@@ -115,13 +115,13 @@ async fn create_reading_list_items(
 }
 
 async fn get_for_owner(
-	id: &String,
+	id: &str,
 	conn: &DbConn,
 	user_id: String,
 ) -> Result<reading_list::Model> {
 	// Check if reading list exists
 	let reading_list = reading_list::Entity::find()
-		.filter(reading_list::Column::Id.eq(id.clone()))
+		.filter(reading_list::Column::Id.eq(id.to_owned()))
 		.one(conn)
 		.await?
 		.ok_or("Reading list not found")?;
@@ -160,7 +160,7 @@ mod tests {
 			.append_query_results(vec![vec![get_reading_list_test_object()]])
 			.into_connection();
 
-		let reading_list = get_for_owner(&"123".to_string(), &mock_db, "42".to_string())
+		let reading_list = get_for_owner("123", &mock_db, "42".to_string())
 			.await
 			.unwrap();
 
@@ -175,8 +175,7 @@ mod tests {
 			.append_query_results(vec![vec![test_model]])
 			.into_connection();
 
-		let result =
-			get_for_owner(&"123".to_string(), &mock_db, "user".to_string()).await;
+		let result = get_for_owner("123", &mock_db, "user".to_string()).await;
 
 		assert!(result.is_err());
 	}

--- a/crates/graphql/src/mutation/series.rs
+++ b/crates/graphql/src/mutation/series.rs
@@ -163,7 +163,11 @@ impl SeriesMutation {
 	}
 
 	// TODO(graphql): Implement mark_series_as_complete
-	async fn mark_series_as_complete(&self, ctx: &Context<'_>, id: ID) -> Result<Series> {
+	async fn mark_series_as_complete(
+		&self,
+		_ctx: &Context<'_>,
+		_id: ID,
+	) -> Result<Series> {
 		unimplemented!()
 	}
 

--- a/crates/graphql/src/mutation/upload.rs
+++ b/crates/graphql/src/mutation/upload.rs
@@ -235,7 +235,7 @@ impl UploadMutation {
 	) -> Result<Series> {
 		let AuthContext { user, .. } = ctx.data()?;
 		let core = ctx.data::<CoreContext>()?;
-		let conn = core.conn.as_ref();
+		let _conn = core.conn.as_ref();
 
 		let series = series::ModelWithMetadata::find_for_user(user)
 			.filter(series::Column::Id.eq(id.to_string()))

--- a/crates/graphql/src/object/smart_list_item.rs
+++ b/crates/graphql/src/object/smart_list_item.rs
@@ -4,8 +4,8 @@ use crate::object::{library::Library, media::Media, series::Series};
 
 #[derive(Debug, Union)]
 pub enum SmartListItemEntity {
-	Series(Series),
-	Library(Library),
+	Series(Box<Series>),
+	Library(Box<Library>),
 }
 
 #[derive(Debug, SimpleObject)]

--- a/crates/graphql/src/query/config.rs
+++ b/crates/graphql/src/query/config.rs
@@ -1,6 +1,5 @@
 use async_graphql::{Context, Object, Result, SimpleObject};
 use models::shared::enums::UserPermission;
-use sea_orm::prelude::*;
 use stump_core::config::StumpConfig;
 
 use crate::{data::CoreContext, guard::PermissionGuard};

--- a/crates/graphql/src/query/smart_lists_builder.rs
+++ b/crates/graphql/src/query/smart_lists_builder.rs
@@ -69,7 +69,7 @@ async fn group_by_series(
 				.remove(&series_model.series.id)
 				.unwrap_or_default();
 			SmartListGroupedItem {
-				entity: SmartListItemEntity::Series(series_model.into()),
+				entity: SmartListItemEntity::Series(Box::new(series_model.into())),
 				books,
 			}
 		})
@@ -136,7 +136,7 @@ async fn group_by_library(
 				.collect();
 
 			SmartListGroupedItem {
-				entity: SmartListItemEntity::Library(library_model.into()),
+				entity: SmartListItemEntity::Library(Box::new(library_model.into())),
 				books,
 			}
 		})

--- a/crates/macros/filter-gen/src/ordering.rs
+++ b/crates/macros/filter-gen/src/ordering.rs
@@ -63,7 +63,7 @@ pub fn ordering_impl(input: TokenStream) -> Result<TokenStream, syn::Error> {
 fn find_attr(
 	attr_name: &str,
 	attr_param: &str,
-	attrs: &Vec<syn::Attribute>,
+	attrs: &[syn::Attribute],
 ) -> Result<Option<String>, syn::Error> {
 	let mut name = None;
 	attrs
@@ -90,7 +90,7 @@ fn find_attr(
 
 const RAW_IDENTIFIER: &str = "r#";
 
-fn is_skip_column(attrs: &Vec<syn::Attribute>) -> bool {
+fn is_skip_column(attrs: &[syn::Attribute]) -> bool {
 	attrs
 		.iter()
 		.filter(|attr| attr.path().is_ident("ordering"))

--- a/crates/models/src/entity/job.rs
+++ b/crates/models/src/entity/job.rs
@@ -79,6 +79,9 @@ impl ActiveModelBehavior for ActiveModel {
 			}
 			self.ms_elapsed = Set(0);
 			self.created_at = Set(DateTimeWithTimeZone::from(Utc::now()));
+			if self.status.is_not_set() {
+				self.status = Set(JobStatus::Queued);
+			}
 		}
 
 		Ok(self)

--- a/crates/models/src/entity/reading_list.rs
+++ b/crates/models/src/entity/reading_list.rs
@@ -59,17 +59,17 @@ impl Related<super::user::Entity> for Entity {
 
 impl ActiveModelBehavior for ActiveModel {}
 
-fn get_reading_list_rbac_for_user(user_id: &String, minimum_role: i32) -> Condition {
+fn get_reading_list_rbac_for_user(user_id: &str, minimum_role: i32) -> Condition {
 	// A common condition that asserts there is a RBAC entry for the user that has a role
 	// greater than or equal to the minimum role:
 	// 1 for reader, 2 for collaborator, 3 for creator
 	let base_rbac = Condition::all()
-		.add(reading_list_rule::Column::UserId.eq(user_id.clone()))
+		.add(reading_list_rule::Column::UserId.eq(user_id.to_owned()))
 		.add(reading_list_rule::Column::Role.gte(minimum_role));
 
 	Condition::any()
 		// creator always has access
-		.add(Column::CreatingUserId.eq(user_id.clone()))
+		.add(Column::CreatingUserId.eq(user_id.to_owned()))
 		// condition where visibility is PUBLIC:
 		.add(
 			Condition::all()
@@ -122,7 +122,7 @@ mod tests {
 
 	#[test]
 	fn test_reading_list_rbac() {
-		let condition = get_reading_list_rbac_for_user(&"42".to_string(), 1);
+		let condition = get_reading_list_rbac_for_user("42", 1);
 		assert_eq!(
 			condition_to_string(&condition),
 			r#"SELECT  WHERE "#.to_string()

--- a/crates/models/src/lib.rs
+++ b/crates/models/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 mod tests {
 	pub mod common;
 }


### PR DESCRIPTION
This PR is a mix of lints fixed via running ` __CARGO_FIX_YOLO=1 cargo clippy --fix` and a refactor of:

- The benchmarks to use SeaORM so it compiles and allows clippy to run
- The scanner concurrency logic to align with changes made to the thumbnail generation (see https://github.com/stumpapp/stump/issues/668)