### PR TITLE
🐛 Fix setting default reader settings

### DIFF
--- a/packages/browser/src/scenes/library/tabs/settings/options/readingDefaults/ReadingDefaultsScene.tsx
+++ b/packages/browser/src/scenes/library/tabs/settings/options/readingDefaults/ReadingDefaultsScene.tsx
@@ -31,15 +31,25 @@ export default function ReadingDefaultsScene() {
 					...library.config,
 					...params,
 				},
-				scan_mode: 'NONE',
+				scanAfterPersist: false,
 			})
 		},
 		[patch, library.config],
 	)
 
+	const schema = useMemo(
+		() =>
+			buildSchema([], library).pick({
+				defaultReadingDir: true,
+				defaultReadingImageScaleFit: true,
+				defaultReadingMode: true,
+			}),
+		[library],
+	)
+
 	const form = useForm<PatchParams>({
 		defaultValues: formDefaults(library),
-		resolver: zodResolver(buildSchema([], library)),
+		resolver: zodResolver(schema),
 	})
 
 	const formValues = form.watch([

--- a/packages/browser/src/scenes/library/tabs/settings/options/scanner/IgnoreRulesPatchForm.tsx
+++ b/packages/browser/src/scenes/library/tabs/settings/options/scanner/IgnoreRulesPatchForm.tsx
@@ -23,13 +23,14 @@ export default function IgnoreRulesPatchForm() {
 	})
 
 	const handleSubmit = useCallback(
-		({ ignore_rules }: CreateOrUpdateLibrarySchema) => {
+		({ ignoreRules }: CreateOrUpdateLibrarySchema) => {
 			patch({
+				// @ts-expect-error: This is fine?
 				config: {
 					...library.config,
-					ignore_rules: ignore_rules?.map(({ glob }) => glob),
+					ignoreRules: ignoreRules?.map(({ glob }) => glob),
 				},
-				scan_mode: 'NONE',
+				scanAfterPersist: false,
 			})
 		},
 		[patch, library],


### PR DESCRIPTION
Fix inability to set default reader settings (i.e. Image scaling, Reading direction, Default reader)

Fix inability to set ignore rules

---

I think the typescript error in `IgnoreRulesPatchForm.tsx` is similar to the one in `ReadingDefaultsScene.tsx` so I hope it's okay.