### PR TITLE
🐛 fix inability to set avatarUrl

### DIFF
--- a/packages/browser/src/scenes/settings/app/general/ProfileForm.tsx
+++ b/packages/browser/src/scenes/settings/app/general/ProfileForm.tsx
@@ -93,9 +93,12 @@ export default function ProfileForm() {
 
 		mutate({
 			input: {
-				...user,
+				username: values.username,
+				avatarUrl: values.avatarUrl,
+				password: values.password || undefined, // undefined -> no change, null or "" -> no password :(
+				permissions: user.permissions,
 				ageRestriction: user.ageRestriction || null,
-				...values,
+				maxSessionsAllowed: user.maxSessionsAllowed,
 			},
 		})
 	}


### PR DESCRIPTION
Hope this is right. I triple checked but setting `password` needs to be perfect (or else updating the avatar could remove the password).

It was an issue with the extra properties on the `user` object.