### PR TITLE
🐛 Fix: Allow press and hold on mobile browser

### DIFF
--- a/packages/browser/src/components/readers/epub/controls/FontSizeControl.tsx
+++ b/packages/browser/src/components/readers/epub/controls/FontSizeControl.tsx
@@ -1,4 +1,4 @@
-import { cx, Label, Text, TEXT_VARIANTS } from '@stump/components'
+import { cx, IconButton, Label, Text, TEXT_VARIANTS } from '@stump/components'
 import { Minus, Plus } from 'lucide-react'
 import { useCallback, useEffect, useRef } from 'react'
 
@@ -31,7 +31,8 @@ export default function FontSizeControl() {
 		[setBookPreferences],
 	)
 
-	const { bindButton } = usePressAndHold()
+	const { bindButton: bindMinus, isHolding: isHoldingMinus } = usePressAndHold()
+	const { bindButton: bindPlus, isHolding: isHoldingPlus } = usePressAndHold()
 
 	/**
 	 * Used to preview the font size as it will be displayed in the reader. The max
@@ -44,28 +45,32 @@ export default function FontSizeControl() {
 		<div className="flex flex-col gap-y-2.5">
 			<Label>Font size</Label>
 			<div className="flex items-center gap-x-2">
-				<button
-					{...bindButton({
+				<IconButton
+					{...bindMinus({
 						callback: () => handleSetFontSize(fontSizeRef.current - 1),
 					})}
-					className={cx('text-base', TEXT_VARIANTS.secondary)}
+					variant="ghost"
+					size="xs"
+					className={isHoldingMinus ? 'select-none bg-background-surface-hover' : ''}
 				>
-					<Minus className="h-3 w-3" />
-				</button>
+					<Minus className="h-4 w-4" />
+				</IconButton>
 				<span
 					className={cx('flex items-center justify-center', TEXT_VARIANTS.default)}
 					style={{ fontSize: `${displayedFontSize}px` }}
 				>
 					{fontSize}px
 				</span>
-				<button
-					{...bindButton({
+				<IconButton
+					{...bindPlus({
 						callback: () => handleSetFontSize(fontSizeRef.current + 1),
 					})}
-					className={cx('text-base', TEXT_VARIANTS.secondary)}
+					variant="ghost"
+					size="xs"
+					className={isHoldingPlus ? 'select-none bg-background-surface-hover' : ''}
 				>
-					<Plus className="h-3 w-3" />
-				</button>
+					<Plus className="h-4 w-4" />
+				</IconButton>
 			</div>
 			{fontSize > 50 && (
 				<Text size="xs" className="text-left" variant="muted">

--- a/packages/browser/src/components/readers/epub/controls/LineHeightControl.tsx
+++ b/packages/browser/src/components/readers/epub/controls/LineHeightControl.tsx
@@ -1,4 +1,4 @@
-import { cx, Label, TEXT_VARIANTS } from '@stump/components'
+import { cx, IconButton, Label, TEXT_VARIANTS } from '@stump/components'
 import { Minus, Plus } from 'lucide-react'
 import { useCallback, useEffect, useRef } from 'react'
 
@@ -31,31 +31,36 @@ export default function LineHeightControl() {
 		[setBookPreferences],
 	)
 
-	const { bindButton } = usePressAndHold()
+	const { bindButton: bindMinus, isHolding: isHoldingMinus } = usePressAndHold()
+	const { bindButton: bindPlus, isHolding: isHoldingPlus } = usePressAndHold()
 
 	return (
 		<div className="flex flex-col gap-y-2.5">
 			<Label>Line height</Label>
 			<div className="flex items-center gap-x-2">
-				<button
-					{...bindButton({
+				<IconButton
+					{...bindMinus({
 						callback: () => handleSetLineHeight(lineHeightRef.current - 0.1),
 					})}
-					className={cx('text-base', TEXT_VARIANTS.secondary)}
+					variant="ghost"
+					size="xs"
+					className={isHoldingMinus ? 'select-none bg-background-surface-hover' : ''}
 				>
-					<Minus className="h-3 w-3" />
-				</button>
+					<Minus className="h-4 w-4" />
+				</IconButton>
 				<span className={cx('flex items-center justify-center', TEXT_VARIANTS.default)}>
 					{lineHeight.toFixed(1)}
 				</span>
-				<button
-					{...bindButton({
+				<IconButton
+					{...bindPlus({
 						callback: () => handleSetLineHeight(lineHeightRef.current + 0.1),
 					})}
-					className={cx('text-base', TEXT_VARIANTS.secondary)}
+					variant="ghost"
+					size="xs"
+					className={isHoldingPlus ? 'select-none bg-background-surface-hover' : ''}
 				>
-					<Plus className="h-3 w-3" />
-				</button>
+					<Plus className="h-4 w-4" />
+				</IconButton>
 			</div>
 		</div>
 	)

--- a/packages/browser/src/hooks/usePressAndHold.ts
+++ b/packages/browser/src/hooks/usePressAndHold.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react'
+import { useCallback, useRef, useState } from 'react'
 
 type Params = {
 	intervalMs?: number
@@ -9,20 +9,7 @@ type Params = {
  */
 export function usePressAndHold({ intervalMs = 100 }: Params = {}) {
 	const intervalRef = useRef<NodeJS.Timeout | null>(null)
-
-	/**
-	 * Start the press and hold event, using the given callback. The callback will be
-	 * called every `intervalMs` milliseconds.
-	 */
-	const start = useCallback(
-		(callback: () => void) => {
-			if (intervalRef.current) return
-
-			callback()
-			intervalRef.current = setInterval(callback, intervalMs)
-		},
-		[intervalMs],
-	)
+	const [isHolding, setIsHolding] = useState(false)
 
 	/**
 	 * Stop the press and hold event. This will clear the interval.
@@ -32,23 +19,45 @@ export function usePressAndHold({ intervalMs = 100 }: Params = {}) {
 			clearTimeout(intervalRef.current)
 			intervalRef.current = null
 		}
+		setIsHolding(false)
+		window.removeEventListener('mouseup', stop)
+		window.removeEventListener('touchend', stop)
+		window.removeEventListener('touchcancel', stop)
 	}, [])
+
+	/**
+	 * Start the press and hold event, using the given callback. The callback will be
+	 * called every `intervalMs` milliseconds.
+	 */
+	const start = useCallback(
+		(callback: () => void) => {
+			if (intervalRef.current) return
+
+			setIsHolding(true)
+			callback()
+			intervalRef.current = setInterval(callback, intervalMs)
+			window.addEventListener('mouseup', stop)
+			window.addEventListener('touchend', stop)
+			window.addEventListener('touchcancel', stop)
+		},
+		[intervalMs, stop],
+	)
 
 	/**
 	 * A utility function that returns the necessary props for creating a press and hold
 	 * event on a button. The general idea is:
 	 *
 	 * 1. When the mouse is pressed down, start the press and hold event
-	 * 2. When the mouse is released, stop the press and hold event
+	 * 2. Even if the mouse moves off the button, it will still be held
+	 * 3. When the mouse is released, stop the press and hold event
 	 */
 	const bindButton = useCallback(
 		({ callback }: { callback: () => void }) => ({
 			onMouseDown: () => start(callback),
-			onMouseLeave: stop,
-			onMouseUp: stop,
+			onTouchStart: () => start(callback),
 		}),
-		[start, stop],
+		[start],
 	)
 
-	return { bindButton, start, stop }
+	return { bindButton, isHolding, start, stop }
 }

