### PR TITLE
🐛 fix auto scaling for image based reader

### DIFF
--- a/packages/browser/src/components/readers/imageBased/paged/PageSet.tsx
+++ b/packages/browser/src/components/readers/imageBased/paged/PageSet.tsx
@@ -47,13 +47,10 @@ const PageSet = forwardRef<HTMLDivElement, Props>(
 				style={{
 					...styles[imageScaling.scaleToFit].imagesHolder,
 					filter: `brightness(${brightness * 100}%)`,
-					display: 'flex',
-					flexDirection: 'row',
-					justifyContent: 'center',
 				}}
 			>
 				<div
-					className={cn('relative flex justify-center', {
+					className={cn('relative flex w-full justify-center', {
 						'mx-auto flex-row gap-0': currentSet.length > 1,
 					})}
 				>
@@ -140,6 +137,7 @@ const styles = {
 	[ReadingImageScaleFit.Auto]: {
 		imagesHolder: {
 			// no min width
+			maxWidth: '100%',
 			// no width
 			// no min height
 			height: '100vh',
@@ -158,6 +156,7 @@ const styles = {
 	[ReadingImageScaleFit.Height]: {
 		imagesHolder: {
 			minWidth: 'max-content',
+			// no max width
 			// no width
 			// no min height
 			height: '100vh',
@@ -176,6 +175,7 @@ const styles = {
 	[ReadingImageScaleFit.Width]: {
 		imagesHolder: {
 			// no min width
+			// no max width
 			width: '100vw',
 			minHeight: '100vh',
 			// no neight
@@ -194,6 +194,7 @@ const styles = {
 	[ReadingImageScaleFit.None]: {
 		imagesHolder: {
 			minWidth: 'max-content',
+			// no max width
 			// no width
 			minHeight: '100vh',
 			// no height

--- a/packages/browser/src/components/readers/imageBased/paged/PagedReader.tsx
+++ b/packages/browser/src/components/readers/imageBased/paged/PagedReader.tsx
@@ -272,15 +272,7 @@ function PagedReader({ currentPage, onPageChange }: PagedReaderProps) {
 	useHotkeys('right, left, space, escape', (_, handler) => hotKeyHandler(handler))
 
 	return (
-		<div
-			style={{
-				display: 'flex',
-				justifyContent: 'center',
-				margin: 'auto',
-				width: '100vw',
-				position: 'relative',
-			}}
-		>
+		<div className="relative m-auto flex w-[100vw] justify-center">
 			{!showToolBar && tapSidesToNavigate && (
 				<SideBarControl
 					fixed={fixSideNavigation}


### PR DESCRIPTION
Fixes auto scaling mode for `breaking/sea-orm`

Also to me this div seems redundant? Or was it added to fix something because I just messed with it
https://github.com/stumpapp/stump/blob/2e968f91c706380352874a63134b3f0fc525ea92/packages/browser/src/components/readers/imageBased/paged/PageSet.tsx#L55-L59