### PR TITLE
🐛 Fix scrolled mode

### DIFF
--- a/packages/browser/src/components/readers/epub/EpubJsReader.tsx
+++ b/packages/browser/src/components/readers/epub/EpubJsReader.tsx
@@ -392,7 +392,7 @@ export default function EpubJsReader({ id, isIncognito }: EpubJsReaderProps) {
 	 * @param preferences The epub reader preferences
 	 */
 	const applyEpubPreferences = useCallback(
-		(rendition: Rendition, readingMode: ReadingMode, lang: string, pageFlipDirection: string) => {
+		(rendition: Rendition, lang: string, pageFlipDirection: string) => {
 			// ja should be ltr no matter what because text is always written "forwards"
 			const isJaWithPageFlipRtl =
 				(lang === 'ja' || lang === 'zh-TW' || lang === 'zh-HK') && pageFlipDirection === 'rtl'
@@ -419,14 +419,6 @@ export default function EpubJsReader({ id, isIncognito }: EpubJsReaderProps) {
 				rendition.themes.register('stump-light', {})
 				rendition.themes.select('stump-light')
 			}
-
-			// Set flow based on reading mode
-			if (readingMode === ReadingMode.ContinuousVertical) {
-				rendition.flow('scrolled')
-			} else {
-				// Default to paginated for 'paged' mode
-				rendition.flow('paginated')
-			}
 		},
 		[theme],
 	)
@@ -440,6 +432,7 @@ export default function EpubJsReader({ id, isIncognito }: EpubJsReaderProps) {
 					'line-height': `${lineHeight} !important`,
 					'font-family': `${toFamilyName(fontFamily as SupportedFont)} !important`,
 				},
+				img: { 'max-width': '100% !important' },
 			}
 
 			const contents = rendition.getContents()
@@ -499,11 +492,7 @@ export default function EpubJsReader({ id, isIncognito }: EpubJsReaderProps) {
 					await generateLocations(book)
 				}
 
-				const rendition_ = book.renderTo(ref.current!, {
-					width: width,
-					height: height,
-					overflow: readingMode === ReadingMode.ContinuousVertical ? 'scroll' : 'hidden',
-				})
+				const rendition_ = book.renderTo(ref.current!, { width, height })
 
 				rendition_.hooks.content.register(() => {
 					injectFontStylesheet(rendition_)
@@ -534,7 +523,7 @@ export default function EpubJsReader({ id, isIncognito }: EpubJsReaderProps) {
 				const lang = book?.packaging?.metadata?.language
 				// @ts-expect-error: PackagingMetadataObject does have property 'direction'
 				const pageFlipDirection = book?.packaging?.metadata?.direction
-				applyEpubPreferences(rendition_, readingMode, lang, pageFlipDirection)
+				applyEpubPreferences(rendition_, lang, pageFlipDirection)
 
 				setRendition(rendition_)
 
@@ -608,21 +597,11 @@ export default function EpubJsReader({ id, isIncognito }: EpubJsReaderProps) {
 		updateEpubPreferences(rendition, fontSize, lineHeight, fontFamily)
 	}, [rendition, fontSize, fontFamily, lineHeight, updateEpubPreferences])
 
-	/**
-	 * This effect updates the reading mode
-	 *
-	 * For 'scrolled' mode: 'scroll' removes the horizontal scroll bar that appears due to the vertical scroll bar taking some space
-	 * For 'paginated' mode: we must put back 'hidden', otherwise 'scroll' makes horizontal a scroll bar appear
-	 */
+	/* This effect updates the reading mode. This is separated because it causes flashing */
 	useEffect(() => {
-		// @ts-expect-error: Property 'manager' does exist on type 'Rendition'
-		if (!rendition || !rendition.manager) return
-
+		if (!rendition) return
 		const flowStyle = readingMode === ReadingMode.ContinuousVertical ? 'scrolled' : 'paginated'
-		const overflowStyle = readingMode === ReadingMode.ContinuousVertical ? 'scroll' : 'hidden'
 		rendition.flow(flowStyle)
-		// @ts-expect-error: Property 'manager' does exist on type 'Rendition'
-		rendition.manager.stage.overflow(overflowStyle)
 	}, [rendition, readingMode])
 
 	/**

--- a/packages/browser/src/components/readers/epub/EpubJsReader.tsx
+++ b/packages/browser/src/components/readers/epub/EpubJsReader.tsx
@@ -492,7 +492,11 @@ export default function EpubJsReader({ id, isIncognito }: EpubJsReaderProps) {
 					await generateLocations(book)
 				}
 
-				const rendition_ = book.renderTo(ref.current!, { width, height })
+				const rendition_ = book.renderTo(ref.current!, {
+					width: width,
+					height: height,
+					allowScriptedContent: true,
+				})
 
 				rendition_.hooks.content.register(() => {
 					injectFontStylesheet(rendition_)

--- a/packages/browser/src/components/readers/epub/EpubJsReader.tsx
+++ b/packages/browser/src/components/readers/epub/EpubJsReader.tsx
@@ -1,10 +1,4 @@
-import {
-	BookPreferences,
-	queryClient,
-	useGraphQLMutation,
-	useSDK,
-	useSuspenseGraphQL,
-} from '@stump/client'
+import { queryClient, useGraphQLMutation, useSDK, useSuspenseGraphQL } from '@stump/client'
 import {
 	Bookmark,
 	EpubJsReaderQuery,
@@ -198,9 +192,9 @@ export default function EpubJsReader({ id, isIncognito }: EpubJsReaderProps) {
 	const [currentLocation, setCurrentLocation] = useState<EpubLocationState>()
 	const [isInitialLoading, setIsInitialLoading] = useState(true)
 
-	const { bookPreferences } = useBookPreferences({
-		book: ebook.media,
-	})
+	const {
+		bookPreferences: { fontSize, lineHeight, fontFamily, readingMode },
+	} = useBookPreferences({ book: ebook.media })
 
 	const client = useQueryClient()
 	const { mutate } = useGraphQLMutation(mutation, {
@@ -398,12 +392,7 @@ export default function EpubJsReader({ id, isIncognito }: EpubJsReaderProps) {
 	 * @param preferences The epub reader preferences
 	 */
 	const applyEpubPreferences = useCallback(
-		(
-			rendition: Rendition,
-			preferences: BookPreferences,
-			lang: string,
-			pageFlipDirection: string,
-		) => {
+		(rendition: Rendition, readingMode: ReadingMode, lang: string, pageFlipDirection: string) => {
 			// ja should be ltr no matter what because text is always written "forwards"
 			const isJaWithPageFlipRtl =
 				(lang === 'ja' || lang === 'zh-TW' || lang === 'zh-HK') && pageFlipDirection === 'rtl'
@@ -430,10 +419,10 @@ export default function EpubJsReader({ id, isIncognito }: EpubJsReaderProps) {
 				rendition.themes.register('stump-light', {})
 				rendition.themes.select('stump-light')
 			}
-			rendition.direction(preferences.readingDirection === 'RTL' ? 'rtl' : 'ltr')
+
 			// Set flow based on reading mode
-			if (preferences.readingMode === ReadingMode.ContinuousVertical) {
-				rendition.flow('scrolled-doc')
+			if (readingMode === ReadingMode.ContinuousVertical) {
+				rendition.flow('scrolled')
 			} else {
 				// Default to paginated for 'paged' mode
 				rendition.flow('paginated')
@@ -510,7 +499,11 @@ export default function EpubJsReader({ id, isIncognito }: EpubJsReaderProps) {
 					await generateLocations(book)
 				}
 
-				const rendition_ = book.renderTo(ref.current!, { width, height })
+				const rendition_ = book.renderTo(ref.current!, {
+					width: width,
+					height: height,
+					overflow: readingMode === ReadingMode.ContinuousVertical ? 'scroll' : 'hidden',
+				})
 
 				rendition_.hooks.content.register(() => {
 					injectFontStylesheet(rendition_)
@@ -541,7 +534,7 @@ export default function EpubJsReader({ id, isIncognito }: EpubJsReaderProps) {
 				const lang = book?.packaging?.metadata?.language
 				// @ts-expect-error: PackagingMetadataObject does have property 'direction'
 				const pageFlipDirection = book?.packaging?.metadata?.direction
-				applyEpubPreferences(rendition_, bookPreferences, lang, pageFlipDirection)
+				applyEpubPreferences(rendition_, readingMode, lang, pageFlipDirection)
 
 				setRendition(rendition_)
 
@@ -560,7 +553,7 @@ export default function EpubJsReader({ id, isIncognito }: EpubJsReaderProps) {
 	}, [
 		book,
 		applyEpubPreferences,
-		bookPreferences,
+		readingMode,
 		handleLocationChange,
 		isIncognito,
 		ebook,
@@ -605,7 +598,6 @@ export default function EpubJsReader({ id, isIncognito }: EpubJsReaderProps) {
 		}
 	}, [rendition])
 
-	const { fontSize, lineHeight, fontFamily } = bookPreferences
 	/**
 	 * This effect is responsible for updating the epub theme options whenever the epub
 	 * preferences change. It will only run when the epub preferences change and the
@@ -615,6 +607,23 @@ export default function EpubJsReader({ id, isIncognito }: EpubJsReaderProps) {
 		if (!rendition) return
 		updateEpubPreferences(rendition, fontSize, lineHeight, fontFamily)
 	}, [rendition, fontSize, fontFamily, lineHeight, updateEpubPreferences])
+
+	/**
+	 * This effect updates the reading mode
+	 *
+	 * For 'scrolled' mode: 'scroll' removes the horizontal scroll bar that appears due to the vertical scroll bar taking some space
+	 * For 'paginated' mode: we must put back 'hidden', otherwise 'scroll' makes horizontal a scroll bar appear
+	 */
+	useEffect(() => {
+		// @ts-expect-error: Property 'manager' does exist on type 'Rendition'
+		if (!rendition || !rendition.manager) return
+
+		const flowStyle = readingMode === ReadingMode.ContinuousVertical ? 'scrolled' : 'paginated'
+		const overflowStyle = readingMode === ReadingMode.ContinuousVertical ? 'scroll' : 'hidden'
+		rendition.flow(flowStyle)
+		// @ts-expect-error: Property 'manager' does exist on type 'Rendition'
+		rendition.manager.stage.overflow(overflowStyle)
+	}, [rendition, readingMode])
 
 	/**
 	 * Invalidate the book query when a reader is unmounted so that the book overview

--- a/packages/browser/src/components/readers/epub/EpubJsReader.tsx
+++ b/packages/browser/src/components/readers/epub/EpubJsReader.tsx
@@ -509,21 +509,6 @@ export default function EpubJsReader({ id, isIncognito }: EpubJsReaderProps) {
 
 				rendition_.on('relocated', handleLocationChange)
 
-				// This callback is used to change the page when a keydown event is received.
-				const keydown_callback = (event: KeyboardEvent) => {
-					// Check arrow keys
-					if (event.key == 'ArrowLeft') {
-						rendition_.prev()
-					}
-					if (event.key == 'ArrowRight') {
-						rendition_.next()
-					}
-				}
-				// The rendition fires keydown events when the epub page is in focus
-				rendition_.on('keydown', keydown_callback)
-				// When the epub page isn't in focus, the window fires them instead
-				window.addEventListener('keydown', keydown_callback)
-
 				const lang = book?.packaging?.metadata?.language
 				// @ts-expect-error: PackagingMetadataObject does have property 'direction'
 				const pageFlipDirection = book?.packaging?.metadata?.direction
@@ -552,6 +537,23 @@ export default function EpubJsReader({ id, isIncognito }: EpubJsReaderProps) {
 		ebook,
 		generateLocations,
 	])
+
+	/** This effect handles page turning via keyboard keys */
+	useEffect(() => {
+		const handleKeyDown = (event: KeyboardEvent) => {
+			if (event.key === 'ArrowLeft') {
+				rendition?.prev()
+			} else if (event.key === 'ArrowRight') {
+				rendition?.next()
+			}
+		}
+		window.addEventListener('keydown', handleKeyDown, { capture: true })
+		rendition?.on('keydown', handleKeyDown)
+		return () => {
+			window.removeEventListener('keydown', handleKeyDown, { capture: true })
+			rendition?.off('keydown', handleKeyDown)
+		}
+	}, [rendition])
 
 	// I'm hopeful this solves: https://github.com/stumpapp/stump/issues/726
 	// Honestly though epub.js is such a migraine that I'm OK just waiting until

--- a/packages/browser/src/components/readers/epub/EpubJsReader.tsx
+++ b/packages/browser/src/components/readers/epub/EpubJsReader.tsx
@@ -267,19 +267,6 @@ export default function EpubJsReader({ id, isIncognito }: EpubJsReaderProps) {
 		return { chapter: position, chapterName: name, sectionIndex: sectionIndex }
 	}, [book, currentLocation])
 
-	/**
-	 * A function for focusing the iframe in the epub reader. This will be used to ensure
-	 * the iframe is focused whenever the reader is loaded and/or the location changes.
-	 */
-	const focusIframe = () => {
-		const iframe = ref.current?.querySelector('iframe')
-		if (iframe) {
-			iframe.focus()
-		} else {
-			console.warn('Failed to find iframe in epub reader')
-		}
-	}
-
 	const computeNaiveProgress = useCallback(
 		({ start }: EpubLocationState) => {
 			let percentage: number | null = null
@@ -358,7 +345,6 @@ export default function EpubJsReader({ id, isIncognito }: EpubJsReaderProps) {
 				return
 			}
 			setCurrentLocation(changeState)
-			focusIframe()
 			computeProgress(changeState)
 		},
 		[computeProgress],
@@ -495,7 +481,8 @@ export default function EpubJsReader({ id, isIncognito }: EpubJsReaderProps) {
 				const rendition_ = book.renderTo(ref.current!, {
 					width: width,
 					height: height,
-					allowScriptedContent: true,
+					// enable the following line to allow rendition?.on('keydown', handleKeyDown) to work for Safari
+					// allowScriptedContent: true,
 				})
 
 				rendition_.hooks.content.register(() => {

--- a/packages/browser/src/components/readers/epub/controls/ReadingMode.tsx
+++ b/packages/browser/src/components/readers/epub/controls/ReadingMode.tsx
@@ -1,5 +1,5 @@
 import { Label, NativeSelect } from '@stump/components'
-import { ReadingMode as ReadingModeType } from '@stump/sdk'
+import { ReadingMode as ReadingModeType } from '@stump/graphql'
 
 import { useBookPreferences } from '@/scenes/book/reader/useBookPreferences'
 
@@ -25,8 +25,8 @@ export default function ReadingMode() {
 				id="reading-mode"
 				size="sm"
 				options={[
-					{ label: 'Paged', value: 'paged' },
-					{ label: 'Continuous', value: 'continuous:vertical' },
+					{ label: 'Paged', value: ReadingModeType.Paged },
+					{ label: 'Continuous', value: ReadingModeType.ContinuousVertical },
 				]}
 				value={readingMode}
 				onChange={handleChange}


### PR DESCRIPTION
Fixes scrolled mode for desktop browsers only ~and makes the useless horizontal scroll bar disappear (only for horizontal-tb books right now)~

When using a book that needs to scroll e.g. downwards, there is an annoying horizontal scroll bar because of the vertical scroll bar taking a tiny amount of space. I couldn't fix it while keeping books that scroll sideways working.

Also fixes an issue with images in books going half outside the browser window if using a tall screen.

---

One more note, I tried to change `readingDirection === 'rtl'` to `readingDirection === ReadingDirection.Rtl`, etc because of the red squigglies annoying me, but that breaks page turn direction because `'rtl'` is still the correct string to use. I'll look at it later.