### PR TITLE
💄 Scrollbar colours for Safari and Chrome and 🐛 fix dark epubjs theme

### DIFF
--- a/packages/browser/src/components/HorizontalCardList.tsx
+++ b/packages/browser/src/components/HorizontalCardList.tsx
@@ -20,7 +20,7 @@ export default function HorizontalCardList_({ title, items, onFetchMore, emptySt
 	const isAtLeastMedium = useMediaMatch('(min-width: 768px)')
 
 	const height = useMemo(
-		() => (!isAtLeastSmall ? 325 : !isAtLeastMedium ? 350 : 385),
+		() => (!isAtLeastSmall ? 330 : !isAtLeastMedium ? 350 : 385),
 		[isAtLeastSmall, isAtLeastMedium],
 	)
 

--- a/packages/browser/src/components/readers/epub/EpubJsReader.tsx
+++ b/packages/browser/src/components/readers/epub/EpubJsReader.tsx
@@ -19,7 +19,7 @@ import { useTheme } from '@/hooks'
 import { useBookPreferences } from '@/scenes/book/reader/useBookPreferences'
 
 import EpubReaderContainer from './EpubReaderContainer'
-import { stumpDark, toFamilyName } from './themes'
+import { darkVariantText, toFamilyName } from './themes'
 
 // TODO: Fix all lifecycle lints
 // TODO: Consider a total re-write or at least thorough review of this component, it was written a while
@@ -175,7 +175,7 @@ const injectFontStylesheet = (rendition: Rendition) => {
  */
 export default function EpubJsReader({ id, isIncognito }: EpubJsReaderProps) {
 	const { sdk } = useSDK()
-	const { theme } = useTheme()
+	const { isDarkVariant } = useTheme()
 
 	const {
 		data: { epubById: ebook },
@@ -398,15 +398,15 @@ export default function EpubJsReader({ id, isIncognito }: EpubJsReaderProps) {
 				})
 			}
 
-			if (theme === 'dark') {
-				rendition.themes.register('stump-dark', stumpDark)
-				rendition.themes.select('stump-dark')
+			if (isDarkVariant) {
+				rendition.themes.register('dark-variant', darkVariantText)
+				rendition.themes.select('dark-variant')
 			} else {
-				rendition.themes.register('stump-light', {})
-				rendition.themes.select('stump-light')
+				rendition.themes.register('light-variant', {})
+				rendition.themes.select('light-variant')
 			}
 		},
-		[theme],
+		[isDarkVariant],
 	)
 
 	/**	A function for applying updates to the the epub reader preferences to the epubjs rendition instance */
@@ -491,8 +491,8 @@ export default function EpubJsReader({ id, isIncognito }: EpubJsReaderProps) {
 
 				//? TODO: I guess here I would need to wait for and load in custom theme blobs...
 				//* Color manipulation reference: https://github.com/futurepress/epub.js/issues/1019
-				rendition_.themes.register('stump-dark', stumpDark)
-				rendition_.themes.register('stump-light', {})
+				rendition_.themes.register('dark-variant', darkVariantText)
+				rendition_.themes.register('light-variant', {})
 
 				rendition_.on('relocated', handleLocationChange)
 

--- a/packages/browser/src/components/readers/epub/themes.ts
+++ b/packages/browser/src/components/readers/epub/themes.ts
@@ -8,10 +8,10 @@ export interface EpubTheme {
 // blockquote: {p: {color: '...'}}
 
 // Note: Not React CSS, has to be true CSS fields. E.g. font-size not fontSize.
-export const stumpDark: EpubTheme = {
+export const darkVariantText: EpubTheme = {
 	a: { color: '#4299E1' },
 	blockquote: { color: 'rgb(168 172 176) !important' },
-	body: { background: '#161719 !important', color: '#E8EDF4' },
+	body: { color: '#E8EDF4' },
 	h1: { color: '#E8EDF4' },
 	h2: { color: '#E8EDF4' },
 	h3: { color: '#E8EDF4' },

--- a/packages/browser/src/hooks/useTheme.ts
+++ b/packages/browser/src/hooks/useTheme.ts
@@ -45,5 +45,5 @@ export function useTheme() {
 	}
 }
 
-export const DARK_THEMES = ['dark', 'cosmic', 'pumpkin', 'autumn']
+export const DARK_THEMES = ['dark', 'ocean', 'cosmic', 'pumpkin', 'autumn']
 export const THEMES_WITH_GRADIENTS = ['cosmic']

--- a/packages/browser/src/styles/index.css
+++ b/packages/browser/src/styles/index.css
@@ -34,3 +34,26 @@ form {
 #nprogress .bar {
 	@apply fixed left-0 top-0 z-50 h-0.5 w-full bg-brand-500;
 }
+
+/* For Safari & Chrome only */
+::-webkit-scrollbar {
+	width: 12px;
+	height: 12px;
+}
+::-webkit-scrollbar-track {
+	background: hsl(var(--twc-scrollbar));
+}
+::-webkit-scrollbar-corner {
+	background: hsl(var(--twc-scrollbar));
+}
+::-webkit-scrollbar-thumb {
+	background-color: hsl(var(--twc-scrollbar-thumb) / var(--twc-scrollbar-thumb-opacity));
+	border-radius: 6px;
+	border: 3px solid transparent;
+	background-clip: padding-box;
+}
+::-webkit-scrollbar-thumb:hover {
+	background-color: hsl(
+		var(--twc-scrollbar-thumb-hover) / var(--twc-scrollbar-thumb-hover-opacity)
+	);
+}

--- a/packages/components/themes/autumn.ts
+++ b/packages/components/themes/autumn.ts
@@ -81,4 +81,11 @@ export const autumn = {
 			secondary: '#4B382D',
 		},
 	},
+	scrollbar: {
+		DEFAULT: '#4B382D',
+		thumb: {
+			DEFAULT: 'hsla(0, 0%, 100%, 0.4)',
+			hover: 'hsla(0, 0%, 100%, 0.3)',
+		},
+	},
 } satisfies StumpTheme

--- a/packages/components/themes/bronze.ts
+++ b/packages/components/themes/bronze.ts
@@ -35,4 +35,11 @@ export const bronze = {
 			secondary: '#D3C4BA',
 		},
 	},
+	scrollbar: {
+		DEFAULT: '#EDE8E4',
+		thumb: {
+			DEFAULT: 'hsla(0, 0%, 0%, 0.3)',
+			hover: 'hsla(0, 0%, 0%, 0.5)',
+		},
+	},
 } satisfies StumpTheme

--- a/packages/components/themes/cosmic.ts
+++ b/packages/components/themes/cosmic.ts
@@ -89,4 +89,11 @@ export const cosmic = {
 			secondary: '#2A1969',
 		},
 	},
