### PR TITLE
💄 (expo): UX Enhancements

### DIFF
--- a/apps/expo/app/(tabs)/index.tsx
+++ b/apps/expo/app/(tabs)/index.tsx
@@ -108,9 +108,9 @@ export default function Screen() {
 						<Text className="text-foreground-muted">Stump</Text>
 
 						{!stumpServers.length && (
-							<View className="h-24 w-full items-center justify-center gap-2 rounded-lg border border-dashed border-edge p-3">
+							<View className="squircle h-24 w-full items-center justify-center gap-2 rounded-2xl border border-dashed border-edge p-3">
 								<View className="relative flex justify-center">
-									<View className="flex items-center justify-center rounded-lg bg-background-surface p-2">
+									<View className="squircle flex items-center justify-center rounded-lg bg-background-surface p-2">
 										<Server className="h-6 w-6 text-foreground-muted" />
 										<Slash className="absolute h-6 w-6 scale-x-[-1] transform text-foreground opacity-80" />
 									</View>
@@ -135,9 +135,9 @@ export default function Screen() {
 					<Text className="text-foreground-muted">OPDS</Text>
 
 					{!allOPDSServers.length && (
-						<View className="h-24 w-full items-center justify-center gap-2 rounded-lg border border-dashed border-edge p-3">
+						<View className="squircle h-24 w-full items-center justify-center gap-2 rounded-2xl border border-dashed border-edge p-3">
 							<View className="relative flex justify-center">
-								<View className="flex items-center justify-center rounded-lg bg-background-surface p-2">
+								<View className="squircle flex items-center justify-center rounded-lg bg-background-surface p-2">
 									<Rss className="h-6 w-6 text-foreground-muted" />
 									<Slash className="absolute h-6 w-6 scale-x-[-1] transform text-foreground opacity-80" />
 								</View>

--- a/apps/expo/app/(tabs)/settings/index.tsx
+++ b/apps/expo/app/(tabs)/settings/index.tsx
@@ -35,7 +35,7 @@ export default function Screen() {
 				<View>
 					<Text className="mb-3 text-foreground-muted">Stump</Text>
 
-					<View className="mb-2 rounded-xl bg-fill-info-secondary p-2 tablet:p-3">
+					<View className="squircle mb-2 rounded-xl bg-fill-info-secondary p-2 tablet:p-3">
 						<Text className="text-fill-info">
 							Stump features are optional, you can completely turn them off if you just want OPDS
 							support

--- a/apps/expo/app/(tabs)/settings/usage/[id].tsx
+++ b/apps/expo/app/(tabs)/settings/usage/[id].tsx
@@ -68,9 +68,9 @@ export default function Screen() {
 						<Heading>Downloads</Heading>
 
 						{!downloadedFiles.length && (
-							<View className="h-24 w-full items-center justify-center gap-2 rounded-lg border border-dashed border-edge p-3">
+							<View className="squircle h-24 w-full items-center justify-center gap-2 rounded-lg border border-dashed border-edge p-3">
 								<View className="relative flex justify-center">
-									<View className="flex items-center justify-center rounded-lg bg-background-surface p-2">
+									<View className="squircle flex items-center justify-center rounded-lg bg-background-surface p-2">
 										<HardDriveDownload className="h-6 w-6 text-foreground-muted" />
 										<Slash className="absolute h-6 w-6 scale-x-[-1] transform text-foreground opacity-80" />
 									</View>

--- a/apps/expo/app/(tabs)/settings/usage/index.tsx
+++ b/apps/expo/app/(tabs)/settings/usage/index.tsx
@@ -78,7 +78,7 @@ export default function Screen() {
 						<Heading>Servers</Heading>
 
 						{savedServers.length > 0 && (
-							<Card className="flex rounded-xl border border-edge bg-background-surface">
+							<Card className="squircle flex rounded-xl border border-edge bg-background-surface">
 								{savedServers.map((server, idx) => (
 									<Pressable
 										key={server.id}
@@ -110,9 +110,9 @@ export default function Screen() {
 						)}
 
 						{savedServers.length === 0 && (
-							<View className="h-24 w-full items-center justify-center gap-2 rounded-lg border border-dashed border-edge p-3">
+							<View className="squircle h-24 w-full items-center justify-center gap-2 rounded-lg border border-dashed border-edge p-3">
 								<View className="relative flex justify-center">
-									<View className="flex items-center justify-center rounded-lg bg-background-surface p-2">
+									<View className="squircle flex items-center justify-center rounded-lg bg-background-surface p-2">
 										<Server className="h-6 w-6 text-foreground-muted" />
 										<Slash className="absolute h-6 w-6 scale-x-[-1] transform text-foreground opacity-80" />
 									</View>

--- a/apps/expo/app/_layout.tsx
+++ b/apps/expo/app/_layout.tsx
@@ -130,6 +130,7 @@ export default function RootLayout() {
 								options={{
 									headerShown: false,
 									animation: animationEnabled ? 'default' : 'none',
+									autoHideHomeIndicator: shouldHideStatusBar,
 								}}
 							/>
 							<Stack.Screen

--- a/apps/expo/app/opds/[id]/auth.tsx
+++ b/apps/expo/app/opds/[id]/auth.tsx
@@ -125,7 +125,7 @@ export default function Screen() {
 				)}
 
 				{loginError && (
-					<View className="mb-2 rounded-xl bg-fill-danger-secondary p-2">
+					<View className="squircle mb-2 rounded-xl bg-fill-danger-secondary p-2">
 						<Text className="text-fill-danger">{loginError}</Text>
 					</View>
 				)}

--- a/apps/expo/app/opds/[id]/auth.tsx
+++ b/apps/expo/app/opds/[id]/auth.tsx
@@ -6,13 +6,12 @@ import { isAxiosError } from 'axios'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import { useCallback, useEffect, useState } from 'react'
 import { Controller, useForm } from 'react-hook-form'
-import { View } from 'react-native'
+import { Image, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import urlJoin from 'url-join'
 import { z } from 'zod'
 
 import { useActiveServer } from '~/components/activeServer'
-import { Image } from '~/components/Image'
 import { Button, Input, Text } from '~/components/ui'
 
 type Credentials = {

--- a/apps/expo/app/opds/[id]/publication/index.tsx
+++ b/apps/expo/app/opds/[id]/publication/index.tsx
@@ -6,7 +6,7 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 
 import { useActiveServer } from '~/components/activeServer'
 import { InfoRow, InfoSection } from '~/components/book/overview'
-import { FasterImage } from '~/components/Image'
+import { TurboImage } from '~/components/Image'
 import {
 	getDateField,
 	getNumberField,
@@ -89,14 +89,14 @@ export default function Screen() {
 				<View className="flex-1 gap-8 pb-3">
 					<View className="mt-6 flex items-center gap-4">
 						<View className="aspect-[2/3] self-center overflow-hidden rounded-lg">
-							<FasterImage
+							<TurboImage
 								source={{
-									url: thumbnailURL || '',
+									uri: thumbnailURL || '',
 									headers: {
 										Authorization: sdk.authorizationHeader || '',
 									},
-									resizeMode: 'fill',
 								}}
+								resizeMode="cover"
 								style={{ height: 350, width: 'auto' }}
 							/>
 						</View>

--- a/apps/expo/app/opds/[id]/publication/index.tsx
+++ b/apps/expo/app/opds/[id]/publication/index.tsx
@@ -125,13 +125,13 @@ export default function Screen() {
 					</View>
 
 					{!canStream && (
-						<View className="rounded-lg bg-fill-info-secondary p-3">
+						<View className="squircle rounded-lg bg-fill-info-secondary p-3">
 							<Text>This publication lacks a defined reading order and cannot be streamed</Text>
 						</View>
 					)}
 
 					{!isSupportedStream && (
-						<View className="rounded-lg bg-fill-info-secondary p-3">
+						<View className="squircle rounded-lg bg-fill-info-secondary p-3">
 							<Text>
 								This publication contains unsupported media types and cannot be streamed yet
 							</Text>
@@ -172,10 +172,10 @@ export default function Screen() {
 								? [
 										<View
 											key="noInformation"
-											className="h-24 w-full items-center justify-center gap-2 rounded-lg border border-dashed border-edge p-3"
+											className="squircle h-24 w-full items-center justify-center gap-2 rounded-lg border border-dashed border-edge p-3"
 										>
 											<View className="relative flex justify-center">
-												<View className="flex items-center justify-center rounded-lg bg-background-surface p-2">
+												<View className="squircle flex items-center justify-center rounded-lg bg-background-surface p-2">
 													<Info className="h-6 w-6 text-foreground-muted" />
 													<Slash className="absolute h-6 w-6 scale-x-[-1] transform text-foreground opacity-80" />
 												</View>
@@ -195,10 +195,10 @@ export default function Screen() {
 								? [
 										<View
 											key="noSeries"
-											className="h-24 w-full items-center justify-center gap-2 rounded-lg border border-dashed border-edge p-3"
+											className="squircle h-24 w-full items-center justify-center gap-2 rounded-lg border border-dashed border-edge p-3"
 										>
 											<View className="relative flex justify-center">
-												<View className="flex items-center justify-center rounded-lg bg-background-surface p-2">
+												<View className="squircle flex items-center justify-center rounded-lg bg-background-surface p-2">
 													<BookCopy className="h-6 w-6 text-foreground-muted" />
 													<Slash className="absolute h-6 w-6 scale-x-[-1] transform text-foreground opacity-80" />
 												</View>
@@ -238,7 +238,7 @@ export default function Screen() {
 												{({ pressed }) => (
 													<View
 														className={cn(
-															'rounded-lg border border-edge bg-background-surface-secondary p-1 text-center',
+															'squircle rounded-lg border border-edge bg-background-surface-secondary p-1 text-center',
 															{
 																'opacity-80': pressed,
 															},

--- a/apps/expo/app/opds/[id]/publication/index.tsx
+++ b/apps/expo/app/opds/[id]/publication/index.tsx
@@ -18,6 +18,7 @@ import { useDynamicHeader } from '~/lib/hooks/useDynamicHeader'
 import { cn } from '~/lib/utils'
 
 import { usePublicationContext } from './context'
+import { BorderAndShadow } from '~/components/BorderAndShadow'
 
 const { Info, Slash, BookCopy, ChevronLeft } = icons
 
@@ -86,9 +87,11 @@ export default function Screen() {
 				className="flex-1 gap-5 bg-background px-4 tablet:px-6"
 				contentInsetAdjustmentBehavior="automatic"
 			>
-				<View className="flex-1 gap-8 pb-3">
-					<View className="mt-6 flex items-center gap-4">
-						<View className="aspect-[2/3] self-center overflow-hidden rounded-lg">
+				<View className="flex-1 gap-8 py-4">
+					<View className="flex items-center gap-4">
+						<BorderAndShadow
+							style={{ borderRadius: 10, borderWidth: 0.4, shadowRadius: 5, elevation: 8 }}
+						>
 							<TurboImage
 								source={{
 									uri: thumbnailURL || '',
@@ -96,10 +99,11 @@ export default function Screen() {
 										Authorization: sdk.authorizationHeader || '',
 									},
 								}}
-								resizeMode="cover"
-								style={{ height: 350, width: 'auto' }}
+								resizeMode="stretch"
+								resize={350 * (2 / 3) * 1.5}
+								style={{ height: 350, width: 350 * (2 / 3) }}
 							/>
-						</View>
+						</BorderAndShadow>
 					</View>
 
 					<View className="flex w-full flex-row items-center gap-2 tablet:max-w-sm tablet:self-center">

--- a/apps/expo/app/server/[id]/(tabs)/index/index.tsx
+++ b/apps/expo/app/server/[id]/(tabs)/index/index.tsx
@@ -28,7 +28,7 @@ export default function Screen() {
 			refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
 			contentInsetAdjustmentBehavior="always"
 		>
-			<View className="flex flex-1 gap-8 pb-8 pt-4">
+			<View className="flex flex-1 gap-4 pt-4">
 				<ContinueReading />
 				<OnDeck />
 				<RecentlyAddedSeriesHorizontal />

--- a/apps/expo/app/server/[id]/books/[id]/index.tsx
+++ b/apps/expo/app/server/[id]/books/[id]/index.tsx
@@ -13,7 +13,7 @@ import { useActiveServer } from '~/components/activeServer'
 import { BookMetaLink } from '~/components/book'
 import { BookActionMenu } from '~/components/book/overview'
 import { BookDescription, InfoRow, InfoSection, InfoStat } from '~/components/book/overview'
-import { FasterImage } from '~/components/Image'
+import { TurboImage } from '~/components/Image'
 import RefreshControl from '~/components/RefreshControl'
 import { Button, Heading, icons, Text } from '~/components/ui'
 import { useColors } from '~/lib/constants'
@@ -246,29 +246,27 @@ export default function Screen() {
 					)}
 
 					<View className="flex items-center gap-4">
-						<View className="aspect-[2/3] self-center">
-							<FasterImage
-								source={{
-									url: book.thumbnail.url,
-									headers: {
-										Authorization: sdk.authorizationHeader || '',
-									},
-									resizeMode: 'fill',
-									borderRadius: 8,
-								}}
-								style={{
-									height: 350,
-									width: 'auto',
-									shadowColor: '#000',
-									shadowOffset: { width: 0, height: 1 },
-									shadowOpacity: 0.2,
-									shadowRadius: 5,
-									borderRadius: 8,
-									borderWidth: 0.2,
-									borderColor: colors.edge.DEFAULT,
-								}}
-							/>
-						</View>
+						<TurboImage
+							source={{
+								uri: book.thumbnail.url,
+								headers: {
+									Authorization: sdk.authorizationHeader || '',
+								},
+							}}
+							resizeMode="stretch"
+							resize={350 * (2 / 3) * 1.5}
+							style={{
+								height: 350,
+								width: 350 * (2 / 3),
+								shadowColor: '#000',
+								shadowOffset: { width: 0, height: 1 },
+								shadowOpacity: 0.2,
+								shadowRadius: 5,
+								borderRadius: 8,
+								borderWidth: 0.2,
+								borderColor: colors.edge.DEFAULT,
+							}}
+						/>
 					</View>
 
 					<View className="gap-2">

--- a/apps/expo/app/server/[id]/books/[id]/index.tsx
+++ b/apps/expo/app/server/[id]/books/[id]/index.tsx
@@ -13,6 +13,7 @@ import { useActiveServer } from '~/components/activeServer'
 import { BookMetaLink } from '~/components/book'
 import { BookActionMenu } from '~/components/book/overview'
 import { BookDescription, InfoRow, InfoSection, InfoStat } from '~/components/book/overview'
+import { BorderAndShadow } from '~/components/BorderAndShadow'
 import { TurboImage } from '~/components/Image'
 import RefreshControl from '~/components/RefreshControl'
 import { Button, Heading, icons, Text } from '~/components/ui'
@@ -246,27 +247,21 @@ export default function Screen() {
 					)}
 
 					<View className="flex items-center gap-4">
-						<TurboImage
-							source={{
-								uri: book.thumbnail.url,
-								headers: {
-									Authorization: sdk.authorizationHeader || '',
-								},
-							}}
-							resizeMode="stretch"
-							resize={350 * (2 / 3) * 1.5}
-							style={{
-								height: 350,
-								width: 350 * (2 / 3),
-								shadowColor: '#000',
-								shadowOffset: { width: 0, height: 1 },
-								shadowOpacity: 0.2,
-								shadowRadius: 5,
-								borderRadius: 8,
-								borderWidth: 0.2,
-								borderColor: colors.edge.DEFAULT,
-							}}
-						/>
+						<BorderAndShadow
+							style={{ borderRadius: 10, borderWidth: 0.4, shadowRadius: 5, elevation: 8 }}
+						>
+							<TurboImage
+								source={{
+									uri: book.thumbnail.url,
+									headers: {
+										Authorization: sdk.authorizationHeader || '',
+									},
+								}}
+								resizeMode="stretch"
+								resize={350 * (2 / 3) * 1.5}
+								style={{ height: 350, width: 350 * (2 / 3) }}
+							/>
+						</BorderAndShadow>
 					</View>
 
 					<View className="gap-2">

--- a/apps/expo/app/server/[id]/books/[id]/index.tsx
+++ b/apps/expo/app/server/[id]/books/[id]/index.tsx
@@ -17,7 +17,6 @@ import { BorderAndShadow } from '~/components/BorderAndShadow'
 import { TurboImage } from '~/components/Image'
 import RefreshControl from '~/components/RefreshControl'
 import { Button, Heading, icons, Text } from '~/components/ui'
-import { useColors } from '~/lib/constants'
 import { formatBytes, parseGraphQLDecimal } from '~/lib/format'
 import { cn } from '~/lib/utils'
 
@@ -114,7 +113,6 @@ export default function Screen() {
 	})
 
 	const router = useRouter()
-	const colors = useColors()
 
 	// TODO: prefetch, see https://github.com/candlefinance/faster-image/issues/73
 	// useEffect(() => {

--- a/apps/expo/app/server/[id]/files/index.tsx
+++ b/apps/expo/app/server/[id]/files/index.tsx
@@ -1,13 +1,13 @@
 import { FlashList } from '@shopify/flash-list'
 import { useSuspenseGraphQL } from '@stump/client'
 import { graphql } from '@stump/graphql'
-import { Image } from 'expo-image'
 import { useRouter } from 'expo-router'
-import { Platform, View } from 'react-native'
+import { Image, Platform, View } from 'react-native'
 import { Pressable } from 'react-native-gesture-handler'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import { useActiveServer } from '~/components/activeServer'
+import { TurboImage } from '~/components/Image'
 import { Text } from '~/components/ui'
 import { useDisplay } from '~/lib/hooks'
 
@@ -63,9 +63,13 @@ export default function Screen() {
 					>
 						{({ pressed }) => (
 							<View className="items-center" style={{ opacity: pressed ? 0.75 : 1 }}>
-								<Image
-									// eslint-disable-next-line @typescript-eslint/no-require-imports
-									source={require('../../../../assets/icons/Folder.png')}
+								<TurboImage
+									source={{
+										// eslint-disable-next-line @typescript-eslint/no-require-imports
+										uri: Image.resolveAssetSource(require('../../../../assets/icons/Folder.png'))
+											.uri,
+									}}
+									resize={100 * 1.5}
 									style={{ width: 100, height: 100 }}
 								/>
 								<View>

--- a/apps/expo/components/BorderAndShadow.tsx
+++ b/apps/expo/components/BorderAndShadow.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import { View, StyleProp, ViewStyle } from 'react-native'
+
+import { useColors } from '~/lib/constants'
+
+type BorderAndShadowStyle = {
+	borderRadius: number
+	borderWidth: number
+	shadowRadius: number
+	elevation: number
+}
+
+type BorderAndShadowProps = {
+	children: React.ReactNode
+	style: BorderAndShadowStyle
+	outerStyle?: StyleProp<ViewStyle>
+	innerStyle?: StyleProp<ViewStyle>
+}
+
+/**
+ * A reusable container that provides a shadow and a border.
+ * The outer View handles the shadow, and the inner View handles the border and clipping.
+ */
+export const BorderAndShadow = ({
+	children,
+	style,
+	outerStyle,
+	innerStyle,
+}: BorderAndShadowProps) => {
+	const colors = useColors()
+
+	const shadowStyle: ViewStyle = {
+		shadowColor: '#000',
+		shadowOffset: { width: 0, height: 1 },
+		shadowOpacity: 0.2,
+		shadowRadius: style.shadowRadius,
+		elevation: style.elevation, // for android
+		borderRadius: style.borderRadius, // for android
+	}
+
+	const borderStyle: ViewStyle = {
+		borderRadius: style.borderRadius,
+		borderWidth: style.borderWidth,
+		borderColor: colors.edge.DEFAULT,
+		borderCurve: 'continuous',
+		overflow: 'hidden',
+	}
+
+	return (
+		<View style={[shadowStyle, outerStyle]}>
+			<View style={[borderStyle, innerStyle]}>{children}</View>
+		</View>
+	)
+}

--- a/apps/expo/components/ChevronBackLink.tsx
+++ b/apps/expo/components/ChevronBackLink.tsx
@@ -8,7 +8,7 @@ export default function ChevronBackLink() {
 	const router = useRouter()
 	return (
 		<TouchableOpacity onPress={() => router.back()}>
-			<Icon as={ChevronLeft} className="text-foreground" />
+			<Icon as={ChevronLeft} className="text-foreground" size={24} />
 		</TouchableOpacity>
 	)
 }

--- a/apps/expo/components/Image.tsx
+++ b/apps/expo/components/Image.tsx
@@ -1,41 +1,17 @@
-import { FasterImageProps, FasterImageView } from '@candlefinance/faster-image'
-import { Image as EImage, ImageProps } from 'expo-image'
+//import { useState } from 'react'
+//import { StyleSheet } from 'react-native'
+import TImage, { type TurboImageProps } from 'react-native-turbo-image'
 
-import { usePreferencesStore } from '~/stores'
-import { CachePolicy } from '~/stores/reader'
+//import { usePreferencesStore } from '~/stores'
+//import { CachePolicy } from '~/stores/reader'
 
-export const Image = (props: ImageProps) => {
-	const cachePolicy = usePreferencesStore((state) => state.cachePolicy)
-	const allowDownscaling = usePreferencesStore((state) => state.allowDownscaling)
+//export const Image = (props: ImageProps) => {
+//	const cachePolicy = usePreferencesStore((state) => state.cachePolicy)
+//	const allowDownscaling = usePreferencesStore((state) => state.allowDownscaling)
+//
+//	return <EImage cachePolicy={cachePolicy} allowDownscaling={allowDownscaling} {...props} />
+//}
 
-	return <EImage cachePolicy={cachePolicy} allowDownscaling={allowDownscaling} {...props} />
-}
-
-export const FasterImage = ({ source, ...props }: FasterImageProps) => {
-	const cachePolicy = usePreferencesStore((state) => state.cachePolicy)
-
-	return (
-		<FasterImageView
-			source={{
-				cachePolicy: intoFastCachePolicy(cachePolicy),
-				...source,
-			}}
-			{...props}
-		/>
-	)
-}
-
-export const intoFastCachePolicy = (
-	policy: CachePolicy,
-): FasterImageProps['source']['cachePolicy'] => {
-	switch (policy) {
-		case 'disk':
-			return 'discWithCacheControl'
-		case 'memory':
-			return 'memory'
-		case 'memory-disk':
-			return 'memoryAndDisc'
-		default:
-			return 'discNoCacheControl'
-	}
+export const TurboImage = ({ source, style, ...props }: TurboImageProps) => {
+	return <TImage source={source} cachePolicy="dataCache" style={style} {...props} />
 }

--- a/apps/expo/components/ListEmpty.tsx
+++ b/apps/expo/components/ListEmpty.tsx
@@ -12,9 +12,9 @@ type Props = {
 
 export default function ListEmpty({ message }: Props) {
 	return (
-		<View className="h-24 w-full items-center justify-center gap-2 rounded-lg border border-dashed border-edge p-3">
+		<View className="squircle h-24 w-full items-center justify-center gap-2 rounded-lg border border-dashed border-edge p-3">
 			<View className="relative flex justify-center">
-				<View className="flex items-center justify-center rounded-lg bg-background-surface p-2">
+				<View className="squircle flex items-center justify-center rounded-lg bg-background-surface p-2">
 					<Rss className="h-6 w-6 text-foreground-muted" />
 					<Slash className="absolute h-6 w-6 scale-x-[-1] transform text-foreground opacity-80" />
 				</View>

--- a/apps/expo/components/ServerAuthDialog.tsx
+++ b/apps/expo/components/ServerAuthDialog.tsx
@@ -85,7 +85,9 @@ export default function ServerAuthDialog({ isOpen, onClose }: ServerAuthDialogPr
 				index={snapPoints.length - 1}
 				snapPoints={snapPoints}
 				onChange={handleChange}
-				backgroundComponent={(props) => <View {...props} className="rounded-t-xl bg-background" />}
+				backgroundComponent={(props) => (
+					<View {...props} className="squircle rounded-t-xl bg-background" />
+				)}
 				handleIndicatorStyle={{ backgroundColor: colorScheme === 'dark' ? '#333' : '#ccc' }}
 				handleComponent={(props) => (
 					<BottomSheet.Handle

--- a/apps/expo/components/ServerConnectFailed.tsx
+++ b/apps/expo/components/ServerConnectFailed.tsx
@@ -17,7 +17,7 @@ export default function ServerConnectFailed() {
 				</Heading>
 
 				<View className="relative flex flex-row justify-center">
-					<View className="flex items-center justify-center rounded-lg bg-background-surface p-2">
+					<View className="squircle flex items-center justify-center rounded-lg bg-background-surface p-2">
 						<WifiOff className="h-10 w-10 text-foreground-muted" />
 					</View>
 				</View>

--- a/apps/expo/components/StackedEffectThumbnail.tsx
+++ b/apps/expo/components/StackedEffectThumbnail.tsx
@@ -9,7 +9,7 @@ import { match } from 'ts-pattern'
 import { useDisplay } from '~/lib/hooks'
 import { cn } from '~/lib/utils'
 
-import { FasterImage } from './Image'
+import { TurboImage } from './Image'
 import { Text } from './ui'
 
 type Props = {
@@ -60,14 +60,14 @@ export default function StackedEffectThumbnail({ label, uri, href }: Props) {
 								'opacity-80': pressed,
 							})}
 						>
-							<FasterImage
+							<TurboImage
 								source={{
-									url: uri,
+									uri: uri,
 									headers: {
 										Authorization: sdk.authorizationHeader || '',
 									},
-									resizeMode: 'fill',
 								}}
+								resizeMode="stretch"
 								style={{ height: itemDimension * 1.5, width: itemDimension }}
 							/>
 						</View>

--- a/apps/expo/components/StackedEffectThumbnail.tsx
+++ b/apps/expo/components/StackedEffectThumbnail.tsx
@@ -56,7 +56,7 @@ export default function StackedEffectThumbnail({ label, uri, href }: Props) {
 				<Pressable style={{ zIndex: 10 }} onPress={() => router.push(href)}>
 					{({ pressed }) => (
 						<View
-							className={cn('aspect-[2/3] overflow-hidden rounded-lg', {
+							className={cn('squircle aspect-[2/3] overflow-hidden rounded-lg', {
 								'opacity-80': pressed,
 							})}
 						>
@@ -76,7 +76,7 @@ export default function StackedEffectThumbnail({ label, uri, href }: Props) {
 
 				<View
 					className={cn(
-						'absolute -left-1 top-0 aspect-[2/3] rotate-[-5deg] transform overflow-hidden rounded-lg',
+						'squircle absolute -left-1 top-0 aspect-[2/3] rotate-[-5deg] transform overflow-hidden rounded-lg',
 						{
 							'bg-background': !colors,
 						},
@@ -91,7 +91,7 @@ export default function StackedEffectThumbnail({ label, uri, href }: Props) {
 
 				<View
 					className={cn(
-						'absolute left-0 top-1 aspect-[2/3] rotate-[4deg] transform overflow-hidden rounded-lg',
+						'squircle absolute left-0 top-1 aspect-[2/3] rotate-[4deg] transform overflow-hidden rounded-lg',
 						{
 							'bg-background': !colors,
 						},

--- a/apps/expo/components/Unimplemented.tsx
+++ b/apps/expo/components/Unimplemented.tsx
@@ -12,7 +12,7 @@ type Props = {
 
 export default function Unimplemented({ message = 'This feature is not yet implemented' }: Props) {
 	return (
-		<View className="m-6 flex-1 items-center justify-center gap-5 rounded-xl border border-dashed border-edge">
+		<View className="squircle m-6 flex-1 items-center justify-center gap-5 rounded-xl border border-dashed border-edge">
 			<PackageX className="h-10 w-10 text-foreground-muted" />
 			<Text>{message}</Text>
 		</View>

--- a/apps/expo/components/activeServer/home/ContinueReading.tsx
+++ b/apps/expo/components/activeServer/home/ContinueReading.tsx
@@ -10,6 +10,7 @@ import { Heading, Text } from '~/components/ui'
 
 import { useActiveServer } from '../context'
 import ReadingNow from './ReadingNow'
+import { useListItemSize } from '~/lib/hooks'
 
 const query = graphql(`
 	query ContinueReading($pagination: Pagination) {
@@ -66,12 +67,14 @@ function ContinueReading() {
 		[],
 	)
 
+	const { gap } = useListItemSize()
+
 	return (
 		<Fragment>
 			{activeBooks.length > 0 && <ReadingNow books={activeBooks} />}
 
 			{(leftOffBooks.length > 0 || activeBooks.length === 0) && (
-				<View className="flex gap-4">
+				<View className="flex">
 					<Heading size="xl" className="px-4">
 						Continue Reading
 					</Heading>
@@ -81,10 +84,11 @@ function ContinueReading() {
 						keyExtractor={({ id }) => id}
 						renderItem={renderItem}
 						horizontal
-						contentContainerStyle={{ paddingHorizontal: 16 }}
+						contentContainerStyle={{ padding: 16 }}
 						onEndReached={onEndReached}
 						onEndReachedThreshold={0.85}
 						showsHorizontalScrollIndicator={false}
+						ItemSeparatorComponent={() => <View style={{ width: gap * 2 }} />}
 						ListEmptyComponent={
 							<Text className="px-4 text-foreground-muted">No books in progress</Text>
 						}

--- a/apps/expo/components/activeServer/home/OnDeck.tsx
+++ b/apps/expo/components/activeServer/home/OnDeck.tsx
@@ -59,7 +59,7 @@ function OnDeck() {
 	const { gap } = useListItemSize()
 
 	return (
-		<View className="flex gap-4">
+		<View className="flex">
 			<Heading size="xl" className="px-4">
 				Your Next Read
 			</Heading>
@@ -69,7 +69,7 @@ function OnDeck() {
 				keyExtractor={({ id }) => id}
 				renderItem={renderItem}
 				horizontal
-				contentContainerStyle={{ paddingHorizontal: 16 }}
+				contentContainerStyle={{ padding: 16 }}
 				onEndReached={onEndReached}
 				onEndReachedThreshold={0.85}
 				showsHorizontalScrollIndicator={false}

--- a/apps/expo/components/activeServer/home/ReadingNow.tsx
+++ b/apps/expo/components/activeServer/home/ReadingNow.tsx
@@ -11,6 +11,7 @@ import { runOnJS, useSharedValue } from 'react-native-reanimated'
 import Carousel, { ICarouselInstance, Pagination } from 'react-native-reanimated-carousel'
 
 import { BookMetaLink } from '~/components/book'
+import { BorderAndShadow } from '~/components/BorderAndShadow'
 import { TurboImage } from '~/components/Image'
 import { Heading, Progress, Text } from '~/components/ui'
 import { COLORS, useColors } from '~/lib/constants'
@@ -89,7 +90,7 @@ export default function ReadingNow({ books }: Props) {
 		})
 
 	return (
-		<View className="mb-[-16px] flex items-start gap-4">
+		<View className="flex items-start gap-4">
 			{/* <Heading size="xl">Jump Back In</Heading> */}
 
 			{/* This view prevents the left 20px of the carousel from overriding swipe back navigation */}
@@ -99,14 +100,14 @@ export default function ReadingNow({ books }: Props) {
 				<Carousel
 					ref={carouselRef}
 					width={width}
-					height={IMAGE_HEIGHT}
+					height={IMAGE_HEIGHT + 8} // add some padding to not cut it off the shadow
 					data={books}
 					loop={false}
 					mode="parallax"
 					modeConfig={{
 						parallaxScrollingOffset: 95,
-						parallaxScrollingScale: 0.99,
-						parallaxAdjacentItemScale: 0.94,
+						parallaxScrollingScale: 1,
+						parallaxAdjacentItemScale: 0.95,
 					}}
 					onProgressChange={progressValue}
 					// Note: I added this to fix vertical scroll conflicts
@@ -236,6 +237,7 @@ function ReadingNowItem({ book }: ReadingNowItemProps) {
 	}, [isTablet, width, data])
 
 	const router = useRouter()
+	const colors = useColors()
 	const isEbookProgress = !!data.readProgress?.epubcfi
 	const { colors: gradientColors, locations: gradientLocations } = easeGradient({
 		colorStops: {
@@ -248,102 +250,96 @@ function ReadingNowItem({ book }: ReadingNowItemProps) {
 
 	return (
 		<View className="flex flex-row gap-4">
-			<Pressable
-				className="relative aspect-[2/3] shrink-0 rounded-lg"
-				onPress={() => router.navigate(`/server/${serverID}/books/${data.id}`)}
-				style={{
-					shadowColor: '#000',
-					shadowOffset: { width: 0, height: 1 },
-					shadowOpacity: 0.2,
-					shadowRadius: 1.41,
-				}}
-			>
-				<LinearGradient
-					colors={gradientColors}
-					style={{ position: 'absolute', inset: 0, zIndex: 10, borderRadius: 8 }}
-					locations={gradientLocations}
-				/>
+			<Pressable onPress={() => router.navigate(`/server/${serverID}/books/${data.id}`)}>
+				<BorderAndShadow
+					style={{ borderRadius: 12, borderWidth: 0.4, shadowRadius: 1.41, elevation: 2 }}
+				>
+					<LinearGradient
+						colors={gradientColors}
+						style={{ position: 'absolute', inset: 0, zIndex: 10 }}
+						locations={gradientLocations}
+					/>
 
-				<TurboImage
-					source={{
-						uri: data.thumbnail.url,
-						headers: {
-							Authorization: sdk.authorizationHeader || '',
-						},
-					}}
-					resizeMode="stretch"
-					resize={IMAGE_WIDTH * 1.5}
-					style={{
-						height: IMAGE_HEIGHT,
-						width: IMAGE_WIDTH,
-						borderRadius: 8,
-					}}
-				/>
+					<TurboImage
+						source={{
+							uri: data.thumbnail.url,
+							headers: {
+								Authorization: sdk.authorizationHeader || '',
+							},
+						}}
+						resizeMode="stretch"
+						resize={IMAGE_WIDTH * 1.5}
+						style={{
+							height: IMAGE_HEIGHT,
+							width: IMAGE_WIDTH,
+						}}
+					/>
 
-				<View className="absolute bottom-0 z-20 w-full gap-2 p-2">
-					{!isTablet && (
-						<Text
-							className="text-2xl font-bold leading-8"
-							style={{
-								textShadowOffset: { width: 2, height: 1 },
-								textShadowRadius: 2,
-								textShadowColor: 'rgba(0, 0, 0, 0.5)',
-								zIndex: 20,
-								color: COLORS.dark.foreground.DEFAULT,
-							}}
-						>
-							{data.resolvedName}
-						</Text>
-					)}
+					<View className="absolute bottom-0 z-20 w-full gap-2 p-3">
+						{!isTablet && (
+							<Text
+								className="text-2xl font-bold leading-8"
+								style={{
+									textShadowOffset: { width: 2, height: 1 },
+									textShadowRadius: 2,
+									textShadowColor: 'rgba(0, 0, 0, 0.5)',
+									zIndex: 20,
+									color: COLORS.dark.foreground.DEFAULT,
+								}}
+							>
+								{data.resolvedName}
+							</Text>
+						)}
 
-					<View className="flex items-start gap-2">
-						<View className="flex w-full flex-row items-center justify-between">
-							{!isEbookProgress && !!data.readProgress?.page && data.readProgress.page > 0 && (
-								<Text
-									className="flex-wrap text-base"
-									style={{
-										color: COLORS.dark.foreground.subtle,
-										opacity: 0.9,
-									}}
-								>
-									Page {data.readProgress?.page} of {data.pages}
-								</Text>
-							)}
+						<View className="flex items-start gap-2">
+							<View className="flex w-full flex-row items-center justify-between">
+								{!isEbookProgress && !!data.readProgress?.page && data.readProgress.page > 0 && (
+									<Text
+										className="flex-wrap text-base"
+										style={{
+											color: COLORS.dark.foreground.subtle,
+											opacity: 0.9,
+										}}
+									>
+										Page {data.readProgress?.page} of {data.pages}
+									</Text>
+								)}
 
-							{isEbookProgress && percentageCompleted != null && (
-								<Text
-									className="flex-wrap text-base"
-									style={{
-										color: COLORS.dark.foreground.subtle,
-										opacity: 0.9,
-									}}
-								>
-									{(percentageCompleted * 100).toFixed(0)}%
-								</Text>
-							)}
+								{isEbookProgress && percentageCompleted != null && (
+									<Text
+										className="flex-wrap text-base"
+										style={{
+											color: COLORS.dark.foreground.subtle,
+											opacity: 0.9,
+										}}
+									>
+										{(percentageCompleted * 100).toFixed(0)}%
+									</Text>
+								)}
 
-							{!!data.readProgress?.updatedAt && (
-								<Text
-									className="flex-wrap text-base"
-									style={{
-										color: COLORS.dark.foreground.subtle,
-										opacity: 0.9,
-									}}
-								>
-									{dayjs(data.readProgress?.updatedAt).fromNow()}
-								</Text>
+								{!!data.readProgress?.updatedAt && (
+									<Text
+										className="flex-wrap text-base"
+										style={{
+											color: COLORS.dark.foreground.subtle,
+											opacity: 0.9,
+										}}
+									>
+										{dayjs(data.readProgress?.updatedAt).fromNow()}
+									</Text>
+								)}
+							</View>
+
+							{percentageCompleted && (
+								<Progress
+									className="h-1 bg-[#898d94]"
+									indicatorClassName="bg-[#f5f3ef]"
+									value={percentageCompleted * 100}
+								/>
 							)}
 						</View>
-
-						{percentageCompleted && (
-							<Progress
-								className="h-1 bg-[#898d94]"
-								indicatorClassName="bg-[#f5f3ef]"
-								value={percentageCompleted * 100}
-							/>
-						)}
 					</View>
-				</View>
+				</BorderAndShadow>
 			</Pressable>
 
 			{renderBookContent()}

--- a/apps/expo/components/activeServer/home/ReadingNow.tsx
+++ b/apps/expo/components/activeServer/home/ReadingNow.tsx
@@ -100,7 +100,7 @@ export default function ReadingNow({ books }: Props) {
 				<Carousel
 					ref={carouselRef}
 					width={width}
-					height={IMAGE_HEIGHT + 8} // add some padding to not cut it off the shadow
+					height={IMAGE_HEIGHT + 8} // add some padding to not cut off the shadow
 					data={books}
 					loop={false}
 					mode="parallax"
@@ -237,7 +237,6 @@ function ReadingNowItem({ book }: ReadingNowItemProps) {
 	}, [isTablet, width, data])
 
 	const router = useRouter()
-	const colors = useColors()
 	const isEbookProgress = !!data.readProgress?.epubcfi
 	const { colors: gradientColors, locations: gradientLocations } = easeGradient({
 		colorStops: {
@@ -252,7 +251,7 @@ function ReadingNowItem({ book }: ReadingNowItemProps) {
 		<View className="flex flex-row gap-4">
 			<Pressable onPress={() => router.navigate(`/server/${serverID}/books/${data.id}`)}>
 				<BorderAndShadow
-					style={{ borderRadius: 12, borderWidth: 0.4, shadowRadius: 1.41, elevation: 2 }}
+					style={{ borderRadius: 12, borderWidth: 0.5, shadowRadius: 1.41, elevation: 2 }}
 				>
 					<LinearGradient
 						colors={gradientColors}

--- a/apps/expo/components/activeServer/home/ReadingNow.tsx
+++ b/apps/expo/components/activeServer/home/ReadingNow.tsx
@@ -11,7 +11,7 @@ import { runOnJS, useSharedValue } from 'react-native-reanimated'
 import Carousel, { ICarouselInstance, Pagination } from 'react-native-reanimated-carousel'
 
 import { BookMetaLink } from '~/components/book'
-import { FasterImage } from '~/components/Image'
+import { TurboImage } from '~/components/Image'
 import { Heading, Progress, Text } from '~/components/ui'
 import { COLORS, useColors } from '~/lib/constants'
 import { parseGraphQLDecimal } from '~/lib/format'
@@ -264,18 +264,19 @@ function ReadingNowItem({ book }: ReadingNowItemProps) {
 					locations={gradientLocations}
 				/>
 
-				<FasterImage
+				<TurboImage
 					source={{
-						url: data.thumbnail.url,
+						uri: data.thumbnail.url,
 						headers: {
 							Authorization: sdk.authorizationHeader || '',
 						},
-						resizeMode: 'fill',
-						borderRadius: 8,
 					}}
+					resizeMode="stretch"
+					resize={IMAGE_WIDTH * 1.5}
 					style={{
 						height: IMAGE_HEIGHT,
 						width: IMAGE_WIDTH,
+						borderRadius: 8,
 					}}
 				/>
 

--- a/apps/expo/components/activeServer/home/RecentlyAddedBooks.tsx
+++ b/apps/expo/components/activeServer/home/RecentlyAddedBooks.tsx
@@ -9,6 +9,7 @@ import { BookListItemFragmentType } from '~/components/book/BookListItem'
 import { Heading, Text } from '~/components/ui'
 
 import { useActiveServer } from '../context'
+import { useListItemSize } from '~/lib/hooks'
 
 const query = graphql(`
 	query RecentlyAddedBooks($pagination: Pagination) {
@@ -56,8 +57,10 @@ function RecentlyAddedBooks() {
 		[],
 	)
 
+	const { gap } = useListItemSize()
+
 	return (
-		<View className="flex gap-4">
+		<View className="flex">
 			<Heading size="xl" className="px-4">
 				Recently Added Books
 			</Heading>
@@ -67,12 +70,11 @@ function RecentlyAddedBooks() {
 				keyExtractor={({ id }) => id}
 				renderItem={renderItem}
 				horizontal
-				contentContainerStyle={{
-					paddingHorizontal: 16,
-				}}
+				contentContainerStyle={{ padding: 16 }}
 				onEndReached={onEndReached}
 				onEndReachedThreshold={0.85}
 				showsHorizontalScrollIndicator={false}
+				ItemSeparatorComponent={() => <View style={{ width: gap * 2 }} />}
 				ListEmptyComponent={<Text className="text-foreground-muted">No books recently added</Text>}
 			/>
 		</View>

--- a/apps/expo/components/activeServer/home/RecentlyAddedSeriesHorizontal.tsx
+++ b/apps/expo/components/activeServer/home/RecentlyAddedSeriesHorizontal.tsx
@@ -62,7 +62,7 @@ function RecentlyAddedSeriesHorizontal() {
 	)
 
 	return (
-		<View className="flex gap-4">
+		<View className="flex">
 			<Heading size="xl" className="px-4">
 				Recently Added Series
 			</Heading>
@@ -73,9 +73,7 @@ function RecentlyAddedSeriesHorizontal() {
 				renderItem={renderItem}
 				horizontal
 				ItemSeparatorComponent={() => <View style={{ width: gap * 2 }} />}
-				contentContainerStyle={{
-					paddingHorizontal: 16,
-				}}
+				contentContainerStyle={{ padding: 16 }}
 				onEndReached={onEndReached}
 				onEndReachedThreshold={0.85}
 				showsHorizontalScrollIndicator={false}

--- a/apps/expo/components/appSettings/AppSettingsRow.tsx
+++ b/apps/expo/components/appSettings/AppSettingsRow.tsx
@@ -30,7 +30,7 @@ const AppSettingsRow = forwardRef<View, Props>(
 							style={{ opacity: pressed && isLink ? 0.7 : 1 }}
 						>
 							<View className="flex-row items-center gap-4">
-								<View className="flex h-8 w-8 items-center justify-center rounded-xl bg-background-surface">
+								<View className="squircle flex h-8 w-8 items-center justify-center rounded-xl bg-background-surface">
 									<Icon
 										as={(icons[icon] as LucideIcon) || BadgeQuestionMark}
 										className="h-6 w-6 text-foreground-muted"

--- a/apps/expo/components/appSettings/preferences/CachePolicySelect.tsx
+++ b/apps/expo/components/appSettings/preferences/CachePolicySelect.tsx
@@ -1,133 +1,54 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { View } from 'react-native'
-import * as DropdownMenu from 'zeego/dropdown-menu'
+import TurboImage from 'react-native-turbo-image'
 
-import { icons, Text } from '~/components/ui'
-import { cn } from '~/lib/utils'
-import { usePreferencesStore } from '~/stores'
-import { CachePolicy } from '~/stores/reader'
-
+import { Button, Dialog, Text } from '~/components/ui'
 import AppSettingsRow from '../AppSettingsRow'
 
-// TODO(android): Use non-native dropdown
-
-const { ChevronsUpDown } = icons
-
 export default function CachePolicySelect() {
-	const [isOpen, setIsOpen] = useState(false)
+	const [dialogMessage, setDialogMessage] = useState<string | null>(null)
 
-	const { cachePolicy = 'memory-disk', patch } = usePreferencesStore((state) => ({
-		cachePolicy: state.cachePolicy,
-		patch: state.patch,
-	}))
-
-	const onChange = (policy: CachePolicy) =>
-		patch({
-			cachePolicy: policy,
-		})
+	useEffect(() => {
+		if (!dialogMessage) return
+		const dialogTimer = setTimeout(() => {
+			setDialogMessage(null)
+		}, 1000)
+		return () => clearTimeout(dialogTimer)
+	}, [dialogMessage])
 
 	return (
-		<AppSettingsRow icon="Image" title="Cache Policy">
-			<DropdownMenu.Root onOpenChange={setIsOpen}>
-				<DropdownMenu.Trigger>
-					<View className={cn('flex-row items-center gap-1.5', { 'opacity-80': isOpen })}>
-						<Text className="text-foreground-muted">{LABELS[cachePolicy]}</Text>
-						<ChevronsUpDown className="h-5 text-foreground-muted" />
-					</View>
-				</DropdownMenu.Trigger>
-
-				<DropdownMenu.Content>
-					<DropdownMenu.CheckboxItem
-						key="paged"
-						value={cachePolicy === 'memory-disk'}
-						onValueChange={() => onChange('memory-disk')}
+		<>
+			<AppSettingsRow icon="Image" title="Clear Cache">
+				<View className="flex-row gap-2">
+					<Button
+						size="sm"
+						variant="destructive"
+						onPress={async () => {
+							await TurboImage.clearMemoryCache()
+							setDialogMessage('Memory cache cleared')
+						}}
 					>
-						<DropdownMenu.ItemTitle>{LABELS['memory-disk']}</DropdownMenu.ItemTitle>
-					</DropdownMenu.CheckboxItem>
-
-					<DropdownMenu.CheckboxItem
-						key="disk"
-						value={cachePolicy === 'disk'}
-						onValueChange={() => onChange('disk')}
+						<Text className="text-foreground">Memory</Text>
+					</Button>
+					<Button
+						size="sm"
+						variant="destructive"
+						onPress={async () => {
+							await TurboImage.clearDiskCache()
+							setDialogMessage('Disk cache cleared       ')
+						}}
 					>
-						<DropdownMenu.ItemTitle>{LABELS['disk']}</DropdownMenu.ItemTitle>
-					</DropdownMenu.CheckboxItem>
+						<Text className="text-foreground">Disk</Text>
+					</Button>
+				</View>
+			</AppSettingsRow>
 
-					<DropdownMenu.CheckboxItem
-						key="memory"
-						value={cachePolicy === 'memory'}
-						onValueChange={() => onChange('memory')}
-					>
-						<DropdownMenu.ItemTitle>{LABELS['memory']}</DropdownMenu.ItemTitle>
-					</DropdownMenu.CheckboxItem>
-
-					<DropdownMenu.CheckboxItem
-						key="none"
-						value={cachePolicy === 'none'}
-						onValueChange={() => onChange('none')}
-						destructive
-					>
-						<DropdownMenu.ItemTitle>{LABELS['none']}</DropdownMenu.ItemTitle>
-					</DropdownMenu.CheckboxItem>
-				</DropdownMenu.Content>
-			</DropdownMenu.Root>
-		</AppSettingsRow>
+			<Dialog open={!!dialogMessage} onOpenChange={() => setDialogMessage(null)}>
+				<Dialog.Content>
+					<Dialog.Title>Cache Cleared</Dialog.Title>
+					<Dialog.Description>{dialogMessage}</Dialog.Description>
+				</Dialog.Content>
+			</Dialog>
+		</>
 	)
-
-	return (
-		<View className="flex flex-row items-center justify-between p-4">
-			<Text>Cache Policy</Text>
-
-			<DropdownMenu.Root onOpenChange={setIsOpen}>
-				<DropdownMenu.Trigger>
-					<View className={cn('flex-row items-center gap-1.5', { 'opacity-80': isOpen })}>
-						<Text>{LABELS[cachePolicy]}</Text>
-						<ChevronsUpDown className="h-5 text-foreground-muted" />
-					</View>
-				</DropdownMenu.Trigger>
-
-				<DropdownMenu.Content>
-					<DropdownMenu.CheckboxItem
-						key="paged"
-						value={cachePolicy === 'memory-disk'}
-						onValueChange={() => onChange('memory-disk')}
-					>
-						<DropdownMenu.ItemTitle>{LABELS['memory-disk']}</DropdownMenu.ItemTitle>
-					</DropdownMenu.CheckboxItem>
-
-					<DropdownMenu.CheckboxItem
-						key="disk"
-						value={cachePolicy === 'disk'}
-						onValueChange={() => onChange('disk')}
-					>
-						<DropdownMenu.ItemTitle>{LABELS['disk']}</DropdownMenu.ItemTitle>
-					</DropdownMenu.CheckboxItem>
-
-					<DropdownMenu.CheckboxItem
-						key="memory"
-						value={cachePolicy === 'memory'}
-						onValueChange={() => onChange('memory')}
-					>
-						<DropdownMenu.ItemTitle>{LABELS['memory']}</DropdownMenu.ItemTitle>
-					</DropdownMenu.CheckboxItem>
-
-					<DropdownMenu.CheckboxItem
-						key="none"
-						value={cachePolicy === 'none'}
-						onValueChange={() => onChange('none')}
-						destructive
-					>
-						<DropdownMenu.ItemTitle>{LABELS['none']}</DropdownMenu.ItemTitle>
-					</DropdownMenu.CheckboxItem>
-				</DropdownMenu.Content>
-			</DropdownMenu.Root>
-		</View>
-	)
-}
-
-const LABELS: Record<CachePolicy, string> = {
-	none: 'None',
-	disk: 'Disk',
-	memory: 'Memory',
-	'memory-disk': 'Memory & Disk',
 }

--- a/apps/expo/components/book/BookListItem.tsx
+++ b/apps/expo/components/book/BookListItem.tsx
@@ -8,7 +8,9 @@ import { Pressable } from 'react-native-gesture-handler'
 import { useListItemSize } from '~/lib/hooks'
 import { cn } from '~/lib/utils'
 
+import { useColors } from '~/lib/constants'
 import { useActiveServer } from '../activeServer'
+import { BorderAndShadow } from '../BorderAndShadow'
 import { TurboImage } from '../Image'
 import { Text } from '../ui'
 
@@ -37,18 +39,17 @@ function BookListItem({ book }: Props) {
 	} = useActiveServer()
 
 	const router = useRouter()
+	const colors = useColors()
 
 	const { width, height } = useListItemSize()
 
 	return (
 		<Pressable onPress={() => router.navigate(`/server/${serverID}/books/${data.id}`)}>
 			{({ pressed }) => (
-				<View
-					className={cn('flex items-start px-1 tablet:px-2', {
-						'opacity-90': pressed,
-					})}
-				>
-					<View className="relative overflow-hidden rounded-lg">
+				<View className="relative" style={{ opacity: pressed ? 0.8 : 1 }}>
+					<BorderAndShadow
+						style={{ borderRadius: 8, borderWidth: 0.3, shadowRadius: 1.41, elevation: 2 }}
+					>
 						<TurboImage
 							source={{
 								uri: data.thumbnail.url,
@@ -56,11 +57,11 @@ function BookListItem({ book }: Props) {
 									Authorization: sdk.authorizationHeader || '',
 								},
 							}}
-							resizeMode="cover"
+							resizeMode="stretch"
 							resize={width * 1.5}
 							style={{ height, width }}
 						/>
-					</View>
+					</BorderAndShadow>
 
 					<View>
 						<Text className="mt-2" style={{ maxWidth: width - 4 }} numberOfLines={2}>

--- a/apps/expo/components/book/BookListItem.tsx
+++ b/apps/expo/components/book/BookListItem.tsx
@@ -6,9 +6,7 @@ import { View } from 'react-native'
 import { Pressable } from 'react-native-gesture-handler'
 
 import { useListItemSize } from '~/lib/hooks'
-import { cn } from '~/lib/utils'
 
-import { useColors } from '~/lib/constants'
 import { useActiveServer } from '../activeServer'
 import { BorderAndShadow } from '../BorderAndShadow'
 import { TurboImage } from '../Image'
@@ -39,7 +37,6 @@ function BookListItem({ book }: Props) {
 	} = useActiveServer()
 
 	const router = useRouter()
-	const colors = useColors()
 
 	const { width, height } = useListItemSize()
 

--- a/apps/expo/components/book/BookListItem.tsx
+++ b/apps/expo/components/book/BookListItem.tsx
@@ -9,7 +9,7 @@ import { useListItemSize } from '~/lib/hooks'
 import { cn } from '~/lib/utils'
 
 import { useActiveServer } from '../activeServer'
-import { FasterImage } from '../Image'
+import { TurboImage } from '../Image'
 import { Text } from '../ui'
 
 const fragment = graphql(`
@@ -49,14 +49,15 @@ function BookListItem({ book }: Props) {
 					})}
 				>
 					<View className="relative overflow-hidden rounded-lg">
-						<FasterImage
+						<TurboImage
 							source={{
-								url: data.thumbnail.url,
+								uri: data.thumbnail.url,
 								headers: {
 									Authorization: sdk.authorizationHeader || '',
 								},
-								resizeMode: 'fill',
 							}}
+							resizeMode="cover"
+							resize={width * 1.5}
 							style={{ height, width }}
 						/>
 					</View>

--- a/apps/expo/components/book/BookSearchItem.tsx
+++ b/apps/expo/components/book/BookSearchItem.tsx
@@ -9,7 +9,7 @@ import { formatBytes } from '~/lib/format'
 import { useDisplay } from '~/lib/hooks'
 
 import { useActiveServer } from '../activeServer'
-import { FasterImage } from '../Image'
+import { TurboImage } from '../Image'
 import { Text } from '../ui'
 
 const fragment = graphql(`
@@ -55,16 +55,16 @@ export default function BookSearchItem({ book }: Props) {
 			}}
 		>
 			<View className="flex-row items-start gap-4 py-4">
-				<FasterImage
+				<TurboImage
 					source={{
-						url: data.thumbnail.url,
+						uri: data.thumbnail.url,
 						headers: {
 							Authorization: sdk.authorizationHeader || '',
 						},
-						resizeMode: 'fill',
-						borderRadius: 8,
 					}}
-					style={{ width: 75, height: 75 / (2 / 3) }}
+					resizeMode="stretch"
+					resize={75 * 1.5}
+					style={{ width: 75, height: 75 / (2 / 3), borderRadius: 8 }}
 				/>
 
 				<View className="flex flex-1 flex-col gap-1">

--- a/apps/expo/components/book/BookSearchItem.tsx
+++ b/apps/expo/components/book/BookSearchItem.tsx
@@ -11,6 +11,7 @@ import { useDisplay } from '~/lib/hooks'
 import { useActiveServer } from '../activeServer'
 import { TurboImage } from '../Image'
 import { Text } from '../ui'
+import { BorderAndShadow } from '../BorderAndShadow'
 
 const fragment = graphql(`
 	fragment BookSearchItem on Media {
@@ -54,24 +55,28 @@ export default function BookSearchItem({ book }: Props) {
 				width: width * 0.75,
 			}}
 		>
-			<View className="flex-row items-start gap-4 py-4">
-				<TurboImage
-					source={{
-						uri: data.thumbnail.url,
-						headers: {
-							Authorization: sdk.authorizationHeader || '',
-						},
-					}}
-					resizeMode="stretch"
-					resize={75 * 1.5}
-					style={{ width: 75, height: 75 / (2 / 3), borderRadius: 8 }}
-				/>
+			<View className="flex-row items-start gap-4 p-4">
+				<BorderAndShadow
+					style={{ borderRadius: 4, borderWidth: 0.3, shadowRadius: 1.41, elevation: 2 }}
+				>
+					<TurboImage
+						source={{
+							uri: data.thumbnail.url,
+							headers: {
+								Authorization: sdk.authorizationHeader || '',
+							},
+						}}
+						resizeMode="stretch"
+						resize={75 * 1.5}
+						style={{ width: 75, height: 75 / (2 / 3) }}
+					/>
+				</BorderAndShadow>
 
 				<View className="flex flex-1 flex-col gap-1">
 					<Text>{data.resolvedName}</Text>
 
 					<Text className="text-foreground-muted">
-						{formatBytes(data.size)} • {data.pages} {pluralize('page', data.pages)}
+						{formatBytes(data.size, 1)} • {data.pages} {pluralize('page', data.pages)}
 					</Text>
 				</View>
 			</View>

--- a/apps/expo/components/book/OnDeckBookItem.tsx
+++ b/apps/expo/components/book/OnDeckBookItem.tsx
@@ -6,12 +6,13 @@ import { Platform, View } from 'react-native'
 import { Pressable } from 'react-native-gesture-handler'
 import LinearGradient from 'react-native-linear-gradient'
 
-import { COLORS } from '~/lib/constants'
+import { COLORS, useColors } from '~/lib/constants'
 
+import { useListItemSize } from '~/lib/hooks'
 import { useActiveServer } from '../activeServer'
 import { TurboImage } from '../Image'
 import { Text } from '../ui'
-import { useListItemSize } from '~/lib/hooks'
+import { BorderAndShadow } from '../BorderAndShadow'
 
 const fragment = graphql(`
 	fragment OnDeckBookItem on Media {
@@ -44,65 +45,65 @@ function OnDeckBookItem({ book }: Props) {
 	const { height, width } = useListItemSize()
 
 	const router = useRouter()
+	const colors = useColors()
 
 	return (
 		<Pressable onPress={() => router.navigate(`/server/${serverID}/books/${data.id}`)}>
 			{({ pressed }) => (
-				<View
-					className="relative"
-					style={{
-						opacity: pressed ? 0.75 : 1,
-					}}
-				>
-					<LinearGradient
-						colors={['transparent', 'rgba(0, 0, 0, 0.9)']}
-						style={{ position: 'absolute', inset: 0, zIndex: 10, borderRadius: 8 }}
-						locations={[0.4, 1]}
-					/>
+				<View className="relative" style={{ opacity: pressed ? 0.8 : 1 }}>
+					<BorderAndShadow
+						style={{ borderRadius: 8, borderWidth: 0.3, shadowRadius: 1.41, elevation: 2 }}
+					>
+						<LinearGradient
+							colors={['transparent', 'rgba(0, 0, 0, 0.9)']}
+							style={{ position: 'absolute', inset: 0, zIndex: 10 }}
+							locations={[0.4, 1]}
+						/>
 
-					<TurboImage
-						source={{
-							uri: data.thumbnail.url,
-							headers: {
-								Authorization: sdk.authorizationHeader || '',
-							},
-						}}
-						resizeMode="stretch"
-						resize={width * 1.5}
-						style={{ width, height, borderRadius: 8 }}
-					/>
-
-					<View className="absolute bottom-0 z-20 w-full gap-1 p-2">
-						<Text
-							className="flex-1 flex-wrap text-lg font-semibold leading-5"
-							style={{
-								textShadowOffset: { width: 2, height: 1 },
-								textShadowRadius: 2,
-								textShadowColor: 'rgba(0, 0, 0, 0.5)',
-								zIndex: 20,
-								color: COLORS.dark.foreground.DEFAULT,
+						<TurboImage
+							source={{
+								uri: data.thumbnail.url,
+								headers: {
+									Authorization: sdk.authorizationHeader || '',
+								},
 							}}
-							numberOfLines={2}
-						>
-							{data.resolvedName}
-						</Text>
+							resizeMode="stretch"
+							resize={width * 1.5}
+							style={{ width, height }}
+						/>
 
-						{data.seriesPosition != null && (
+						<View className="absolute bottom-0 z-20 w-full gap-1 p-2">
 							<Text
-								className="flex-1 flex-wrap text-sm font-medium"
+								className="flex-1 flex-wrap text-lg font-semibold leading-5"
 								style={{
 									textShadowOffset: { width: 2, height: 1 },
 									textShadowRadius: 2,
 									textShadowColor: 'rgba(0, 0, 0, 0.5)',
 									zIndex: 20,
-									color: COLORS.dark.foreground.subtle,
+									color: COLORS.dark.foreground.DEFAULT,
 								}}
-								numberOfLines={0}
+								numberOfLines={2}
 							>
-								Book {data.seriesPosition} of {data.series?.mediaCount ?? '?'}
+								{data.resolvedName}
 							</Text>
-						)}
-					</View>
+
+							{data.seriesPosition != null && (
+								<Text
+									className="flex-1 flex-wrap text-sm font-medium"
+									style={{
+										textShadowOffset: { width: 2, height: 1 },
+										textShadowRadius: 2,
+										textShadowColor: 'rgba(0, 0, 0, 0.5)',
+										zIndex: 20,
+										color: COLORS.dark.foreground.subtle,
+									}}
+									numberOfLines={0}
+								>
+									Book {data.seriesPosition} of {data.series?.mediaCount ?? '?'}
+								</Text>
+							)}
+						</View>
+					</BorderAndShadow>
 				</View>
 			)}
 		</Pressable>

--- a/apps/expo/components/book/OnDeckBookItem.tsx
+++ b/apps/expo/components/book/OnDeckBookItem.tsx
@@ -9,7 +9,7 @@ import LinearGradient from 'react-native-linear-gradient'
 import { COLORS } from '~/lib/constants'
 
 import { useActiveServer } from '../activeServer'
-import { FasterImage } from '../Image'
+import { TurboImage } from '../Image'
 import { Text } from '../ui'
 import { useListItemSize } from '~/lib/hooks'
 
@@ -60,17 +60,16 @@ function OnDeckBookItem({ book }: Props) {
 						locations={[0.4, 1]}
 					/>
 
-					<FasterImage
+					<TurboImage
 						source={{
-							url: data.thumbnail.url,
+							uri: data.thumbnail.url,
 							headers: {
 								Authorization: sdk.authorizationHeader || '',
 							},
-							resizeMode: 'fill',
-							// FIXME: I REALLY shouldn't have to do this
-							borderRadius: Platform.OS === 'android' ? 24 : 8,
 						}}
-						style={{ width, height }}
+						resizeMode="stretch"
+						resize={width * 1.5}
+						style={{ width, height, borderRadius: 8 }}
 					/>
 
 					<View className="absolute bottom-0 z-20 w-full gap-1 p-2">

--- a/apps/expo/components/book/OnDeckBookItem.tsx
+++ b/apps/expo/components/book/OnDeckBookItem.tsx
@@ -2,17 +2,18 @@ import { useSDK } from '@stump/client'
 import { FragmentType, graphql, useFragment } from '@stump/graphql'
 import { useRouter } from 'expo-router'
 import { memo } from 'react'
-import { Platform, View } from 'react-native'
+import { Easing, View } from 'react-native'
+import { easeGradient } from 'react-native-easing-gradient'
 import { Pressable } from 'react-native-gesture-handler'
 import LinearGradient from 'react-native-linear-gradient'
 
-import { COLORS, useColors } from '~/lib/constants'
+import { COLORS } from '~/lib/constants'
 
 import { useListItemSize } from '~/lib/hooks'
 import { useActiveServer } from '../activeServer'
+import { BorderAndShadow } from '../BorderAndShadow'
 import { TurboImage } from '../Image'
 import { Text } from '../ui'
-import { BorderAndShadow } from '../BorderAndShadow'
 
 const fragment = graphql(`
 	fragment OnDeckBookItem on Media {
@@ -45,7 +46,15 @@ function OnDeckBookItem({ book }: Props) {
 	const { height, width } = useListItemSize()
 
 	const router = useRouter()
-	const colors = useColors()
+
+	const { colors: gradientColors, locations: gradientLocations } = easeGradient({
+		colorStops: {
+			0.2: { color: 'transparent' },
+			1: { color: 'rgba(0, 0, 0, 0.90)' },
+		},
+		extraColorStopsPerTransition: 16,
+		easing: Easing.bezier(0.42, 0, 1, 1), // https://cubic-bezier.com/#.42,0,1,1
+	})
 
 	return (
 		<Pressable onPress={() => router.navigate(`/server/${serverID}/books/${data.id}`)}>
@@ -55,9 +64,9 @@ function OnDeckBookItem({ book }: Props) {
 						style={{ borderRadius: 8, borderWidth: 0.3, shadowRadius: 1.41, elevation: 2 }}
 					>
 						<LinearGradient
-							colors={['transparent', 'rgba(0, 0, 0, 0.9)']}
+							colors={gradientColors}
 							style={{ position: 'absolute', inset: 0, zIndex: 10 }}
-							locations={[0.4, 1]}
+							locations={gradientLocations}
 						/>
 
 						<TurboImage

--- a/apps/expo/components/book/filterHeader/Characters.tsx
+++ b/apps/expo/components/book/filterHeader/Characters.tsx
@@ -94,7 +94,7 @@ export default function Characters() {
 				<View className="gap-3">
 					<Text>Available Characters</Text>
 
-					<View className="gap-0 rounded-lg border border-edge bg-background-surface">
+					<View className="squircle gap-0 rounded-lg border border-edge bg-background-surface">
 						{characters.map((character, idx) => (
 							<Fragment key={character}>
 								<View className="flex flex-row items-center gap-3 p-3">

--- a/apps/expo/components/book/filterHeader/Genres.tsx
+++ b/apps/expo/components/book/filterHeader/Genres.tsx
@@ -98,7 +98,7 @@ export default function Genres() {
 				<View className="gap-3">
 					<Text>Available Genres</Text>
 
-					<View className="gap-0 rounded-lg border border-edge bg-background-surface">
+					<View className="squircle gap-0 rounded-lg border border-edge bg-background-surface">
 						{genres.map((genre, idx) => (
 							<Fragment key={genre}>
 								<View className="flex flex-row items-center gap-3 p-3">

--- a/apps/expo/components/book/filterHeader/ReadStatus.tsx
+++ b/apps/expo/components/book/filterHeader/ReadStatus.tsx
@@ -84,7 +84,7 @@ export default function ReadStatus() {
 				<View className="gap-3">
 					<Text>Available Read Status</Text>
 
-					<View className="gap-0 rounded-lg border border-edge bg-background-surface">
+					<View className="squircle gap-0 rounded-lg border border-edge bg-background-surface">
 						{STATUSES.map((status, idx) => (
 							<Fragment key={status}>
 								<View className="flex flex-row items-center gap-3 p-3">

--- a/apps/expo/components/book/filterHeader/Series.tsx
+++ b/apps/expo/components/book/filterHeader/Series.tsx
@@ -92,7 +92,7 @@ export default function Series() {
 				<View className="gap-3">
 					<Text>Available Series</Text>
 
-					<View className="gap-0 rounded-lg border border-edge bg-background-surface">
+					<View className="squircle gap-0 rounded-lg border border-edge bg-background-surface">
 						{seriesList.map((series, idx) => {
 							const isLast = idx === seriesList.length - 1
 							return (

--- a/apps/expo/components/book/filterHeader/Sort.tsx
+++ b/apps/expo/components/book/filterHeader/Sort.tsx
@@ -87,7 +87,7 @@ export default function Sort() {
 					<RadioGroup
 						value={direction}
 						onValueChange={handleSortDirectionChanged}
-						className="gap-0 rounded-lg border border-edge bg-background-surface"
+						className="squircle gap-0 rounded-lg border border-edge bg-background-surface"
 					>
 						<View className="flex flex-row items-center gap-3 p-3">
 							<RadioGroupItem value="ASC" id="ascending" />
@@ -107,7 +107,7 @@ export default function Sort() {
 					<RadioGroup
 						value={field}
 						onValueChange={(value) => handleSortFieldChanged(value, false)}
-						className="gap-0 rounded-lg border border-edge bg-background-surface"
+						className="squircle gap-0 rounded-lg border border-edge bg-background-surface"
 					>
 						<View className="flex flex-row items-center gap-3 p-3">
 							<RadioGroupItem value="NAME" id="name" />
@@ -178,7 +178,7 @@ export default function Sort() {
 					<RadioGroup
 						value={field}
 						onValueChange={(value) => handleSortFieldChanged(value, true)}
-						className="gap-0 rounded-lg border border-edge bg-background-surface"
+						className="squircle gap-0 rounded-lg border border-edge bg-background-surface"
 					>
 						<View className="flex flex-row items-center gap-3 p-3">
 							<RadioGroupItem value="TITLE" id="title" />

--- a/apps/expo/components/book/filterHeader/Writers.tsx
+++ b/apps/expo/components/book/filterHeader/Writers.tsx
@@ -92,7 +92,7 @@ export default function Writers() {
 				<View className="gap-3">
 					<Text>Available Writers</Text>
 
-					<View className="gap-0 rounded-lg border border-edge bg-background-surface">
+					<View className="squircle gap-0 rounded-lg border border-edge bg-background-surface">
 						{writers.map((writer, idx) => (
 							<Fragment key={writer}>
 								<View className="flex flex-row items-center gap-3 p-3">

--- a/apps/expo/components/book/overview/AndroidBookMenu.tsx
+++ b/apps/expo/components/book/overview/AndroidBookMenu.tsx
@@ -53,7 +53,7 @@ export default function AndroidBookMenu({
 	return (
 		<DropdownMenu>
 			<DropdownMenuTrigger asChild>
-				<Button className="h-8 w-8 rounded-full p-0" variant="ghost" size="icon">
+				<Button className="squircle h-8 w-8 rounded-full p-0" variant="ghost" size="icon">
 					<View>
 						<Ellipsis size={20} className="text-foreground" />
 					</View>

--- a/apps/expo/components/book/overview/InfoSection.tsx
+++ b/apps/expo/components/book/overview/InfoSection.tsx
@@ -12,7 +12,7 @@ export default function InfoSection({ label, rows }: Props) {
 	return (
 		<View className="flex w-full gap-2">
 			<Text className="text-lg text-foreground-muted">{label}</Text>
-			<View className="flex flex-col rounded-lg border border-edge bg-background-surface">
+			<View className="squircle flex flex-col rounded-lg border border-edge bg-background-surface">
 				{rows.map((row, index) => (
 					<View key={`section-${label}-${index}`}>
 						{row}

--- a/apps/expo/components/book/reader/image/ControlsOverlay.tsx
+++ b/apps/expo/components/book/reader/image/ControlsOverlay.tsx
@@ -1,11 +1,12 @@
 import { Fragment, useEffect, useState } from 'react'
-import { Pressable } from 'react-native'
+import { Easing, Pressable } from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated'
 
 import { cn } from '~/lib/utils'
 import { useReaderStore } from '~/stores'
 
+import { easeGradient } from 'react-native-easing-gradient'
 import Footer from './Footer'
 import Header from './Header'
 import ImageReaderGlobalSettingsDialog from './ImageReaderGlobalSettingsDialog'
@@ -37,6 +38,17 @@ export default function ControlsOverlay() {
 		}
 	})
 
+	const { colors: gradientColors, locations: gradientLocations } = easeGradient({
+		colorStops: {
+			0: { color: 'rgba(0, 0, 0, 0.8)' },
+			0.4: { color: 'rgba(0, 0, 0, 0.50)' },
+			0.6: { color: 'rgba(0, 0, 0, 0.50)' },
+			1: { color: 'rgba(0, 0, 0, 0.8)' },
+		},
+		extraColorStopsPerTransition: 16,
+		easing: Easing.bezier(0.62, 0, 0.38, 1), // https://cubic-bezier.com/#.62,0,.38,1
+	})
+
 	return (
 		<Fragment>
 			<Header onShowGlobalSettings={() => setShowGlobalSettings(true)} />
@@ -49,19 +61,9 @@ export default function ControlsOverlay() {
 					}}
 				>
 					<LinearGradient
-						colors={[
-							'hsla(0, 0%, 0%, 0.75)',
-							'hsla(0, 0%, 0%, 0.75)',
-							'hsla(0, 0%, 0%, 0.5)',
-							'hsla(0, 0%, 0%, 0.5)',
-							'hsla(0, 0%, 0%, 0.5)',
-							'hsla(0, 0%, 0%, 0.5)',
-							'hsla(0, 0%, 0%, 0.75)',
-							'hsla(0, 0%, 0%, 0.95)',
-						]}
-						style={{
-							flex: 1,
-						}}
+						colors={gradientColors}
+						locations={gradientLocations}
+						style={{ flex: 1 }}
 					/>
 				</Pressable>
 			</Animated.View>

--- a/apps/expo/components/book/reader/image/Footer.tsx
+++ b/apps/expo/components/book/reader/image/Footer.tsx
@@ -4,14 +4,14 @@ import { ReadingDirection } from '@stump/graphql'
 import { STUMP_SAVE_BASIC_SESSION_HEADER } from '@stump/sdk/constants'
 import dayjs from 'dayjs'
 import duration from 'dayjs/plugin/duration'
-import { Image as EImage } from 'expo-image'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Platform, View } from 'react-native'
 import { FlatList, Pressable } from 'react-native-gesture-handler'
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import TImage from 'react-native-turbo-image'
 
-import { FasterImage } from '~/components/Image'
+import { TurboImage } from '~/components/Image'
 import { Progress, Text } from '~/components/ui'
 import { useDisplay, usePrevious } from '~/lib/hooks'
 import { cn } from '~/lib/utils'
@@ -196,7 +196,6 @@ export default function Footer() {
 		[imageSizes, setImageSizes],
 	)
 
-	// TODO: prefetch, see https://github.com/candlefinance/faster-image/issues/73
 	useEffect(
 		() => {
 			if (footerControls !== 'images' || isOPDS) return
@@ -211,14 +210,17 @@ export default function Footer() {
 			const urls = Array.from({ length: end - start }, (_, i) =>
 				pageThumbnailURL ? pageThumbnailURL(i + start) : pageURL(i + start),
 			)
-			// FIXME: This crashes when in OPDS for some reason
-			EImage.prefetch(urls, {
-				headers: {
-					Authorization: sdk.authorizationHeader || '',
-					[STUMP_SAVE_BASIC_SESSION_HEADER]: 'false',
-				},
-				cachePolicy: 'disk',
-			})
+			// TODO: Test if turbo image crashes when in OPDS (it previously did with expo image)
+			TImage.prefetch(
+				urls.map((url) => ({
+					uri: url,
+					headers: {
+						Authorization: sdk.authorizationHeader || '',
+						[STUMP_SAVE_BASIC_SESSION_HEADER]: 'false',
+					},
+				})),
+				'dataCache',
+			)
 		},
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[currentPage, readingDirection, isOPDS],
@@ -317,17 +319,17 @@ export default function Footer() {
 						{pageSet.map((pageIdx, i) => {
 							const source = pageSource(pageIdx + 1)
 							return (
-								<FasterImage
+								<TurboImage
 									key={`thumb-${pageIdx + 1}-${i}`}
 									source={{
-										url: source.uri,
+										uri: source.uri,
 										headers: source.headers as Record<string, string>,
-										resizeMode: 'fill',
-										borderRadius: 8,
 									}}
+									resizeMode="stretch"
 									style={{
 										width: pageSet.length === 1 ? '100%' : '50%',
 										height: '100%',
+										borderRadius: 8,
 									}}
 									onSuccess={({ nativeEvent }) => onImageLoaded(pageIdx, nativeEvent)}
 								/>
@@ -431,17 +433,18 @@ export default function Footer() {
 					>
 						{item.map((pageIdx, i) => {
 							return (
-								<FasterImage
+								<TurboImage
 									key={`thumb-${pageIdx + 1}-${i}`}
 									source={{
-										url: pageSource(pageIdx + 1).uri,
+										uri: pageSource(pageIdx + 1).uri,
 										headers: pageSource(pageIdx + 1).headers as Record<string, string>,
-										resizeMode: 'fill',
-										borderRadius: 8,
 									}}
+									resizeMode="stretch"
+									resize={(baseSize.width / WIDTH_MODIFIER) * 1.5}
 									style={{
 										width: item.length === 1 ? '100%' : '50%',
 										height: '100%',
+										borderRadius: 8,
 									}}
 									onSuccess={({ nativeEvent }) => onImageLoaded(pageIdx, nativeEvent)}
 								/>

--- a/apps/expo/components/book/reader/image/Footer.tsx
+++ b/apps/expo/components/book/reader/image/Footer.tsx
@@ -512,6 +512,7 @@ export default function Footer() {
 						trackStyle={{
 							height: 12,
 							borderRadius: 6,
+							borderCurve: 'continuous',
 							backgroundColor: '#898d9490',
 						}}
 						minimumTrackStyle={minimumTrackStyle}

--- a/apps/expo/components/book/reader/image/Footer.tsx
+++ b/apps/expo/components/book/reader/image/Footer.tsx
@@ -326,10 +326,11 @@ export default function Footer() {
 										headers: source.headers as Record<string, string>,
 									}}
 									resizeMode="stretch"
+									resize={containerSize.width * 1.5}
 									style={{
 										width: pageSet.length === 1 ? '100%' : '50%',
 										height: '100%',
-										borderRadius: 8,
+										borderRadius: 6,
 									}}
 									onSuccess={({ nativeEvent }) => onImageLoaded(pageIdx, nativeEvent)}
 								/>
@@ -444,7 +445,7 @@ export default function Footer() {
 									style={{
 										width: item.length === 1 ? '100%' : '50%',
 										height: '100%',
-										borderRadius: 8,
+										borderRadius: 6,
 									}}
 									onSuccess={({ nativeEvent }) => onImageLoaded(pageIdx, nativeEvent)}
 								/>

--- a/apps/expo/components/book/reader/image/Header.tsx
+++ b/apps/expo/components/book/reader/image/Header.tsx
@@ -99,7 +99,7 @@ export default function Header({ onShowGlobalSettings }: Props) {
 					>
 						{({ pressed }) => (
 							<View
-								className="rounded-full border p-1 tablet:p-2"
+								className="squircle rounded-full border p-1 tablet:p-2"
 								style={{
 									backgroundColor: COLORS.dark.background.overlay.DEFAULT,
 									borderColor: COLORS.dark.edge.DEFAULT,
@@ -227,7 +227,7 @@ export default function Header({ onShowGlobalSettings }: Props) {
 			<DropdownMenu>
 				<DropdownMenuTrigger asChild>
 					<Button
-						className="h-[unset] w-[unset] rounded-full border p-1 tablet:p-2"
+						className="squircle h-[unset] w-[unset] rounded-full border p-1 tablet:p-2"
 						variant="ghost"
 						size="icon"
 						style={{
@@ -357,7 +357,7 @@ export default function Header({ onShowGlobalSettings }: Props) {
 				>
 					{({ pressed }) => (
 						<View
-							className="rounded-full border p-1 tablet:p-2"
+							className="squircle rounded-full border p-1 tablet:p-2"
 							style={{
 								backgroundColor: COLORS.dark.background.overlay.DEFAULT,
 								borderColor: COLORS.dark.edge.DEFAULT,

--- a/apps/expo/components/book/reader/image/ImageBasedReader.tsx
+++ b/apps/expo/components/book/reader/image/ImageBasedReader.tsx
@@ -16,7 +16,6 @@ import {
 	TapGestureHandlerEventPayload,
 } from 'react-native-gesture-handler'
 import { useSharedValue } from 'react-native-reanimated'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { Success } from 'react-native-turbo-image'
 
 import { TurboImage } from '~/components/Image'
@@ -217,14 +216,12 @@ const Page = React.memo(
 		maxHeight,
 		// readingDirection,
 	}: PageProps) => {
-		const { book, pageURL, flatListRef, setImageSizes } = useImageBasedReader()
+		const { book, pageURL, flatListRef, pageSets, setImageSizes } = useImageBasedReader()
 		const {
 			preferences: { tapSidesToNavigate, readingDirection, allowDownscaling },
 		} = useBookPreferences({ book })
 		const { isTablet } = useDisplay()
 		const { sdk } = useSDK()
-
-		const insets = useSafeAreaInsets()
 
 		const scale = useSharedValue(1)
 		const showControls = useReaderStore((state) => state.showControls)
@@ -237,17 +234,18 @@ const Page = React.memo(
 				const isLeft = x < maxWidth / tapThresholdRatio
 				const isRight = x > maxWidth - maxWidth / tapThresholdRatio
 
-				if (isLeft) {
-					const modifier = readingDirection === ReadingDirection.Rtl ? 1 : -1
-					flatListRef.current?.scrollToIndex({ index: index + modifier, animated: true })
-				} else if (isRight) {
-					const modifier = readingDirection === ReadingDirection.Rtl ? -1 : 1
-					flatListRef.current?.scrollToIndex({ index: index + modifier, animated: true })
+				let modifier = 0
+				if (isLeft) modifier = readingDirection === ReadingDirection.Rtl ? 1 : -1
+				if (isRight) modifier = readingDirection === ReadingDirection.Rtl ? -1 : 1
+
+				const nextIndex = index + modifier
+				if (nextIndex >= 0 && nextIndex < pageSets.length) {
+					flatListRef.current?.scrollToIndex({ index: nextIndex, animated: true })
 				}
 
 				return isLeft || isRight
 			},
-			[maxWidth, index, flatListRef, tapThresholdRatio, readingDirection],
+			[maxWidth, index, flatListRef, tapThresholdRatio, readingDirection, pageSets],
 		)
 
 		const onSingleTap = useCallback(
@@ -287,7 +285,6 @@ const Page = React.memo(
 			[setImageSizes, sizes, indexes],
 		)
 
-		const safeMaxHeight = maxHeight - insets.top - insets.bottom
 		const [imageRatio, setImageRatio] = useState<number | undefined>(undefined)
 		const roughPageRenderWidth = indexes.length > 1 ? maxWidth / 2 : maxWidth
 

--- a/apps/expo/components/book/reader/image/ImageBasedReader.tsx
+++ b/apps/expo/components/book/reader/image/ImageBasedReader.tsx
@@ -2,8 +2,7 @@ import { Zoomable } from '@likashefqet/react-native-image-zoom'
 import { useSDK } from '@stump/client'
 import { ReadingDirection, ReadingMode } from '@stump/graphql'
 import { STUMP_SAVE_BASIC_SESSION_HEADER } from '@stump/sdk/constants'
-import { ImageLoadEventData } from 'expo-image'
-import React, { useCallback, useEffect, useMemo, useRef } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
 	FlatList,
 	NativeScrollEvent,
@@ -18,8 +17,9 @@ import {
 } from 'react-native-gesture-handler'
 import { useSharedValue } from 'react-native-reanimated'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { Success } from 'react-native-turbo-image'
 
-import { Image } from '~/components/Image'
+import { TurboImage } from '~/components/Image'
 import { useDisplay, usePrevious } from '~/lib/hooks'
 import { cn } from '~/lib/utils'
 import { useReaderStore } from '~/stores'
@@ -192,7 +192,6 @@ export default function ImageBasedReader({ initialPage, onPastEndReached }: Prop
 			})}
 			showsVerticalScrollIndicator={false}
 			showsHorizontalScrollIndicator={false}
-			removeClippedSubviews
 			onScroll={handleScroll}
 		/>
 	)
@@ -220,7 +219,7 @@ const Page = React.memo(
 	}: PageProps) => {
 		const { book, pageURL, flatListRef, setImageSizes } = useImageBasedReader()
 		const {
-			preferences: { tapSidesToNavigate, readingDirection },
+			preferences: { tapSidesToNavigate, readingDirection, allowDownscaling },
 		} = useBookPreferences({ book })
 		const { isTablet } = useDisplay()
 		const { sdk } = useSDK()
@@ -269,10 +268,11 @@ const Page = React.memo(
 		)
 
 		const onImageLoaded = useCallback(
-			(event: ImageLoadEventData, idxIdx: number) => {
-				const { height, width } = event.source
+			(event: NativeSyntheticEvent<Success>, idxIdx: number) => {
+				const { height, width } = event.nativeEvent
 				if (!height || !width) return
 				const ratio = width / height
+				setImageRatio(ratio)
 
 				const pageSize = sizes[idxIdx]
 				const isDifferent = pageSize?.height !== height || pageSize?.width !== width
@@ -288,11 +288,9 @@ const Page = React.memo(
 		)
 
 		const safeMaxHeight = maxHeight - insets.top - insets.bottom
+		const [imageRatio, setImageRatio] = useState<number | undefined>(undefined)
+		const [renderedWidth, setRenderedWidth] = useState<number | undefined>(undefined)
 
-		// TODO: Absolutely don't do this, this is terrible. We need my PRs to be merged upstream:
-		// https://github.com/candlefinance/faster-image/pulls
-
-		// https://github.com/candlefinance/faster-image/issues/75
 		return (
 			<Zoomable
 				minScale={1}
@@ -312,28 +310,31 @@ const Page = React.memo(
 						width: maxWidth,
 					}}
 				>
-					{indexes.map((pageIdx, i) => (
-						<Image
-							key={`${pageIdx}-${i}`}
-							source={{
-								uri: pageURL(pageIdx + 1),
-								headers: {
-									Authorization: sdk.authorizationHeader || '',
-									[STUMP_SAVE_BASIC_SESSION_HEADER]: 'false',
-								},
-								// FIXME: I can't remember why this was here or why its complaining
-								// cachePolicy,
-							}}
-							style={{
-								height: '100%',
-								width: indexes.length > 1 ? '50%' : '100%',
-							}}
-							contentFit="contain"
-							contentPosition={indexes.length > 1 ? (i === 0 ? 'right' : 'left') : 'center'}
-							onLoad={(e) => onImageLoaded(e, i)}
-							allowDownscaling={false}
-						/>
-					))}
+					{indexes.map((pageIdx, i) => {
+						return (
+							<TurboImage
+								key={`${pageIdx}-${i}`}
+								source={{
+									uri: pageURL(pageIdx + 1),
+									headers: {
+										Authorization: sdk.authorizationHeader || '',
+										[STUMP_SAVE_BASIC_SESSION_HEADER]: 'false',
+									},
+								}}
+								style={{
+									maxHeight: '100%',
+									maxWidth: indexes.length > 1 ? '50%' : '100%',
+									aspectRatio: imageRatio,
+								}}
+								onLayout={(event) => {
+									if (allowDownscaling) setRenderedWidth(event.nativeEvent.layout.width)
+								}}
+								resizeMode="contain"
+								resize={allowDownscaling && renderedWidth ? renderedWidth * 1.5 : undefined}
+								onSuccess={(event) => onImageLoaded(event, i)}
+							/>
+						)
+					})}
 				</View>
 			</Zoomable>
 		)

--- a/apps/expo/components/book/reader/image/ImageBasedReader.tsx
+++ b/apps/expo/components/book/reader/image/ImageBasedReader.tsx
@@ -289,26 +289,23 @@ const Page = React.memo(
 
 		const safeMaxHeight = maxHeight - insets.top - insets.bottom
 		const [imageRatio, setImageRatio] = useState<number | undefined>(undefined)
-		const [renderedWidth, setRenderedWidth] = useState<number | undefined>(undefined)
+		const roughPageRenderWidth = indexes.length > 1 ? maxWidth / 2 : maxWidth
 
 		return (
 			<Zoomable
 				minScale={1}
 				maxScale={5}
 				scale={scale}
-				doubleTapScale={3}
+				doubleTapScale={2.5}
 				isSingleTapEnabled={true}
 				isDoubleTapEnabled={true}
 				onSingleTap={onSingleTap}
 			>
 				<View
-					className={cn('relative flex justify-center', {
-						'mx-auto flex-row gap-0': indexes.length > 1,
+					className={cn('relative flex-row items-center justify-center', {
+						'mx-auto gap-0': indexes.length > 1,
 					})}
-					style={{
-						height: safeMaxHeight,
-						width: maxWidth,
-					}}
+					style={{ height: maxHeight, width: maxWidth }}
 				>
 					{indexes.map((pageIdx, i) => {
 						return (
@@ -322,15 +319,13 @@ const Page = React.memo(
 									},
 								}}
 								style={{
-									maxHeight: '100%',
+									height: '100%',
 									maxWidth: indexes.length > 1 ? '50%' : '100%',
 									aspectRatio: imageRatio,
 								}}
-								onLayout={(event) => {
-									if (allowDownscaling) setRenderedWidth(event.nativeEvent.layout.width)
-								}}
+								indicator={{ color: 'transparent' }}
 								resizeMode="contain"
-								resize={allowDownscaling && renderedWidth ? renderedWidth * 1.5 : undefined}
+								resize={allowDownscaling ? roughPageRenderWidth * 1.2 : undefined}
 								onSuccess={(event) => onImageLoaded(event, i)}
 							/>
 						)

--- a/apps/expo/components/book/reader/image/ImageBasedReaderContainer.tsx
+++ b/apps/expo/components/book/reader/image/ImageBasedReaderContainer.tsx
@@ -1,7 +1,7 @@
 import { ReadingDirection, ReadingMode } from '@stump/graphql'
 import { generatePageSets, ImageBasedBookPageRef } from '@stump/sdk'
 import { ComponentProps, useCallback, useMemo, useRef, useState } from 'react'
-import { Dimensions, View } from 'react-native'
+import { View } from 'react-native'
 import { FlatList } from 'react-native-gesture-handler'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
@@ -133,14 +133,7 @@ export default function ImageBasedReaderContainer({
 				flatListRef,
 			}}
 		>
-			<View
-				className="fixed inset-0 flex-1 bg-black"
-				style={{
-					paddingTop: insets.top,
-					paddingBottom: insets.bottom,
-					height: Dimensions.get('screen').height - insets.top - insets.bottom,
-				}}
-			>
+			<View className="fixed inset-0 flex-1 bg-black">
 				<ControlsOverlay />
 
 				{nextInSeries && (

--- a/apps/expo/components/book/reader/image/ImageBasedReaderContainer.tsx
+++ b/apps/expo/components/book/reader/image/ImageBasedReaderContainer.tsx
@@ -3,7 +3,6 @@ import { generatePageSets, ImageBasedBookPageRef } from '@stump/sdk'
 import { ComponentProps, useCallback, useMemo, useRef, useState } from 'react'
 import { View } from 'react-native'
 import { FlatList } from 'react-native-gesture-handler'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 import { useDisplay } from '~/lib/hooks'
 import { DEFAULT_BOOK_PREFERENCES, useBookPreferences } from '~/stores/reader'
@@ -106,7 +105,6 @@ export default function ImageBasedReaderContainer({
 
 	const flatListRef = useRef<FlatList>(null)
 	// const flatListRef = useRef<FlashList<number>>(null)
-	const insets = useSafeAreaInsets()
 
 	// TODO: prefetch, see https://github.com/candlefinance/faster-image/issues/73
 	// useEffect(

--- a/apps/expo/components/book/reader/image/ImageReaderGlobalSettingsDialog.tsx
+++ b/apps/expo/components/book/reader/image/ImageReaderGlobalSettingsDialog.tsx
@@ -69,7 +69,9 @@ export default function ImageReaderGlobalSettingsDialog({ isOpen, onClose }: Pro
 				index={snapPoints.length - 1}
 				snapPoints={snapPoints}
 				onChange={handleChange}
-				backgroundComponent={(props) => <View {...props} className="rounded-t-xl bg-background" />}
+				backgroundComponent={(props) => (
+					<View {...props} className="squircle rounded-t-xl bg-background" />
+				)}
 				handleIndicatorStyle={{ backgroundColor: colorScheme === 'dark' ? '#333' : '#ccc' }}
 				handleComponent={(props) => (
 					<BottomSheet.Handle

--- a/apps/expo/components/book/reader/image/NextUpOverlay.tsx
+++ b/apps/expo/components/book/reader/image/NextUpOverlay.tsx
@@ -8,7 +8,7 @@ import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-na
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 import { useActiveServer } from '~/components/activeServer'
-import { FasterImage } from '~/components/Image'
+import { TurboImage } from '~/components/Image'
 import { Button, Heading, icons, Label, Text } from '~/components/ui'
 import { COLORS } from '~/lib/constants'
 import { useDisplay } from '~/lib/hooks'
@@ -122,16 +122,16 @@ export default function NextUpOverlay({ isVisible, book, onClose }: Props) {
 						{book.name}
 					</Heading>
 				</View>
-				<FasterImage
+				<TurboImage
 					source={{
-						url: book.thumbnailUrl,
+						uri: book.thumbnailUrl,
 						headers: {
 							Authorization: sdk.authorizationHeader || '',
 						},
-						resizeMode: 'fill',
-						borderRadius: 8,
 					}}
-					style={{ width: size, height: size / (2 / 3) }}
+					resizeMode="stretch"
+					resize={size * 1.5}
+					style={{ width: size, height: size / (2 / 3), borderRadius: 8 }}
 				/>
 
 				<View

--- a/apps/expo/components/book/reader/image/NextUpOverlay.tsx
+++ b/apps/expo/components/book/reader/image/NextUpOverlay.tsx
@@ -76,7 +76,7 @@ export default function NextUpOverlay({ isVisible, book, onClose }: Props) {
 			>
 				<View className="flex-row items-center justify-between">
 					<Button
-						className="h-[unset] w-[unset] rounded-full border p-1 tablet:p-2"
+						className="squircle h-[unset] w-[unset] rounded-full border p-1 tablet:p-2"
 						variant="ghost"
 						size="icon"
 						style={{

--- a/apps/expo/components/book/reader/image/NextUpOverlay.tsx
+++ b/apps/expo/components/book/reader/image/NextUpOverlay.tsx
@@ -131,7 +131,7 @@ export default function NextUpOverlay({ isVisible, book, onClose }: Props) {
 					}}
 					resizeMode="stretch"
 					resize={size * 1.5}
-					style={{ width: size, height: size / (2 / 3), borderRadius: 8 }}
+					style={{ width: size, height: size / (2 / 3), borderRadius: 12 }}
 				/>
 
 				<View

--- a/apps/expo/components/book/reader/settings/ReaderSettings.tsx
+++ b/apps/expo/components/book/reader/settings/ReaderSettings.tsx
@@ -68,7 +68,7 @@ export default function ReaderSettings({ forBook, forServer }: Props) {
 			<View>
 				<Text className="mb-3 text-foreground-muted">Mode</Text>
 
-				<Card className="flex rounded-xl border border-edge bg-background-surface">
+				<Card className="squircle flex rounded-xl border border-edge bg-background-surface">
 					<ReadingModeSelect
 						mode={activeSettings.readingMode}
 						onChange={(mode) => onPreferenceChange({ readingMode: mode })}
@@ -90,7 +90,7 @@ export default function ReaderSettings({ forBook, forServer }: Props) {
 			<View>
 				<Text className="mb-3 text-foreground-muted">Image Options</Text>
 
-				<Card className="flex rounded-xl border border-edge bg-background-surface">
+				<Card className="squircle flex rounded-xl border border-edge bg-background-surface">
 					<CachePolicySelect
 						policy={activeSettings.cachePolicy || 'memory-disk'}
 						onChange={(policy) => onPreferenceChange({ cachePolicy: policy })}
@@ -152,7 +152,7 @@ export default function ReaderSettings({ forBook, forServer }: Props) {
 			<View>
 				<Text className="mb-3 text-foreground-muted">Navigation</Text>
 
-				<Card className="flex rounded-xl border border-edge bg-background-surface">
+				<Card className="squircle flex rounded-xl border border-edge bg-background-surface">
 					<View className="flex flex-row items-center justify-between border-b border-b-edge p-4">
 						<Text>Tap Sides to Navigate</Text>
 						<Switch

--- a/apps/expo/components/fileExplorer/FileExplorerGridItem.tsx
+++ b/apps/expo/components/fileExplorer/FileExplorerGridItem.tsx
@@ -11,6 +11,7 @@ import { useColorScheme } from '~/lib/useColorScheme'
 import { useActiveServer } from '../activeServer'
 import { TurboImage } from '../Image'
 import { Text } from '../ui'
+import { BorderAndShadow } from '../BorderAndShadow'
 
 type ListedFile = DirectoryListingQuery['listDirectory']['nodes'][number]['files'][number]
 
@@ -56,7 +57,9 @@ export default function FileExplorerGridItem({ file }: Props) {
 						/>
 					)}
 					{!!file.media?.thumbnail.url && (
-						<View className="items-center justify-center" style={{ width: 100, height: 100 }}>
+						<BorderAndShadow
+							style={{ borderRadius: 4, borderWidth: 0.3, shadowRadius: 1.41, elevation: 2 }}
+						>
 							<TurboImage
 								source={{
 									uri: file.media.thumbnail.url,
@@ -66,9 +69,9 @@ export default function FileExplorerGridItem({ file }: Props) {
 								}}
 								resizeMode="stretch"
 								resize={100 * 1.5}
-								style={{ height: 100, width: 100 * (2 / 3), borderRadius: 8 }}
+								style={{ height: 100, width: 100 * (2 / 3) }}
 							/>
-						</View>
+						</BorderAndShadow>
 					)}
 
 					<View>

--- a/apps/expo/components/fileExplorer/FileExplorerGridItem.tsx
+++ b/apps/expo/components/fileExplorer/FileExplorerGridItem.tsx
@@ -1,16 +1,15 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 import { ARCHIVE_EXTENSION, EBOOK_EXTENSION, PDF_EXTENSION, useSDK } from '@stump/client'
 import { DirectoryListingQuery } from '@stump/graphql'
-import { Image } from 'expo-image'
 import { useRouter } from 'expo-router'
 import { useCallback } from 'react'
-import { View } from 'react-native'
+import { Image, View } from 'react-native'
 import { Pressable } from 'react-native-gesture-handler'
 
 import { useColorScheme } from '~/lib/useColorScheme'
 
 import { useActiveServer } from '../activeServer'
-import { FasterImage } from '../Image'
+import { TurboImage } from '../Image'
 import { Text } from '../ui'
 
 type ListedFile = DirectoryListingQuery['listDirectory']['nodes'][number]['files'][number]
@@ -28,7 +27,6 @@ export default function FileExplorerGridItem({ file }: Props) {
 	} = useActiveServer()
 
 	const router = useRouter()
-
 	const friendlyName = file?.media?.resolvedName || file.name
 
 	const onSelect = useCallback(() => {
@@ -50,19 +48,25 @@ export default function FileExplorerGridItem({ file }: Props) {
 		<Pressable onPress={onSelect}>
 			{({ pressed }) => (
 				<View className="items-center" style={{ opacity: pressed ? 0.75 : 1 }}>
-					{!file.media && <Image source={iconSource} style={{ width: 100, height: 100 }} />}
+					{!file.media && (
+						<TurboImage
+							source={{ uri: Image.resolveAssetSource(iconSource).uri }}
+							style={{ width: 100, height: 100 }}
+							resize={100 * 1.5}
+						/>
+					)}
 					{!!file.media?.thumbnail.url && (
 						<View className="items-center justify-center" style={{ width: 100, height: 100 }}>
-							<FasterImage
+							<TurboImage
 								source={{
-									url: file.media.thumbnail.url,
+									uri: file.media.thumbnail.url,
 									headers: {
 										Authorization: sdk.authorizationHeader || '',
 									},
-									borderRadius: 8,
-									resizeMode: 'fill',
 								}}
-								style={{ height: 100, width: 100 * (2 / 3) }}
+								resizeMode="stretch"
+								resize={100 * 1.5}
+								style={{ height: 100, width: 100 * (2 / 3), borderRadius: 8 }}
 							/>
 						</View>
 					)}

--- a/apps/expo/components/fileExplorer/FileExplorerGridItem.tsx
+++ b/apps/expo/components/fileExplorer/FileExplorerGridItem.tsx
@@ -28,6 +28,7 @@ export default function FileExplorerGridItem({ file }: Props) {
 	} = useActiveServer()
 
 	const router = useRouter()
+
 	const friendlyName = file?.media?.resolvedName || file.name
 
 	const onSelect = useCallback(() => {

--- a/apps/expo/components/filter/ClearFilters.tsx
+++ b/apps/expo/components/filter/ClearFilters.tsx
@@ -15,7 +15,7 @@ export default function ClearFilters({ onPress }: Props) {
 			{({ pressed }) => (
 				<View
 					className={cn(
-						'flex flex-grow-0 flex-row items-center justify-center rounded-full bg-fill-danger-secondary px-3 py-2',
+						'squircle flex flex-grow-0 flex-row items-center justify-center rounded-full bg-fill-danger-secondary px-3 py-2',
 						pressed && 'opacity-70',
 					)}
 					style={{ flex: 0 }}

--- a/apps/expo/components/filter/FilterSheet.tsx
+++ b/apps/expo/components/filter/FilterSheet.tsx
@@ -59,7 +59,7 @@ export default function FilterSheet({ label, children, isActive, snapPoints, ico
 				{({ pressed }) => (
 					<View
 						className={cn(
-							'flex flex-grow-0 flex-row items-center justify-center rounded-full bg-background-surface-secondary px-3 py-2',
+							'squircle flex flex-grow-0 flex-row items-center justify-center rounded-full bg-background-surface-secondary px-3 py-2',
 							pressed && 'opacity-70',
 							{ 'bg-fill-brand-secondary': isActive },
 						)}
@@ -76,7 +76,9 @@ export default function FilterSheet({ label, children, isActive, snapPoints, ico
 				index={snaps.length - 1}
 				snapPoints={snaps}
 				onChange={handleChange}
-				backgroundComponent={(props) => <View {...props} className="rounded-t-xl bg-background" />}
+				backgroundComponent={(props) => (
+					<View {...props} className="squircle rounded-t-xl bg-background" />
+				)}
 				handleIndicatorStyle={{ backgroundColor: colorScheme === 'dark' ? '#333' : '#ccc' }}
 				handleComponent={(props) => (
 					<BottomSheet.Handle

--- a/apps/expo/components/grid/GridImageItem.tsx
+++ b/apps/expo/components/grid/GridImageItem.tsx
@@ -5,9 +5,11 @@ import { Pressable } from 'react-native-gesture-handler'
 
 import { cn } from '~/lib/utils'
 
+import { useColors } from '~/lib/constants'
 import { TurboImage } from '../Image'
 import { Text } from '../ui'
 import { useGridItemSize } from './useGridItemSize'
+import { BorderAndShadow } from '../BorderAndShadow'
 
 type Props = {
 	uri: string
@@ -20,19 +22,14 @@ export default function GridImageItem({ uri, title, href }: Props) {
 	const { itemDimension } = useGridItemSize()
 
 	const router = useRouter()
+	const colors = useColors()
 
 	return (
-		<Pressable onPress={() => router.navigate(href)}>
+		<Pressable onPress={() => router.navigate(href)} style={{}}>
 			{({ pressed }) => (
-				<View className={cn('flex-1 gap-2 pb-4')}>
-					<View
-						className={cn({
-							'opacity-80': pressed,
-						})}
-						style={{
-							height: itemDimension * 1.5,
-							width: itemDimension,
-						}}
+				<View className={cn('flex-1 gap-2 pb-4', { 'opacity-80': pressed })}>
+					<BorderAndShadow
+						style={{ borderRadius: 8, borderWidth: 0.3, shadowRadius: 1.41, elevation: 2 }}
 					>
 						<TurboImage
 							source={{
@@ -41,15 +38,14 @@ export default function GridImageItem({ uri, title, href }: Props) {
 									Authorization: sdk.authorizationHeader || '',
 								},
 							}}
-							resizeMode="cover"
+							resizeMode="stretch"
 							resize={itemDimension * 1.5}
 							style={{
-								height: '100%',
-								width: '100%',
-								borderRadius: 8,
+								width: itemDimension,
+								height: itemDimension / (2 / 3),
 							}}
 						/>
-					</View>
+					</BorderAndShadow>
 
 					<Text
 						size="xl"

--- a/apps/expo/components/grid/GridImageItem.tsx
+++ b/apps/expo/components/grid/GridImageItem.tsx
@@ -5,7 +5,7 @@ import { Pressable } from 'react-native-gesture-handler'
 
 import { cn } from '~/lib/utils'
 
-import { FasterImage } from '../Image'
+import { TurboImage } from '../Image'
 import { Text } from '../ui'
 import { useGridItemSize } from './useGridItemSize'
 
@@ -34,19 +34,19 @@ export default function GridImageItem({ uri, title, href }: Props) {
 							width: itemDimension,
 						}}
 					>
-						<FasterImage
+						<TurboImage
 							source={{
-								url: uri,
+								uri: uri,
 								headers: {
 									Authorization: sdk.authorizationHeader || '',
 								},
-								resizeMode: 'cover',
-								borderRadius: 8,
-								cachePolicy: 'discWithCacheControl',
 							}}
+							resizeMode="cover"
+							resize={itemDimension * 1.5}
 							style={{
 								height: '100%',
 								width: '100%',
+								borderRadius: 8,
 							}}
 						/>
 					</View>

--- a/apps/expo/components/grid/GridImageItem.tsx
+++ b/apps/expo/components/grid/GridImageItem.tsx
@@ -5,7 +5,6 @@ import { Pressable } from 'react-native-gesture-handler'
 
 import { cn } from '~/lib/utils'
 
-import { useColors } from '~/lib/constants'
 import { TurboImage } from '../Image'
 import { Text } from '../ui'
 import { useGridItemSize } from './useGridItemSize'
@@ -22,10 +21,9 @@ export default function GridImageItem({ uri, title, href }: Props) {
 	const { itemDimension } = useGridItemSize()
 
 	const router = useRouter()
-	const colors = useColors()
 
 	return (
-		<Pressable onPress={() => router.navigate(href)} style={{}}>
+		<Pressable onPress={() => router.navigate(href)}>
 			{({ pressed }) => (
 				<View className={cn('flex-1 gap-2 pb-4', { 'opacity-80': pressed })}>
 					<BorderAndShadow

--- a/apps/expo/components/library/LibraryGridItem.tsx
+++ b/apps/expo/components/library/LibraryGridItem.tsx
@@ -12,6 +12,7 @@ import { useActiveServer } from '../activeServer'
 import { useGridItemSize } from '../grid/useGridItemSize'
 import { TurboImage } from '../Image'
 import { Text } from '../ui'
+import { BorderAndShadow } from '../BorderAndShadow'
 
 const fragment = graphql(`
 	fragment LibraryGridItem on Library {
@@ -46,55 +47,46 @@ export default function LibraryGridItem({ library }: Props) {
 		// @ts-expect-error: String path
 		<Pressable onPress={() => router.navigate(href)}>
 			{({ pressed }) => (
-				<View
-					className={cn('relative', {
-						'opacity-80': pressed,
-					})}
-					style={{
-						height: itemDimension * 1.5,
-						width: itemDimension,
-					}}
-				>
-					<LinearGradient
-						colors={['transparent', 'rgba(0, 0, 0, 0.50)', 'rgba(0, 0, 0, 0.85)']}
-						style={{ position: 'absolute', inset: 0, zIndex: 10, borderRadius: 8 }}
-					/>
+				<View className={cn('relative', { 'opacity-80': pressed })}>
+					<BorderAndShadow
+						style={{ borderRadius: 8, borderWidth: 0.3, shadowRadius: 1.41, elevation: 2 }}
+					>
+						<LinearGradient
+							colors={['transparent', 'rgba(0, 0, 0, 0.50)', 'rgba(0, 0, 0, 0.85)']}
+							style={{ position: 'absolute', inset: 0, zIndex: 10 }}
+						/>
 
-					<TurboImage
-						source={{
-							uri: uri,
-							headers: {
-								Authorization: sdk.authorizationHeader || '',
-							},
-						}}
-						resizeMode="cover"
-						// This 1.5 is unrelated to height. It is to do downscaling, but not too much.
-						resize={itemDimension * 1.5}
-						style={{
-							height: '100%',
-							width: '100%',
-							borderRadius: 8,
-						}}
-					/>
-
-					<View className="absolute inset-0 z-20 w-full items-center justify-center">
-						<Text
-							size="2xl"
-							className="font-bold leading-8 tracking-wide"
-							numberOfLines={2}
-							ellipsizeMode="tail"
-							style={{
-								maxWidth: itemDimension - 4,
-								textShadowOffset: { width: 2, height: 1 },
-								textShadowRadius: 2,
-								textShadowColor: 'rgba(0, 0, 0, 0.5)',
-								zIndex: 20,
-								color: COLORS.dark.foreground.DEFAULT,
+						<TurboImage
+							source={{
+								uri: uri,
+								headers: {
+									Authorization: sdk.authorizationHeader || '',
+								},
 							}}
-						>
-							{title}
-						</Text>
-					</View>
+							resizeMode="stretch"
+							resize={itemDimension * 1.5}
+							style={{ height: itemDimension / (2 / 3), width: itemDimension }}
+						/>
+
+						<View className="absolute inset-0 z-20 w-full items-center justify-center">
+							<Text
+								size="2xl"
+								className="font-bold leading-8 tracking-wide"
+								numberOfLines={2}
+								ellipsizeMode="tail"
+								style={{
+									maxWidth: itemDimension - 4,
+									textShadowOffset: { width: 2, height: 1 },
+									textShadowRadius: 2,
+									textShadowColor: 'rgba(0, 0, 0, 0.5)',
+									zIndex: 20,
+									color: COLORS.dark.foreground.DEFAULT,
+								}}
+							>
+								{title}
+							</Text>
+						</View>
+					</BorderAndShadow>
 				</View>
 			)}
 		</Pressable>

--- a/apps/expo/components/library/LibraryGridItem.tsx
+++ b/apps/expo/components/library/LibraryGridItem.tsx
@@ -10,7 +10,7 @@ import { cn } from '~/lib/utils'
 
 import { useActiveServer } from '../activeServer'
 import { useGridItemSize } from '../grid/useGridItemSize'
-import { FasterImage } from '../Image'
+import { TurboImage } from '../Image'
 import { Text } from '../ui'
 
 const fragment = graphql(`
@@ -60,19 +60,20 @@ export default function LibraryGridItem({ library }: Props) {
 						style={{ position: 'absolute', inset: 0, zIndex: 10, borderRadius: 8 }}
 					/>
 
-					<FasterImage
+					<TurboImage
 						source={{
-							url: uri,
+							uri: uri,
 							headers: {
 								Authorization: sdk.authorizationHeader || '',
 							},
-							resizeMode: 'cover',
-							borderRadius: 8,
-							cachePolicy: 'discWithCacheControl',
 						}}
+						resizeMode="cover"
+						// This 1.5 is unrelated to height. It is to do downscaling, but not too much.
+						resize={itemDimension * 1.5}
 						style={{
 							height: '100%',
 							width: '100%',
+							borderRadius: 8,
 						}}
 					/>
 

--- a/apps/expo/components/library/LibrarySearchItem.tsx
+++ b/apps/expo/components/library/LibrarySearchItem.tsx
@@ -7,7 +7,7 @@ import { Pressable } from 'react-native-gesture-handler'
 import { useDisplay } from '~/lib/hooks'
 
 import { useActiveServer } from '../activeServer'
-import { FasterImage } from '../Image'
+import { TurboImage } from '../Image'
 import { Text } from '../ui'
 
 const fragment = graphql(`
@@ -51,16 +51,16 @@ export default function LibrarySearchItem({ library }: Props) {
 			}}
 		>
 			<View className="flex-row items-start gap-4 py-4">
-				<FasterImage
+				<TurboImage
 					source={{
-						url: data.thumbnail.url,
+						uri: data.thumbnail.url,
 						headers: {
 							Authorization: sdk.authorizationHeader || '',
 						},
-						resizeMode: 'fill',
-						borderRadius: 8,
 					}}
-					style={{ width: 75, height: 75 / (2 / 3) }}
+					resizeMode="stretch"
+					resize={75 * 1.5}
+					style={{ width: 75, height: 75 / (2 / 3), borderRadius: 8 }}
 				/>
 
 				<View className="flex-1">

--- a/apps/expo/components/library/LibrarySearchItem.tsx
+++ b/apps/expo/components/library/LibrarySearchItem.tsx
@@ -9,6 +9,7 @@ import { useDisplay } from '~/lib/hooks'
 import { useActiveServer } from '../activeServer'
 import { TurboImage } from '../Image'
 import { Text } from '../ui'
+import { BorderAndShadow } from '../BorderAndShadow'
 
 const fragment = graphql(`
 	fragment LibrarySearchItem on Library {
@@ -50,18 +51,22 @@ export default function LibrarySearchItem({ library }: Props) {
 				width: width * 0.75,
 			}}
 		>
-			<View className="flex-row items-start gap-4 py-4">
-				<TurboImage
-					source={{
-						uri: data.thumbnail.url,
-						headers: {
-							Authorization: sdk.authorizationHeader || '',
-						},
-					}}
-					resizeMode="stretch"
-					resize={75 * 1.5}
-					style={{ width: 75, height: 75 / (2 / 3), borderRadius: 8 }}
-				/>
+			<View className="flex-row items-start gap-4 p-4">
+				<BorderAndShadow
+					style={{ borderRadius: 4, borderWidth: 0.3, shadowRadius: 1.41, elevation: 2 }}
+				>
+					<TurboImage
+						source={{
+							uri: data.thumbnail.url,
+							headers: {
+								Authorization: sdk.authorizationHeader || '',
+							},
+						}}
+						resizeMode="stretch"
+						resize={75 * 1.5}
+						style={{ width: 75, height: 75 / (2 / 3) }}
+					/>
+				</BorderAndShadow>
 
 				<View className="flex-1">
 					<Text>{data.name}</Text>

--- a/apps/expo/components/opds/EmptyFeed.tsx
+++ b/apps/expo/components/opds/EmptyFeed.tsx
@@ -11,9 +11,9 @@ type Props = {
 }
 export default function EmptyFeed({ message }: Props) {
 	return (
-		<View className="h-24 w-full items-center justify-center gap-2 rounded-lg border border-dashed border-edge p-3">
+		<View className="squircle h-24 w-full items-center justify-center gap-2 rounded-lg border border-dashed border-edge p-3">
 			<View className="relative flex justify-center">
-				<View className="flex items-center justify-center rounded-lg bg-background-surface p-2">
+				<View className="squircle flex items-center justify-center rounded-lg bg-background-surface p-2">
 					<Rss className="h-6 w-6 text-foreground-muted" />
 					<Slash className="absolute h-6 w-6 scale-x-[-1] transform text-foreground opacity-80" />
 				</View>

--- a/apps/expo/components/opds/MaybeErrorFeed.tsx
+++ b/apps/expo/components/opds/MaybeErrorFeed.tsx
@@ -26,7 +26,7 @@ export default function MaybeErrorFeed({ error }: Props) {
 				<View className="flex-1 items-center gap-2">
 					<Text>{`This feed is not valid. It contains ${error.issues.length} issue${error.issues.length !== 1 ? 's' : ''}:`}</Text>
 
-					<View className="rounded-xl bg-background-surface p-4">
+					<View className="squircle rounded-xl bg-background-surface p-4">
 						<Text>{JSON.stringify(error.issues, null, 2)}</Text>
 					</View>
 				</View>
@@ -37,7 +37,7 @@ export default function MaybeErrorFeed({ error }: Props) {
 					<Text>{error.message}</Text>
 
 					{typeof error.cause === 'string' && (
-						<View className="rounded-xl bg-background-surface p-4">
+						<View className="squircle rounded-xl bg-background-surface p-4">
 							<Text>{error.cause}</Text>
 						</View>
 					)}
@@ -53,7 +53,7 @@ export default function MaybeErrorFeed({ error }: Props) {
 			<ScrollView className="flex-1 bg-background p-4">
 				<View className="flex-1 items-center justify-center gap-2">
 					<View className="relative flex justify-center">
-						<View className="flex items-center justify-center rounded-lg bg-background-surface p-2">
+						<View className="squircle flex items-center justify-center rounded-lg bg-background-surface p-2">
 							<Rss className="h-6 w-6 text-foreground-muted" />
 							<Slash className="absolute h-6 w-6 scale-x-[-1] transform text-foreground opacity-80" />
 						</View>

--- a/apps/expo/components/opds/Navigation.tsx
+++ b/apps/expo/components/opds/Navigation.tsx
@@ -59,9 +59,9 @@ export default function Navigation({ navigation, renderEmpty }: Props) {
 			))}
 
 			{!navigation.length && (
-				<View className="h-24 w-full items-center justify-center gap-2 rounded-lg border border-dashed border-edge p-3">
+				<View className="squircle h-24 w-full items-center justify-center gap-2 rounded-lg border border-dashed border-edge p-3">
 					<View className="relative flex justify-center">
-						<View className="flex items-center justify-center rounded-lg bg-background-surface p-2">
+						<View className="squircle flex items-center justify-center rounded-lg bg-background-surface p-2">
 							<Rss className="h-6 w-6 text-foreground-muted" />
 							<Slash className="absolute h-6 w-6 scale-x-[-1] transform text-foreground opacity-80" />
 						</View>

--- a/apps/expo/components/opds/PublicationFeed.tsx
+++ b/apps/expo/components/opds/PublicationFeed.tsx
@@ -15,6 +15,7 @@ import RefreshControl from '../RefreshControl'
 import { Text } from '../ui'
 import FeedTitle from './FeedTitle'
 import { getPublicationThumbnailURL } from './utils'
+import { BorderAndShadow } from '../BorderAndShadow'
 
 type Props = {
 	feed: OPDSFeed
@@ -135,11 +136,13 @@ export default function PublicationFeed({ feed, onRefresh, isRefreshing }: Props
 							{({ pressed }) => (
 								<View
 									className={cn('xs:items-center flex', {
-										'opacity-90': pressed,
+										'opacity-80': pressed,
 										'py-1': isXSmall,
 									})}
 								>
-									<View className="relative aspect-[2/3] overflow-hidden rounded-lg">
+									<BorderAndShadow
+										style={{ borderRadius: 6, borderWidth: 0.3, shadowRadius: 1.41, elevation: 2 }}
+									>
 										<TurboImage
 											className="z-0"
 											source={{
@@ -148,13 +151,11 @@ export default function PublicationFeed({ feed, onRefresh, isRefreshing }: Props
 													Authorization: sdk.authorizationHeader || '',
 												},
 											}}
-											resizeMode="contain"
-											style={{
-												height: itemHeight,
-												width: itemWidth,
-											}}
+											resizeMode="stretch"
+											resize={itemWidth * 1.5}
+											style={{ height: itemHeight, width: itemWidth }}
 										/>
-									</View>
+									</BorderAndShadow>
 
 									<View
 										style={{

--- a/apps/expo/components/opds/PublicationFeed.tsx
+++ b/apps/expo/components/opds/PublicationFeed.tsx
@@ -10,7 +10,7 @@ import { useDisplay } from '~/lib/hooks'
 import { cn } from '~/lib/utils'
 
 import { useActiveServer } from '../activeServer'
-import { Image } from '../Image'
+import { TurboImage } from '../Image'
 import RefreshControl from '../RefreshControl'
 import { Text } from '../ui'
 import FeedTitle from './FeedTitle'
@@ -140,15 +140,15 @@ export default function PublicationFeed({ feed, onRefresh, isRefreshing }: Props
 									})}
 								>
 									<View className="relative aspect-[2/3] overflow-hidden rounded-lg">
-										<Image
+										<TurboImage
 											className="z-0"
 											source={{
-												uri: thumbnailURL,
+												uri: thumbnailURL || '',
 												headers: {
-													Authorization: sdk.authorizationHeader,
+													Authorization: sdk.authorizationHeader || '',
 												},
 											}}
-											contentFit="scale-down"
+											resizeMode="contain"
 											style={{
 												height: itemHeight,
 												width: itemWidth,

--- a/apps/expo/components/opds/PublicationGroup.tsx
+++ b/apps/expo/components/opds/PublicationGroup.tsx
@@ -10,7 +10,7 @@ import { useDisplay } from '~/lib/hooks'
 import { cn } from '~/lib/utils'
 
 import { useActiveServer } from '../activeServer'
-import { FasterImage } from '../Image'
+import { TurboImage } from '../Image'
 import { Text } from '../ui'
 import EmptyFeed from './EmptyFeed'
 import { FeedComponentOptions } from './types'
@@ -98,20 +98,19 @@ export default function PublicationGroup({
 									})}
 								>
 									<View style={{ height: isTablet ? 225 : 150, width: itemWidth }}>
-										<FasterImage
+										<TurboImage
 											source={{
-												url: thumbnailURL || '',
+												uri: thumbnailURL || '',
 												headers: {
 													Authorization: sdk.authorizationHeader || '',
 													[STUMP_SAVE_BASIC_SESSION_HEADER]: 'false',
 												},
-												resizeMode: 'cover',
-												borderRadius: 8,
-												cachePolicy: 'discWithCacheControl',
 											}}
+											resizeMode="cover"
 											style={{
 												height: '100%',
 												width: '100%',
+												borderRadius: 8,
 											}}
 										/>
 									</View>

--- a/apps/expo/components/opds/PublicationGroup.tsx
+++ b/apps/expo/components/opds/PublicationGroup.tsx
@@ -14,6 +14,7 @@ import { TurboImage } from '../Image'
 import { Text } from '../ui'
 import EmptyFeed from './EmptyFeed'
 import { FeedComponentOptions } from './types'
+import { BorderAndShadow } from '../BorderAndShadow'
 
 type Props = {
 	group: OPDSFeedGroup
@@ -94,26 +95,27 @@ export default function PublicationGroup({
 							{({ pressed }) => (
 								<View
 									className={cn('flex items-start px-1 tablet:px-2', {
-										'opacity-90': pressed,
+										'opacity-80': pressed,
 									})}
 								>
-									<View style={{ height: isTablet ? 225 : 150, width: itemWidth }}>
-										<TurboImage
-											source={{
-												uri: thumbnailURL || '',
-												headers: {
-													Authorization: sdk.authorizationHeader || '',
-													[STUMP_SAVE_BASIC_SESSION_HEADER]: 'false',
-												},
-											}}
-											resizeMode="cover"
-											style={{
-												height: '100%',
-												width: '100%',
-												borderRadius: 8,
-											}}
-										/>
-									</View>
+									<BorderAndShadow
+										style={{ borderRadius: 6, borderWidth: 0.3, shadowRadius: 1.41, elevation: 2 }}
+									>
+										<View style={{ height: isTablet ? 225 : 150, width: itemWidth }}>
+											<TurboImage
+												source={{
+													uri: thumbnailURL || '',
+													headers: {
+														Authorization: sdk.authorizationHeader || '',
+														[STUMP_SAVE_BASIC_SESSION_HEADER]: 'false',
+													},
+												}}
+												resizeMode="stretch"
+												resize={itemWidth * 1.5}
+												style={{ height: '100%', width: '100%' }}
+											/>
+										</View>
+									</BorderAndShadow>
 
 									<View>
 										<Text className="mt-2" style={{ maxWidth: itemWidth - 4 }} numberOfLines={2}>

--- a/apps/expo/components/savedServer/AddOrEditServerForm.tsx
+++ b/apps/expo/components/savedServer/AddOrEditServerForm.tsx
@@ -120,7 +120,7 @@ export default function AddOrEditServerForm({
 	const renderAuthMode = () => {
 		if (authMode === 'default') {
 			return (
-				<View className="rounded-lg border border-dashed border-edge p-3">
+				<View className="squircle rounded-lg border border-dashed border-edge p-3">
 					<Text className="text-foreground-muted">
 						You will be prompted to login when accessing content as needed
 					</Text>
@@ -340,7 +340,7 @@ export default function AddOrEditServerForm({
 				<Button
 					variant="outline"
 					size="sm"
-					className={cn('rounded-lg bg-background-surface', {
+					className={cn('squircle rounded-lg bg-background-surface', {
 						'opacity-70': !url,
 						'bg-fill-success-secondary': didConnect,
 					})}
@@ -355,7 +355,7 @@ export default function AddOrEditServerForm({
 				<Text className="flex-1 text-base font-medium text-foreground-muted">Custom Headers</Text>
 
 				{formValues.customHeaders?.length && (
-					<View className="w-full overflow-hidden rounded-lg border border-edge">
+					<View className="squircle w-full overflow-hidden rounded-lg border border-edge">
 						{formValues.customHeaders.map((header, index) => (
 							<Swipeable
 								key={index}

--- a/apps/expo/components/savedServer/AddServerDialog.tsx
+++ b/apps/expo/components/savedServer/AddServerDialog.tsx
@@ -79,7 +79,9 @@ export default function AddServerDialog() {
 				index={snapPoints.length - 1}
 				snapPoints={snapPoints}
 				onChange={handleChange}
-				backgroundComponent={(props) => <View {...props} className="rounded-t-xl bg-background" />}
+				backgroundComponent={(props) => (
+					<View {...props} className="squircle rounded-t-xl bg-background" />
+				)}
 				handleIndicatorStyle={{ backgroundColor: colorScheme === 'dark' ? '#333' : '#ccc' }}
 				handleComponent={(props) => (
 					<BottomSheet.Handle

--- a/apps/expo/components/savedServer/DeleteServerConfirmation.tsx
+++ b/apps/expo/components/savedServer/DeleteServerConfirmation.tsx
@@ -20,7 +20,7 @@ export default function DeleteServerConfirmation({ deletingServer, onClose, onCo
 				</Dialog.Header>
 
 				{deletingServer?.stumpOPDS && (
-					<View className="rounded-xl bg-fill-danger-secondary p-3">
+					<View className="squircle rounded-xl bg-fill-danger-secondary p-3">
 						<Text className="text-fill-danger">
 							This server is registered for both Stump and OPDS. Deleting it will remove both
 							entries

--- a/apps/expo/components/savedServer/EditServerDialog.tsx
+++ b/apps/expo/components/savedServer/EditServerDialog.tsx
@@ -49,7 +49,9 @@ export default function EditServerDialog({ editingServer, onClose, onSubmit }: P
 				snapPoints={snapPoints}
 				onChange={handleChange}
 				open={isOpen}
-				backgroundComponent={(props) => <View {...props} className="rounded-t-xl bg-background" />}
+				backgroundComponent={(props) => (
+					<View {...props} className="squircle rounded-t-xl bg-background" />
+				)}
 				handleIndicatorStyle={{ backgroundColor: colorScheme === 'dark' ? '#333' : '#ccc' }}
 				handleComponent={(props) => (
 					<BottomSheet.Handle

--- a/apps/expo/components/savedServer/SavedServerListItem.tsx
+++ b/apps/expo/components/savedServer/SavedServerListItem.tsx
@@ -35,7 +35,7 @@ export default function SavedServerListItem({ server, onEdit, onDelete, forceOPD
 	const router = useRouter()
 
 	return (
-		<View className="w-full rounded-2xl">
+		<View className="w-full">
 			<ContextMenu.Root>
 				<ContextMenu.Trigger className="w-full">
 					<Pressable
@@ -49,7 +49,7 @@ export default function SavedServerListItem({ server, onEdit, onDelete, forceOPD
 							})
 						}
 					>
-						<View className="bg-background-muted w-full items-start rounded-2xl border border-edge bg-background-surface p-3">
+						<View className="bg-background-muted squircle w-full items-start rounded-2xl border border-edge bg-background-surface p-3">
 							<View className="flex-1 items-start justify-center gap-1">
 								<Text className="text-lg">{server.name}</Text>
 								<Text className="flex-1 text-foreground-muted">{formatURL(server.url)}</Text>

--- a/apps/expo/components/series/RecentlyAddedSeriesItem.tsx
+++ b/apps/expo/components/series/RecentlyAddedSeriesItem.tsx
@@ -2,12 +2,12 @@ import { useSDK } from '@stump/client'
 import { FragmentType, graphql, useFragment } from '@stump/graphql'
 import dayjs from 'dayjs'
 import { useRouter } from 'expo-router'
-import { Easing, Platform, View } from 'react-native'
+import { Easing, View } from 'react-native'
 import { easeGradient } from 'react-native-easing-gradient'
 import { Pressable } from 'react-native-gesture-handler'
 import LinearGradient from 'react-native-linear-gradient'
 
-import { COLORS, useColors } from '~/lib/constants'
+import { COLORS } from '~/lib/constants'
 
 import { useActiveServer } from '../activeServer'
 import { TurboImage } from '../Image'
@@ -44,7 +44,6 @@ export default function RecentlyAddedSeriesItem({ series }: Props) {
 
 	const data = useFragment(fragment, series)
 	const router = useRouter()
-	const colors = useColors()
 
 	const { colors: gradientColors, locations: gradientLocations } = easeGradient({
 		colorStops: {

--- a/apps/expo/components/series/RecentlyAddedSeriesItem.tsx
+++ b/apps/expo/components/series/RecentlyAddedSeriesItem.tsx
@@ -7,11 +7,12 @@ import { easeGradient } from 'react-native-easing-gradient'
 import { Pressable } from 'react-native-gesture-handler'
 import LinearGradient from 'react-native-linear-gradient'
 
-import { COLORS } from '~/lib/constants'
+import { COLORS, useColors } from '~/lib/constants'
 
 import { useActiveServer } from '../activeServer'
 import { TurboImage } from '../Image'
 import { Text } from '../ui'
+import { BorderAndShadow } from '../BorderAndShadow'
 
 const fragment = graphql(`
 	fragment RecentlyAddedSeriesItem on Series {
@@ -43,6 +44,7 @@ export default function RecentlyAddedSeriesItem({ series }: Props) {
 
 	const data = useFragment(fragment, series)
 	const router = useRouter()
+	const colors = useColors()
 
 	const { colors: gradientColors, locations: gradientLocations } = easeGradient({
 		colorStops: {
@@ -54,63 +56,61 @@ export default function RecentlyAddedSeriesItem({ series }: Props) {
 	})
 
 	return (
-		<Pressable
-			className="relative shrink-0"
-			onPress={() => router.push(`/server/${serverID}/series/${data.id}`)}
-			style={{
-				shadowColor: '#000',
-				shadowOffset: { width: 0, height: 1 },
-				shadowOpacity: 0.2,
-				shadowRadius: 1.41,
-				borderRadius: 8,
-			}}
-		>
-			<LinearGradient
-				colors={gradientColors}
-				style={{ position: 'absolute', inset: 0, zIndex: 10, borderRadius: 8 }}
-				locations={gradientLocations}
-			/>
+		<Pressable onPress={() => router.push(`/server/${serverID}/series/${data.id}`)}>
+			{({ pressed }) => (
+				<View className="relative" style={{ opacity: pressed ? 0.8 : 1 }}>
+					<BorderAndShadow
+						style={{ borderRadius: 8, borderWidth: 0.3, shadowRadius: 1.41, elevation: 2 }}
+					>
+						<LinearGradient
+							colors={gradientColors}
+							style={{ position: 'absolute', inset: 0, zIndex: 10 }}
+							locations={gradientLocations}
+						/>
 
-			<TurboImage
-				source={{
-					uri: data.thumbnail.url,
-					headers: {
-						Authorization: sdk.authorizationHeader || '',
-					},
-				}}
-				resizeMode="stretch"
-				resize={240 * (2 / 3)}
-				style={{ width: 240 * (2 / 3), height: 240, borderRadius: 8 }}
-			/>
+						<TurboImage
+							source={{
+								uri: data.thumbnail.url,
+								headers: {
+									Authorization: sdk.authorizationHeader || '',
+								},
+							}}
+							resizeMode="stretch"
+							resize={240 * (2 / 3)}
+							style={{ width: 240 * (2 / 3), height: 240 }}
+						/>
 
-			<View className="absolute bottom-0 z-20 w-full p-2">
-				<Text
-					className="flex-1 flex-wrap text-xl font-bold"
-					style={{
-						textShadowOffset: { width: 2, height: 1 },
-						textShadowRadius: 2,
-						textShadowColor: 'rgba(0, 0, 0, 0.5)',
-						zIndex: 20,
-						color: COLORS.dark.foreground.DEFAULT,
-					}}
-					numberOfLines={0}
-				>
-					{data.resolvedName}
-				</Text>
-				<Text
-					className="flex-1 flex-wrap font-medium"
-					style={{
-						textShadowOffset: { width: 2, height: 1 },
-						textShadowRadius: 2,
-						textShadowColor: 'rgba(0, 0, 0, 0.5)',
-						zIndex: 20,
-						color: COLORS.dark.foreground.subtle,
-					}}
-					numberOfLines={0}
-				>
-					{dayjs(data.createdAt).fromNow()}
-				</Text>
-			</View>
+						<View className="absolute bottom-0 z-20 w-full p-2">
+							<Text
+								className="flex-1 flex-wrap text-xl font-bold"
+								style={{
+									textShadowOffset: { width: 2, height: 1 },
+									textShadowRadius: 2,
+									textShadowColor: 'rgba(0, 0, 0, 0.5)',
+									zIndex: 20,
+									color: COLORS.dark.foreground.DEFAULT,
+								}}
+								numberOfLines={0}
+							>
+								{data.resolvedName}
+							</Text>
+							<Text
+								className="flex-1 flex-wrap font-medium"
+								style={{
+									textShadowOffset: { width: 2, height: 1 },
+									textShadowRadius: 2,
+									textShadowColor: 'rgba(0, 0, 0, 0.5)',
+									zIndex: 20,
+									color: COLORS.dark.foreground.subtle,
+								}}
+								numberOfLines={0}
+							>
+								{dayjs(data.createdAt).fromNow()}
+							</Text>
+						</View>
+					</BorderAndShadow>
+				</View>
+			)}
 		</Pressable>
 	)
 

--- a/apps/expo/components/series/RecentlyAddedSeriesItem.tsx
+++ b/apps/expo/components/series/RecentlyAddedSeriesItem.tsx
@@ -10,7 +10,7 @@ import LinearGradient from 'react-native-linear-gradient'
 import { COLORS } from '~/lib/constants'
 
 import { useActiveServer } from '../activeServer'
-import { FasterImage } from '../Image'
+import { TurboImage } from '../Image'
 import { Text } from '../ui'
 
 const fragment = graphql(`
@@ -71,17 +71,16 @@ export default function RecentlyAddedSeriesItem({ series }: Props) {
 				locations={gradientLocations}
 			/>
 
-			<FasterImage
+			<TurboImage
 				source={{
-					url: data.thumbnail.url,
+					uri: data.thumbnail.url,
 					headers: {
 						Authorization: sdk.authorizationHeader || '',
 					},
-					resizeMode: 'fill',
-					// FIXME: I REALLY shouldn't have to do this
-					borderRadius: Platform.OS === 'android' ? 24 : 8,
 				}}
-				style={{ width: 240 * (2 / 3), height: 240 }}
+				resizeMode="stretch"
+				resize={240 * (2 / 3)}
+				style={{ width: 240 * (2 / 3), height: 240, borderRadius: 8 }}
 			/>
 
 			<View className="absolute bottom-0 z-20 w-full p-2">

--- a/apps/expo/components/series/SeriesSearchItem.tsx
+++ b/apps/expo/components/series/SeriesSearchItem.tsx
@@ -9,6 +9,7 @@ import { useDisplay } from '~/lib/hooks'
 import { useActiveServer } from '../activeServer'
 import { TurboImage } from '../Image'
 import { Text } from '../ui'
+import { BorderAndShadow } from '../BorderAndShadow'
 
 const fragment = graphql(`
 	fragment SeriesSearchItem on Series {
@@ -54,24 +55,28 @@ export default function SeriesSearchItem({ series }: Props) {
 				width: width * 0.75,
 			}}
 		>
-			<View className="flex-row items-start gap-4 py-4">
-				<TurboImage
-					source={{
-						uri: data.thumbnail.url,
-						headers: {
-							Authorization: sdk.authorizationHeader || '',
-						},
-					}}
-					resizeMode="stretch"
-					resize={75 * 1.5}
-					style={{ width: 75, height: 75 / (2 / 3), borderRadius: 8 }}
-				/>
+			<View className="flex-row items-start gap-4 p-4">
+				<BorderAndShadow
+					style={{ borderRadius: 4, borderWidth: 0.3, shadowRadius: 1.41, elevation: 2 }}
+				>
+					<TurboImage
+						source={{
+							uri: data.thumbnail.url,
+							headers: {
+								Authorization: sdk.authorizationHeader || '',
+							},
+						}}
+						resizeMode="stretch"
+						resize={75 * 1.5}
+						style={{ width: 75, height: 75 / (2 / 3) }}
+					/>
+				</BorderAndShadow>
 
 				<View className="flex flex-1 flex-col gap-1">
 					<Text>{data.resolvedName}</Text>
 
 					<Text className="text-foreground-muted">
-						{data.readCount}/{data.mediaCount} books • {data.percentageCompleted}%
+						{data.readCount}/{data.mediaCount} books • {data.percentageCompleted.toFixed(1)}%
 					</Text>
 				</View>
 			</View>

--- a/apps/expo/components/series/SeriesSearchItem.tsx
+++ b/apps/expo/components/series/SeriesSearchItem.tsx
@@ -7,7 +7,7 @@ import { Pressable } from 'react-native-gesture-handler'
 import { useDisplay } from '~/lib/hooks'
 
 import { useActiveServer } from '../activeServer'
-import { FasterImage } from '../Image'
+import { TurboImage } from '../Image'
 import { Text } from '../ui'
 
 const fragment = graphql(`
@@ -55,16 +55,16 @@ export default function SeriesSearchItem({ series }: Props) {
 			}}
 		>
 			<View className="flex-row items-start gap-4 py-4">
-				<FasterImage
+				<TurboImage
 					source={{
-						url: data.thumbnail.url,
+						uri: data.thumbnail.url,
 						headers: {
 							Authorization: sdk.authorizationHeader || '',
 						},
-						resizeMode: 'fill',
-						borderRadius: 8,
 					}}
-					style={{ width: 75, height: 75 / (2 / 3) }}
+					resizeMode="stretch"
+					resize={75 * 1.5}
+					style={{ width: 75, height: 75 / (2 / 3), borderRadius: 8 }}
 				/>
 
 				<View className="flex flex-1 flex-col gap-1">

--- a/apps/expo/components/series/filterHeader/Sort.tsx
+++ b/apps/expo/components/series/filterHeader/Sort.tsx
@@ -87,7 +87,7 @@ export default function Sort() {
 					<RadioGroup
 						value={direction}
 						onValueChange={handleSortDirectionChanged}
-						className="gap-0 rounded-lg border border-edge bg-background-surface"
+						className="squircle gap-0 rounded-lg border border-edge bg-background-surface"
 					>
 						<View className="flex flex-row items-center gap-3 p-3">
 							<RadioGroupItem value="ASC" id="ascending" />
@@ -107,7 +107,7 @@ export default function Sort() {
 					<RadioGroup
 						value={field}
 						onValueChange={(value) => handleSortFieldChanged(value, false)}
-						className="gap-0 rounded-lg border border-edge bg-background-surface"
+						className="squircle gap-0 rounded-lg border border-edge bg-background-surface"
 					>
 						<View className="flex flex-row items-center gap-3 p-3">
 							<RadioGroupItem value="NAME" id="name" />
@@ -143,7 +143,7 @@ export default function Sort() {
 					<RadioGroup
 						value={field}
 						onValueChange={(value) => handleSortFieldChanged(value, true)}
-						className="gap-0 rounded-lg border border-edge bg-background-surface"
+						className="squircle gap-0 rounded-lg border border-edge bg-background-surface"
 					>
 						<View className="flex flex-row items-center gap-3 p-3">
 							<RadioGroupItem value="TITLE" id="title" />

--- a/apps/expo/components/series/filterHeader/Status.tsx
+++ b/apps/expo/components/series/filterHeader/Status.tsx
@@ -79,7 +79,7 @@ export default function Status() {
 					<Text className="text-foreground-muted">Filter by status</Text>
 				</View>
 
-				<View className="gap-0 rounded-lg border border-edge bg-background-surface">
+				<View className="squircle gap-0 rounded-lg border border-edge bg-background-surface">
 					{STATUSES.map((status, idx) => (
 						<Fragment key={status}>
 							<View className="flex flex-row items-center gap-3 p-3">

--- a/apps/expo/components/ui/avatar.tsx
+++ b/apps/expo/components/ui/avatar.tsx
@@ -11,7 +11,10 @@ const Avatar = React.forwardRef<AvatarPrimitive.RootRef, AvatarPrimitive.RootPro
 	({ className, ...props }, ref) => (
 		<AvatarPrimitiveRoot
 			ref={ref}
-			className={cn('relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full', className)}
+			className={cn(
+				'squircle relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full',
+				className,
+			)}
 			{...props}
 		/>
 	),
@@ -34,7 +37,7 @@ const AvatarFallback = React.forwardRef<AvatarPrimitive.FallbackRef, AvatarPrimi
 		<AvatarPrimitiveFallback
 			ref={ref}
 			className={cn(
-				'bg-muted flex h-full w-full items-center justify-center rounded-full',
+				'bg-muted squircle flex h-full w-full items-center justify-center rounded-full',
 				className,
 			)}
 			{...props}

--- a/apps/expo/components/ui/badge.tsx
+++ b/apps/expo/components/ui/badge.tsx
@@ -7,7 +7,7 @@ import { TextClassContext } from '~/components/ui/text'
 import { cn } from '~/lib/utils'
 
 const badgeVariants = cva(
-	'web:inline-flex items-center rounded-lg border border-border px-2.5 py-2 web:transition-colors web:focus:outline-none web:focus:ring-2 web:focus:ring-ring web:focus:ring-offset-2',
+	'web:inline-flex items-center squircle rounded-lg border border-border px-2.5 py-2 web:transition-colors web:focus:outline-none web:focus:ring-2 web:focus:ring-ring web:focus:ring-offset-2',
 	{
 		variants: {
 			variant: {

--- a/apps/expo/components/ui/bottom-sheet/index.tsx
+++ b/apps/expo/components/ui/bottom-sheet/index.tsx
@@ -74,7 +74,7 @@ const BottomSheetTextInput = forwardRef<
 				ref={ref}
 				{...rest}
 				className={cn(
-					'native:h-12 native:text-lg native:leading-[1.25] h-10 rounded-lg border border-edge bg-background px-3 text-base text-foreground file:border-0 file:bg-transparent file:font-medium lg:text-sm',
+					'native:h-12 native:text-lg native:leading-[1.25] squircle h-10 rounded-lg border border-edge bg-background px-3 text-base text-foreground file:border-0 file:bg-transparent file:font-medium lg:text-sm',
 					rest.editable === false && 'opacity-50',
 					{ 'border-edge-danger': !!errorMessage },
 					rest.className,

--- a/apps/expo/components/ui/button.tsx
+++ b/apps/expo/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { Pressable } from 'react-native'
 import { TextClassContext } from '~/components/ui/text'
 import { cn } from '~/lib/utils'
 
-const buttonVariants = cva('group flex items-center justify-center rounded-lg', {
+const buttonVariants = cva('group flex items-center justify-center squircle rounded-lg', {
 	variants: {
 		variant: {
 			brand: 'bg-fill-brand active:opacity-90',
@@ -17,9 +17,9 @@ const buttonVariants = cva('group flex items-center justify-center rounded-lg', 
 		},
 		size: {
 			default: 'h-10 px-4 py-2 native:h-12 native:px-5 native:py-3 tablet:h-14',
-			sm: 'h-9 rounded-lg px-3',
-			md: 'h-10 rounded-lg px-4',
-			lg: 'h-11 rounded-lg px-8 native:h-14',
+			sm: 'h-9 squircle rounded-lg px-3',
+			md: 'h-10 squircle rounded-lg px-4',
+			lg: 'h-11 squircle rounded-lg px-8 native:h-14',
 			icon: 'h-10 w-10',
 		},
 	},

--- a/apps/expo/components/ui/card.tsx
+++ b/apps/expo/components/ui/card.tsx
@@ -8,7 +8,7 @@ import { cn } from '~/lib/utils'
 const Card = React.forwardRef<ViewRef, ViewProps>(({ className, ...props }, ref) => (
 	<View
 		ref={ref}
-		className={cn('rounded-lg border border-edge bg-background', className)}
+		className={cn('squircle rounded-lg border border-edge bg-background', className)}
 		{...props}
 	/>
 ))

--- a/apps/expo/components/ui/checkbox.tsx
+++ b/apps/expo/components/ui/checkbox.tsx
@@ -22,7 +22,7 @@ function Checkbox({
 	return (
 		<CheckboxPrimitive.Root
 			className={cn(
-				'h-6 w-6 shrink-0 rounded-md border border-edge bg-background-surface shadow-sm shadow-black/5',
+				'squircle h-6 w-6 shrink-0 rounded-md border border-edge bg-background-surface shadow-sm shadow-black/5',
 				Platform.select({
 					native: 'overflow-hidden',
 				}),
@@ -35,7 +35,7 @@ function Checkbox({
 		>
 			<CheckboxPrimitive.Indicator
 				className={cn(
-					'h-full w-full items-center justify-center rounded-md bg-fill-brand',
+					'squircle h-full w-full items-center justify-center rounded-md bg-fill-brand',
 					indicatorClassName,
 				)}
 			>

--- a/apps/expo/components/ui/dialog.tsx
+++ b/apps/expo/components/ui/dialog.tsx
@@ -71,7 +71,7 @@ const DialogContent = React.forwardRef<
 				<DialogPrimitive.Content
 					ref={ref}
 					className={cn(
-						'border-border web:cursor-default web:duration-200 max-w-lg gap-4 rounded-lg border bg-background-surface p-6 shadow-lg',
+						'border-border web:cursor-default web:duration-200 squircle max-w-lg gap-4 rounded-lg border bg-background-surface p-6 shadow-lg',
 						open
 							? 'web:animate-in web:fade-in-0 web:zoom-in-95'
 							: 'web:animate-out web:fade-out-0 web:zoom-out-95',
@@ -87,7 +87,7 @@ const DialogContent = React.forwardRef<
 					{children}
 					<DialogPrimitive.Close
 						className={
-							'web:group web:ring-offset-background web:transition-opacity web:hover:opacity-100 web:focus:outline-none web:focus:ring-2 web:focus:ring-ring web:focus:ring-offset-2 web:disabled:pointer-events-none absolute right-4 top-4 rounded-sm p-0.5 opacity-70'
+							'web:group web:ring-offset-background web:transition-opacity web:hover:opacity-100 web:focus:outline-none web:focus:ring-2 web:focus:ring-ring web:focus:ring-offset-2 web:disabled:pointer-events-none squircle absolute right-4 top-4 rounded-sm p-0.5 opacity-70'
 						}
 					>
 						<X

--- a/apps/expo/components/ui/dropdown-menu.tsx
+++ b/apps/expo/components/ui/dropdown-menu.tsx
@@ -51,7 +51,7 @@ function DropdownMenuSubTrigger({
 		>
 			<DropdownMenuPrimitive.SubTrigger
 				className={cn(
-					'group flex flex-row items-center rounded-sm px-2 py-2 active:bg-background-surface sm:py-1.5',
+					'squircle group flex flex-row items-center rounded-sm px-2 py-2 active:bg-background-surface sm:py-1.5',
 					open && 'bg-background-surface',
 					inset && 'pl-8',
 				)}
@@ -77,7 +77,7 @@ function DropdownMenuSubContent({
 		<NativeOnlyAnimatedView entering={FadeIn}>
 			<DropdownMenuPrimitive.SubContent
 				className={cn(
-					'overflow-hidden rounded-md border border-edge bg-background p-1 shadow-lg shadow-black/5',
+					'squircle overflow-hidden rounded-md border border-edge bg-background p-1 shadow-lg shadow-black/5',
 					className,
 				)}
 				{...props}
@@ -118,7 +118,7 @@ function DropdownMenuContent({
 						<TextClassContext.Provider value="text-foreground-subtle">
 							<DropdownMenuPrimitive.Content
 								className={cn(
-									'min-w-[8rem] overflow-hidden rounded-xl border border-edge bg-background p-1 shadow-lg shadow-black/5',
+									'squircle min-w-[8rem] overflow-hidden rounded-xl border border-edge bg-background p-1 shadow-lg shadow-black/5',
 									className,
 								)}
 								{...props}
@@ -151,7 +151,7 @@ function DropdownMenuItem({
 		>
 			<DropdownMenuPrimitive.Item
 				className={cn(
-					'group relative flex flex-row items-center gap-2 rounded-sm px-2 py-2 active:bg-background-surface sm:py-1.5',
+					'squircle group relative flex flex-row items-center gap-2 rounded-sm px-2 py-2 active:bg-background-surface sm:py-1.5',
 					variant === 'destructive' && 'active:bg-fill-danger-secondary',
 					props.disabled && 'opacity-50',
 					inset && 'pl-8',
@@ -175,7 +175,7 @@ function DropdownMenuCheckboxItem({
 		<TextClassContext.Provider value="text-base text-foreground select-none group-active:text-accent-foreground">
 			<DropdownMenuPrimitive.CheckboxItem
 				className={cn(
-					'group relative flex flex-row items-center gap-2 rounded-sm py-2 pl-8 pr-2 active:bg-background-surface sm:py-1.5',
+					'squircle group relative flex flex-row items-center gap-2 rounded-sm py-2 pl-8 pr-2 active:bg-background-surface sm:py-1.5',
 					props.disabled && 'opacity-50',
 					className,
 				)}
@@ -210,7 +210,7 @@ function DropdownMenuRadioItem({
 		<TextClassContext.Provider value="text-base text-foreground select-none group-active:text-accent-foreground">
 			<DropdownMenuPrimitive.RadioItem
 				className={cn(
-					'group relative flex flex-row items-center gap-2 rounded-sm py-2 pl-8 pr-2 active:bg-background-surface sm:py-1.5',
+					'squircle group relative flex flex-row items-center gap-2 rounded-sm py-2 pl-8 pr-2 active:bg-background-surface sm:py-1.5',
 					props.disabled && 'opacity-50',
 					className,
 				)}

--- a/apps/expo/components/ui/input/raw-input.tsx
+++ b/apps/expo/components/ui/input/raw-input.tsx
@@ -13,7 +13,7 @@ const RawInput = React.forwardRef<React.ElementRef<typeof TextInput>, RawInputPr
 			<TextInput
 				ref={ref}
 				className={cn(
-					'native:h-12 native:text-lg native:leading-[1.25] h-10 rounded-lg border border-edge bg-background px-3 text-base text-foreground file:border-0 file:bg-transparent file:font-medium lg:text-sm',
+					'native:h-12 native:text-lg native:leading-[1.25] squircle h-10 rounded-lg border border-edge bg-background px-3 text-base text-foreground file:border-0 file:bg-transparent file:font-medium lg:text-sm',
 					props.editable === false && 'opacity-50',
 					{ 'border-edge-danger': isInvalid },
 					className,

--- a/apps/expo/components/ui/progress.tsx
+++ b/apps/expo/components/ui/progress.tsx
@@ -21,7 +21,7 @@ const Progress = React.forwardRef<ProgressPrimitive.RootRef, Props>(
 			<ProgressPrimitive.Root
 				ref={ref}
 				className={cn(
-					'relative h-4 w-full overflow-hidden rounded-full bg-background-surface',
+					'squircle relative h-4 w-full overflow-hidden rounded-full bg-background-surface',
 					{ 'rotate-180 transform': inverted },
 					className,
 				)}

--- a/apps/expo/components/ui/radio-group.tsx
+++ b/apps/expo/components/ui/radio-group.tsx
@@ -16,13 +16,13 @@ function RadioGroupItem({
 	return (
 		<RadioGroupPrimitive.Item
 			className={cn(
-				'aspect-square h-6 w-6 shrink-0 items-center justify-center rounded-full border border-edge shadow-sm shadow-black/5 dark:bg-background-surface',
+				'squircle aspect-square h-6 w-6 shrink-0 items-center justify-center rounded-full border border-edge shadow-sm shadow-black/5 dark:bg-background-surface',
 				props.disabled && 'opacity-50',
 				className,
 			)}
 			{...props}
 		>
-			<RadioGroupPrimitive.Indicator className="h-4 w-4 rounded-full bg-fill-brand" />
+			<RadioGroupPrimitive.Indicator className="squircle h-4 w-4 rounded-full bg-fill-brand" />
 		</RadioGroupPrimitive.Item>
 	)
 }

--- a/apps/expo/components/ui/switch.tsx
+++ b/apps/expo/components/ui/switch.tsx
@@ -83,11 +83,11 @@ const SwitchNative = React.forwardRef<SwitchPrimitives.RootRef, Props>(
 		return (
 			<Animated.View
 				style={animatedRootStyle}
-				className={cn('rounded-full', resolvedSize.view, props.disabled && 'opacity-50')}
+				className={cn('squircle rounded-full', resolvedSize.view, props.disabled && 'opacity-50')}
 			>
 				<SwitchPrimitives.Root
 					className={cn(
-						'shrink-0 flex-row items-center rounded-full border border-transparent',
+						'squircle shrink-0 flex-row items-center rounded-full border border-transparent',
 						resolvedSize.root,
 						props.checked ? 'bg-primary' : 'bg-input',
 						className,
@@ -98,7 +98,7 @@ const SwitchNative = React.forwardRef<SwitchPrimitives.RootRef, Props>(
 					<Animated.View style={animatedThumbStyle}>
 						<SwitchPrimitives.Thumb
 							className={cn(
-								'rounded-full bg-background shadow-md shadow-foreground/25 ring-0',
+								'squircle rounded-full bg-background shadow-md shadow-foreground/25 ring-0',
 								resolvedSize.thumb,
 								{
 									'bg-white': variant === 'brand',

--- a/apps/expo/components/ui/tabs.tsx
+++ b/apps/expo/components/ui/tabs.tsx
@@ -11,7 +11,7 @@ const TabsList = React.forwardRef<TabsPrimitive.ListRef, TabsPrimitive.ListProps
 		<TabsPrimitive.List
 			ref={ref}
 			className={cn(
-				'web:inline-flex native:h-12 native:px-1.5 h-10 items-center justify-center rounded-lg bg-background-surface p-1 tablet:h-14',
+				'web:inline-flex native:h-12 native:px-1.5 squircle h-10 items-center justify-center rounded-lg bg-background-surface p-1 tablet:h-14',
 				className,
 			)}
 			{...props}
@@ -33,7 +33,7 @@ const TabsTrigger = React.forwardRef<TabsPrimitive.TriggerRef, TabsPrimitive.Tri
 				<TabsPrimitive.Trigger
 					ref={ref}
 					className={cn(
-						'web:whitespace-nowrap web:ring-offset-background web:transition-all web:focus-visible:outline-none web:focus-visible:ring-2 web:focus-visible:ring-ring web:focus-visible:ring-offset-2 inline-flex items-center justify-center rounded-lg border border-transparent px-3 py-1.5 text-sm font-medium',
+						'web:whitespace-nowrap web:ring-offset-background web:transition-all web:focus-visible:outline-none web:focus-visible:ring-2 web:focus-visible:ring-ring web:focus-visible:ring-offset-2 squircle inline-flex items-center justify-center rounded-lg border border-transparent px-3 py-1.5 text-sm font-medium',
 						props.disabled && 'web:pointer-events-none opacity-50',
 						props.value === value && 'border-edge bg-background-surface-secondary',
 						className,

--- a/apps/expo/components/ui/textarea.tsx
+++ b/apps/expo/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<React.ElementRef<typeof TextInput>, TextInputP
 			<TextInput
 				ref={ref}
 				className={cn(
-					'web:flex border-input native:text-lg native:leading-[1.25] web:ring-offset-background placeholder:text-muted-foreground web:focus-visible:outline-none web:focus-visible:ring-2 web:focus-visible:ring-ring web:focus-visible:ring-offset-2 min-h-[80px] w-full rounded-md border bg-background px-3 py-2 text-base text-foreground lg:text-sm',
+					'web:flex border-input native:text-lg native:leading-[1.25] web:ring-offset-background placeholder:text-muted-foreground web:focus-visible:outline-none web:focus-visible:ring-2 web:focus-visible:ring-ring web:focus-visible:ring-offset-2 squircle min-h-[80px] w-full rounded-md border bg-background px-3 py-2 text-base text-foreground lg:text-sm',
 					props.editable === false && 'web:cursor-not-allowed opacity-50',
 					className,
 				)}

--- a/apps/expo/components/ui/tooltip.tsx
+++ b/apps/expo/components/ui/tooltip.tsx
@@ -25,7 +25,7 @@ const TooltipContent = React.forwardRef<
 						ref={ref}
 						sideOffset={sideOffset}
 						className={cn(
-							'border-border bg-popover web:animate-in web:fade-in-0 web:zoom-in-95 z-50 overflow-hidden rounded-md border px-3 py-1.5 shadow-md shadow-foreground/5 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+							'border-border bg-popover web:animate-in web:fade-in-0 web:zoom-in-95 squircle z-50 overflow-hidden rounded-md border px-3 py-1.5 shadow-md shadow-foreground/5 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
 							className,
 						)}
 						{...props}

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -14,7 +14,6 @@
 		"postinstall": "npx tailwindcss -i ./global.css -o ./node_modules/.cache/nativewind/global.css"
 	},
 	"dependencies": {
-		"@candlefinance/faster-image": "1.7.2",
 		"@codeherence/react-native-header": "^0.14.0",
 		"@craftzdog/react-native-buffer": "^6.0.5",
 		"@epubjs-react-native/core": "^1.4.6",
@@ -52,7 +51,6 @@
 		"expo-constants": "~17.1.7",
 		"expo-file-system": "~18.1.11",
 		"expo-font": "~13.3.2",
-		"expo-image": "~2.4.0",
 		"expo-keep-awake": "~14.1.4",
 		"expo-linking": "~7.1.7",
 		"expo-navigation-bar": "~4.2.8",
@@ -87,6 +85,7 @@
 		"react-native-screens": "~4.16.0",
 		"react-native-super-grid": "^6.0.1",
 		"react-native-svg": "15.11.2",
+		"react-native-turbo-image": "^1.23.0",
 		"react-native-web": "^0.20.0",
 		"react-native-webview": "13.13.5",
 		"react-timer-hook": "^3.0.8",

--- a/apps/expo/tailwind.config.js
+++ b/apps/expo/tailwind.config.js
@@ -1,4 +1,5 @@
 const { hairlineWidth } = require('nativewind/theme')
+const plugin = require('tailwindcss/plugin')
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
@@ -93,7 +94,30 @@ module.exports = {
 				'accordion-down': 'accordion-down 0.2s ease-out',
 				'accordion-up': 'accordion-up 0.2s ease-out',
 			},
+			borderCurve: {
+				continuous: 'continuous',
+				curve: 'curve',
+			},
 		},
 	},
-	plugins: [require('tailwindcss-animate')],
+	plugins: [
+		require('tailwindcss-animate'),
+		plugin(function ({ addUtilities }) {
+			addUtilities({
+				'.border-continuous': {
+					'@rn-move -rn-border-curve border-curve': 'true',
+					'-rn-border-curve': 'continuous',
+				},
+				'.border-circular': {
+					'@rn-move -rn-border-curve border-curve': 'true',
+					'-rn-border-curve': 'circular',
+				},
+				'.squircle': {
+					'@rn-move -rn-border-curve border-curve': 'true',
+					'-rn-border-curve': 'continuous',
+					overflow: 'hidden',
+				},
+			})
+		}),
+	],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1523,7 +1523,7 @@
     "@babel/parser" "^7.27.2"
     "@babel/types" "^7.27.1"
 
-"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3":
+"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3", "@babel/traverse@^7.18.9", "@babel/traverse@^7.23.2", "@babel/traverse@^7.25.3", "@babel/traverse@^7.25.7", "@babel/traverse@^7.25.9", "@babel/traverse@^7.26.5":
   version "7.26.5"
   resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.5.tgz"
   integrity sha512-rkOSPOw+AXbgtwUga3U4u8RpoK9FEFWBNAlTpcnkLFjL5CT+oyHNuUUC/xx6XefEJ16r38r8Bc/lfp6rYuHeJQ==
@@ -1546,19 +1546,6 @@
     "@babel/parser" "^7.27.0"
     "@babel/template" "^7.27.0"
     "@babel/types" "^7.27.0"
-    debug "^4.3.1"
-    globals "^11.1.0"
-
-"@babel/traverse@^7.18.9", "@babel/traverse@^7.23.2", "@babel/traverse@^7.25.3", "@babel/traverse@^7.25.7", "@babel/traverse@^7.25.9", "@babel/traverse@^7.26.5":
-  version "7.26.5"
-  resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.5.tgz"
-  integrity sha512-rkOSPOw+AXbgtwUga3U4u8RpoK9FEFWBNAlTpcnkLFjL5CT+oyHNuUUC/xx6XefEJ16r38r8Bc/lfp6rYuHeJQ==
-  dependencies:
-    "@babel/code-frame" "^7.26.2"
-    "@babel/generator" "^7.26.5"
-    "@babel/parser" "^7.26.5"
-    "@babel/template" "^7.25.9"
-    "@babel/types" "^7.26.5"
     debug "^4.3.1"
     globals "^11.1.0"
 
@@ -1634,11 +1621,6 @@
   version "7.1.1"
   resolved "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.1.tgz"
   integrity sha512-i1L7noDNxtFyL5DmZafWy1wRVhGehQmzZaz1HiN5e7iylJMSZR7ekOV7NsIqa5qBldlLrsKv4HbgFUVlQrz8Mw==
-
-"@candlefinance/faster-image@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.npmjs.org/@candlefinance/faster-image/-/faster-image-1.7.2.tgz"
-  integrity sha512-zHo/MYrcO4G7WRqLLVbg6rnqUPWlQLk4X8DgA7hpO0c3Nv0OOcV0ZQZvE1022X0Pau5VNiZxCVHriqIjEo+0sA==
 
 "@chevrotain/cst-dts-gen@11.0.3":
   version "11.0.3"
@@ -14121,11 +14103,6 @@ expo-font@~13.3.2:
   dependencies:
     fontfaceobserver "^2.1.0"
 
-expo-image@~2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/expo-image/-/expo-image-2.4.0.tgz#02f7fd743387206914cd431a6367f5be53509e3e"
-  integrity sha512-TQ/LvrtJ9JBr+Tf198CAqflxcvdhuj7P24n0LQ1jHaWIVA7Z+zYKbYHnSMPSDMul/y0U46Z5bFLbiZiSidgcNw==
-
 expo-keep-awake@~14.1.4:
   version "14.1.4"
   resolved "https://registry.yarnpkg.com/expo-keep-awake/-/expo-keep-awake-14.1.4.tgz#80197728563e0e17523e5a606fbd6fbed9639503"
@@ -22958,6 +22935,11 @@ react-native-svg@15.11.2:
     css-tree "^1.1.3"
     warn-once "0.1.1"
 
+react-native-turbo-image@^1.23.0:
+  version "1.23.0"
+  resolved "https://registry.yarnpkg.com/react-native-turbo-image/-/react-native-turbo-image-1.23.0.tgz#5c4c68295c0e2e4e97900bbad90dd839f661c02a"
+  integrity sha512-3J2isP+pF731aKLoNhaU15aen6U2uAz8w/DOL8TsGi1/CmHAd5ZHEZ0kUW06Ow/KDm8h68t9w9o7YWJC2N47Uw==
+
 react-native-web@^0.20.0:
   version "0.20.0"
   resolved "https://registry.yarnpkg.com/react-native-web/-/react-native-web-0.20.0.tgz#3fb0591999ed4b54d7822a2785547415e8a5c031"
@@ -25113,16 +25095,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -25270,7 +25243,7 @@ stringify-object@3.3.0, stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -25297,13 +25270,6 @@ strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -27735,7 +27701,7 @@ workbox-window@7.3.0, workbox-window@^7.3.0:
     "@types/trusted-types" "^2.0.2"
     workbox-core "7.3.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -27748,15 +27714,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
So this is a list of things I aim to put into this PR. I am using this space to track/show my progress. I am currently working on: Done!

## Tasks

- [x] 1. Different opacities when tapped ~(also try out squeeze on tap)~
- [x] 2. Squircles (iOS only)
- [x] 3. `expo-image` + `faster-image` -> `react-native-turbo-image`. (The double page reader does work properly too)
- [x] 4. Fix gradients + borders + drop shadows
- [x] 5. Fix "sharp" linear gradient inside reader
- [x] 6. `react-native-reanimated-carousel`: rounded corners + dark mode doesn't like 0.99
- [x] 7. Browse > Books: The back button is tiny
- [x] 8. Weird corner issues
- [x] 9. Add Android drop shadows
- [x] 10. Use full height for image based reader on iPad + use full height when zoomed in.

### Issues / Notes for each task (numbered)

- 2 **Important:** To use squircles you must add class name `squircle` whenever using rounded corners. Or add `style={{borderCurve: 'continuous', overflow: 'hidden'}}`. 
- 2 Adding style `borderCurve: 'continuous'` (or class name `squircle`) often requires removing `borderRadius` (`rounded-xx`), saving then adding it back to see the update.
- 2 There may be a few fixable visual bugs added, since I did a find and replace of `rounded-` to `squircle rounded-` where `squircle` applies the style `borderCurve: 'continuous'` **AND** `overflow: 'hidden'`. I found and fixed only one: where `rounded-xl` was added for seemingly no use, but the new overflow hidden style caused issues:

<details>
<summary> Example Bug before and after fixing (but look at that nice squircle!) </summary>

https://github.com/user-attachments/assets/da74a0e7-1d1d-43bb-9d6f-6535d7a90761

_I have since fixed the OPDS corner rounding amount too_

</details>


- 3 There's a few places, specifically ~`StackedEffectThumbnail.tsx`, `PublicationFeed.tsx`, `PublicationGroup.tsx` and~ `auth.tsx` that I have no idea how to find and test.
- 4 Android dark mode: flickering issues at the edge of images when swiping on carousel due to the gradients (existing issue and I couldn't fix it)
- 4 iOS dark mode (maybe Android too but the gradient issue won't let me check): there is a nearly imperceptible flicker when swiping on carousel due to the thinness of the border. It can only really be seen if you swipe the carousel slowly while looking directly at the edge. Maybe I could boost the thickness up a tiny bit if it's really an issue.


## Reasoning / Benefits

I have done the image library change, it took longer than I thought because I decided to play around with various libraries. Using `react-native-turbo-image` I have turned on downscaling to 1.5x the rendered width for everything except in `ImageBasedReader.tsx`, where the `Downscaling` toggle can can enable it. This gives the following benefit:

<details>
  <summary> Example 1: Images from "Continue Reading" </summary>
  <table>
    <thead>
      <tr>
        <th align="center"><strong> Before </strong></th>
        <th align="center"><strong> After </strong></th>
        <th align="center"><strong> (Why I didn't use a perfect 1x: it's a bit blurry)</strong></th>
      </tr>
    </thead>
    <tbody>
      <tr>
        <td align="center"><img height="auto"  alt="Image" src="https://github.com/user-attachments/assets/0fa3fcde-0aaa-461d-ba9f-0a35525a5edd"/></td>
        <td align="center"><img height="auto"  alt="Image" src="https://github.com/user-attachments/assets/3a319276-8137-4e4e-9347-7e4c43fa583f"/></td>
        <td align="center"><img height="auto" alt="Image" src="https://github.com/user-attachments/assets/9b48bfc3-b525-4a94-9eab-35c09f3c8f63"/></td>
      </tr>
      <tr>
        <td colspan="3"> Note: Some parts of "Before" might look higher res, but since the image is small it was not noticeable. The aliasing was though so obviously I fixed that. </td>
      </tr>
    </tbody>
  </table>
</details>

<details>
  <summary> Example 2: Images from "Search" </summary>
  <table>
    <thead>
      <tr>
        <th align="center"><strong> Before </strong></th>
        <th align="center"><strong> After </strong></th>
      </tr>
    </thead>
    <tbody>
      <tr>
        <td align="center"><img height="400"  alt="Image" src="https://github.com/user-attachments/assets/c625730a-fb6f-499b-a2da-c22c88caf5ca"/></td>
        <td align="center"><img height="400"  alt="Image" src="https://github.com/user-attachments/assets/36f7817f-4518-47a6-b1ab-090c7f9f811d"/></td>
      </tr>
    </tbody>
  </table>
</details>

<details>
  <summary> Example 3: The `Downscaling` toggle </summary>
  <table>
    <thead>
      <tr>
        <th align="center"><strong> Before </strong></th>
        <th align="center"><strong> After </strong></th>
      </tr>
    </thead>
    <tbody>
      <tr>
        <td align="center"><img height="400"  alt="Image" src="https://github.com/user-attachments/assets/ef6580ef-2fc7-4902-887b-10f56ac283ac"/></td>
        <td align="center"><img height="400"  alt="Image" src="https://github.com/user-attachments/assets/3197d231-5c58-4f80-90ce-6e7f650f5d7e"/></td>
      </tr>
      <tr>
        <td colspan="2"> Can be helpful if images have a lot of aliasing / very large. Maybe it doesn't look like much but those stripey stars flicker when you move the image around if you don't use downscaling. The disadvantage of using it is zooming is not as sharp. I set it as 1.2x because it seems the best at removing weird visual artifacts. </td>
      </tr>
    </tbody>
  </table>
</details>

I have also made the image reader span the whole page, meaning zooming in looks better, and also allows an iPad to use the full space. (It works fine on Android too):

<details>
  <summary> Example 1: iPhone zoom </summary>
  <table>
    <thead>
      <tr>
        <th align="center"><strong> Before </strong></th>
        <th align="center"><strong> After </strong></th>
      </tr>
    </thead>
    <tbody>
      <tr>
        <td align="center"><img height="400"  alt="Image" src="https://github.com/user-attachments/assets/25ce37f1-604d-4718-916a-fa4e408aadf1"/></td>
        <td align="center"><img height="400"  alt="Image" src="https://github.com/user-attachments/assets/68d44fbb-a869-42e4-9d98-913606be4713"/></td>
      </tr>
      <tr>
        <td colspan="2"> Ignore the home bar on the left image, it was a temporary bar. Works just as well on Android too! </td>
      </tr>
    </tbody>
  </table>
</details>

<details>
  <summary> Example 2: iPad </summary>
  <table>
    <thead>
      <tr>
        <th align="center"><strong> Before </strong></th>
        <th align="center"><strong> After </strong></th>
      </tr>
    </thead>
    <tbody>
      <tr>
        <td align="center"><img height="400"  alt="Image" src="https://github.com/user-attachments/assets/35b24bd4-c98a-49f2-9bc7-c4c5b71a7bc0"/></td>
        <td align="center"><img height="400"  alt="Image" src="https://github.com/user-attachments/assets/178b1c97-3265-45b6-aaf7-f6fad49dd7c6"/></td>
      </tr>
      <tr>
        <td colspan="2"> Similarly for landscape too. This time the bar and multitasking dots were permanent but now I've hidden them. </td>
      </tr>
    </tbody>
  </table>
</details>