### PR TITLE
:bug: Fix OPDS page in v1.2 feeds

### DIFF
--- a/apps/docs/pages/guides/api.mdx
+++ b/apps/docs/pages/guides/api.mdx
@@ -79,7 +79,7 @@ Stump uses server-side sessions to authenticate users. These sessions are stored
 	Authentication on the REST API
 </Callout>
 
-Stump supports [Basic Authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication) in order to properly support OPDS clients. Authenticating using this method will still create a server-side session for you.
+Stump supports [Basic Authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication) in order to properly support OPDS clients. Authenticating using this method will **not** create a server-side session. It is only intended for OPDS client authentication.
 
 ### JWT Access Tokens
 

--- a/core/src/opds/v1_2/entry.rs
+++ b/core/src/opds/v1_2/entry.rs
@@ -243,7 +243,7 @@ impl IntoOPDSEntry for OPDSEntryBuilder<OPDSPublicationEntity> {
 			OpdsLink::new(
 				thumbnail_opds_link_type,
 				OpdsLinkRel::Image,
-				format!("{base_url}/pages/1"),
+				format!("{base_url}/pages/0?zero_based=true"),
 			),
 			OpdsLink::new(
 				entry_file_acquisition_link_type,


### PR DESCRIPTION
Fixes #771

I've also fixed a couple other v1.2-specific bugs during my testing, but more importantly to call out I've decided to _not_ create server-side sessions for basic auth success. I think 99% of basic auth usage will be for OPDS clients, so think it is acceptable to have this be the new default.