+	scrollbar: {
+		DEFAULT: '#1F0A39',
+		thumb: {
+			DEFAULT: 'hsla(0, 0%, 100%, 0.4)',
+			hover: 'hsla(0, 0%, 100%, 0.3)',
+		},
+	},
 } satisfies StumpTheme

--- a/packages/components/themes/dark.ts
+++ b/packages/components/themes/dark.ts
@@ -81,4 +81,11 @@ export const dark = {
 			secondary: '#1B1B1E',
 		},
 	},
+	scrollbar: {
+		DEFAULT: '#161719',
+		thumb: {
+			DEFAULT: 'hsla(0, 0%, 100%, 0.4)',
+			hover: 'hsla(0, 0%, 100%, 0.3)',
+		},
+	},
 } satisfies StumpTheme

--- a/packages/components/themes/light.ts
+++ b/packages/components/themes/light.ts
@@ -83,4 +83,11 @@ export const light = {
 			secondary: '#F1F1F2',
 		},
 	},
+	scrollbar: {
+		DEFAULT: '#F2F2F3',
+		thumb: {
+			DEFAULT: 'hsla(0, 0%, 0%, 0.3)',
+			hover: 'hsla(0, 0%, 0%, 0.5)',
+		},
+	},
 } satisfies StumpTheme

--- a/packages/components/themes/ocean.ts
+++ b/packages/components/themes/ocean.ts
@@ -81,4 +81,11 @@ export const ocean = {
 			secondary: '#1B6B7D',
 		},
 	},
+	scrollbar: {
+		DEFAULT: '#0A3644',
+		thumb: {
+			DEFAULT: 'hsla(0, 0%, 100%, 0.4)',
+			hover: 'hsla(0, 0%, 100%, 0.3)',
+		},
+	},
 } satisfies StumpTheme

--- a/packages/components/themes/pumpkin.ts
+++ b/packages/components/themes/pumpkin.ts
@@ -65,6 +65,13 @@ export const pumpkin: StumpTheme = {
 			secondary: '#00000040',
 		},
 	},
+	scrollbar: {
+		DEFAULT: '#0C0C0C',
+		thumb: {
+			DEFAULT: 'hsla(0, 0%, 100%, 0.4)',
+			hover: 'hsla(0, 0%, 100%, 0.3)',
+		},
+	},
 }
 
 /*

--- a/packages/components/themes/types.ts
+++ b/packages/components/themes/types.ts
@@ -121,6 +121,13 @@ type Color = Record<(typeof colorVariant)[number], SecondaryVariant & HoverVaria
 	OnBlackVariant
 
 /**
+ * A type for enforcing the structure of a colour used for the scrollbar (used by Wekbit browsers only)
+ */
+type Scrollbar = {
+	thumb: DefaultVariant & HoverVariant
+} & DefaultVariant
+
+/**
  * The primary type which represents the color tokens for the Stump UI. These are translated for use as
  * tailwind classes via tw-colors
  */
@@ -130,4 +137,5 @@ export type StumpTheme = {
 	foreground: Foreground
 	edge: Border
 	fill: Color
+	scrollbar: Scrollbar
 }


### PR DESCRIPTION
Makes Safari and Chrome scrollbar (background) colours match the theme the same way Firefox does. I hope the implementation is okay. One annoyance is there was no setting to make it even darker when clicked and held (which Firefox does have for scrollbars and I quite like that), but it didn't work that way previously anyways.

Also a fix to make all dark themes use light text.

---

Note: Chrome does and soon Safari will support the standard [`scrollbar-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-color) settings but it doesn't have colour change on hover so can't use that.