### PR TITLE
🐛 Fix arrow key for ebook RTL and fix press and hold for Safari Mac

### DIFF
--- a/packages/browser/src/components/readers/epub/EpubJsReader.tsx
+++ b/packages/browser/src/components/readers/epub/EpubJsReader.tsx
@@ -4,6 +4,7 @@ import {
 	EpubJsReaderQuery,
 	EpubProgressInput,
 	graphql,
+	ReadingDirection,
 	ReadingMode,
 	SupportedFont,
 } from '@stump/graphql'
@@ -193,7 +194,7 @@ export default function EpubJsReader({ id, isIncognito }: EpubJsReaderProps) {
 	const [isInitialLoading, setIsInitialLoading] = useState(true)
 
 	const {
-		bookPreferences: { fontSize, lineHeight, fontFamily, readingMode },
+		bookPreferences: { fontSize, lineHeight, fontFamily, readingMode, readingDirection },
 	} = useBookPreferences({ book: ebook.media })
 
 	const client = useQueryClient()
@@ -528,10 +529,15 @@ export default function EpubJsReader({ id, isIncognito }: EpubJsReaderProps) {
 	/** This effect handles page turning via keyboard keys */
 	useEffect(() => {
 		const handleKeyDown = (event: KeyboardEvent) => {
-			if (event.key === 'ArrowLeft') {
-				rendition?.prev()
-			} else if (event.key === 'ArrowRight') {
+			const isLtr = readingDirection === ReadingDirection.Ltr
+
+			const nextKey = isLtr ? 'ArrowRight' : 'ArrowLeft'
+			const prevKey = isLtr ? 'ArrowLeft' : 'ArrowRight'
+
+			if (event.key === nextKey) {
 				rendition?.next()
+			} else if (event.key === prevKey) {
+				rendition?.prev()
 			}
 		}
 		window.addEventListener('keydown', handleKeyDown, { capture: true })
@@ -540,7 +546,7 @@ export default function EpubJsReader({ id, isIncognito }: EpubJsReaderProps) {
 			window.removeEventListener('keydown', handleKeyDown, { capture: true })
 			rendition?.off('keydown', handleKeyDown)
 		}
-	}, [rendition])
+	}, [rendition, readingDirection])
 
 	// I'm hopeful this solves: https://github.com/stumpapp/stump/issues/726
 	// Honestly though epub.js is such a migraine that I'm OK just waiting until

--- a/packages/browser/src/scenes/settings/app/reader/DefaultFontSize.tsx
+++ b/packages/browser/src/scenes/settings/app/reader/DefaultFontSize.tsx
@@ -16,7 +16,7 @@ export default function DefaultFontSize() {
 
 	const onValueChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const value = parseInt(e.target.value)
-		if (!isNaN(value) && value >= 0) {
+		if (!isNaN(value) && value > 0) {
 			setSettings({ fontSize: value })
 		}
 	}

--- a/packages/browser/src/scenes/settings/app/reader/DefaultLineHeight.tsx
+++ b/packages/browser/src/scenes/settings/app/reader/DefaultLineHeight.tsx
@@ -16,7 +16,7 @@ export default function DefaultLineHeight() {
 
 	const onValueChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const value = parseFloat(e.target.value)
-		if (!isNaN(value) && value >= 0) {
+		if (!isNaN(value) && value >= 1.0 && value <= 3.0) {
 			setSettings({ lineHeight: value })
 		}
 	}


### PR DESCRIPTION
So this is a weird one. There was a bug with press and hold not working on Safari on Mac only (existed before I changed anything). At first I thought I'd see what happens if I set a delay for setting `fontSize`, but near 0ms worked I guess.

Also includes a fix for arrow keys for RTL page direction books  (should of thought of that in my previous PR oops)

Edit: and now also a fix for invalid numbers being typed in as the default