--- a/packages/browser/src/hooks/usePressAndHold.ts
+++ b/packages/browser/src/hooks/usePressAndHold.ts
@@ -21,7 +21,7 @@ export function usePressAndHold({ intervalMs = 100 }: Params = {}) {
 		}
 		setIsHolding(false)
 		window.removeEventListener('pointerup', stop)
-		window.removeEventListener('touchcancel', stop)
+		window.removeEventListener('pointercancel', stop)
 	}, [])
 
 	/**
@@ -36,7 +36,7 @@ export function usePressAndHold({ intervalMs = 100 }: Params = {}) {
 			callback()
 			intervalRef.current = setInterval(callback, intervalMs)
 			window.addEventListener('pointerup', stop)
-			window.addEventListener('touchcancel', stop)
+			window.addEventListener('pointercancel', stop)
 		},
 		[intervalMs, stop],
 	)

--- a/packages/browser/src/hooks/usePressAndHold.ts
+++ b/packages/browser/src/hooks/usePressAndHold.ts
@@ -53,8 +53,7 @@ export function usePressAndHold({ intervalMs = 100 }: Params = {}) {
 	 */
 	const bindButton = useCallback(
 		({ callback }: { callback: () => void }) => ({
-			onMouseDown: () => start(callback),
-			onTouchStart: () => start(callback),
+			onPointerDown: () => start(callback),
 		}),
 		[start],
 	)

--- a/packages/browser/src/hooks/usePressAndHold.ts
+++ b/packages/browser/src/hooks/usePressAndHold.ts
@@ -20,8 +20,7 @@ export function usePressAndHold({ intervalMs = 100 }: Params = {}) {
 			intervalRef.current = null
 		}
 		setIsHolding(false)
-		window.removeEventListener('mouseup', stop)
-		window.removeEventListener('touchend', stop)
+		window.removeEventListener('pointerup', stop)
 		window.removeEventListener('touchcancel', stop)
 	}, [])
 
@@ -36,8 +35,7 @@ export function usePressAndHold({ intervalMs = 100 }: Params = {}) {
 			setIsHolding(true)
 			callback()
 			intervalRef.current = setInterval(callback, intervalMs)
-			window.addEventListener('mouseup', stop)
-			window.addEventListener('touchend', stop)
+			window.addEventListener('pointerup', stop)
 			window.addEventListener('touchcancel', stop)
 		},
 		[intervalMs, stop],


### PR DESCRIPTION
Allows press and hold on mobile browsers (only tested safari)

Allows press and hold even if mouse pointer goes off the button, useful when the font preview changes size and pushes the button off the mouse pointer (still stops after mouse up)

Made buttons bigger and have hovering/pressing down indicaton. I hope I used the right `variant`, I just copied `ghost` from the other buttons.