### PR TITLE
:memo: Update docs for migration procedure

### DIFF
--- a/apps/docs/pages/guides/_meta.ts
+++ b/apps/docs/pages/guides/_meta.ts
@@ -14,4 +14,7 @@ export default {
 	cli: 'CLI',
 	desktop: 'Desktop App',
 	mobile: 'Mobile App',
+	'breaking-changes': {
+		display: 'hidden',
+	},
 } satisfies Meta

--- a/apps/docs/pages/guides/access-control/library-exclusions.mdx
+++ b/apps/docs/pages/guides/access-control/library-exclusions.mdx
@@ -7,8 +7,8 @@ A user can be explicitly excluded from seeing a library. This is useful for hidi
 ## Configure Exclusions
 
 <Callout emoji="🔐">
-	This functionality is gated behind the `library:manage` and `user:read` user permissions. To learn
-	more about permissions, see the [permissions](/guides/access-control/permissions) guide.
+	This functionality is gated behind the `MANAGE_LIBRARY` and `READ_USERS` user permissions. To
+	learn more about permissions, see the [permissions](/guides/access-control/permissions) guide.
 </Callout>
 
 <Steps>

--- a/apps/docs/pages/guides/access-control/permissions.md
+++ b/apps/docs/pages/guides/access-control/permissions.md
@@ -4,29 +4,36 @@ Users can be assigned permissions that grant (or deny) them access to various fe
 
 ## Available Permissions
 
-| Permission        | Shorthand               | Description                                    | Associated/Included Permissions                      |
-| ----------------- | ----------------------- | ---------------------------------------------- | ---------------------------------------------------- |
-| Access Book Club  | `bookclub:read`         | Allows access to the Book Club feature         |                                                      |
-| Create Book Club  | `bookclub:create`       | Allows creating new Book Clubs                 | `bookclub:read`                                      |
-| Access Smart List | `smartlist:read`        | Allows access to all Smart List features       |                                                      |
-| Read Emailers     | `emailer:read`          | Allows access read configured emailers         | `email:send`                                         |
-| Create Emailers   | `emailer:create`        | Allows creating new emailers                   | `emailer:read`                                       |
-| Manage Emailers   | `emailer:manage`        | Allows managing existing emailers              | `emailer:read`                                       |
-| Send Email        | `email:send`            | Allows sending emails to known emails          | `emailer:read`                                       |
-| Arbitrary Email   | `email:arbitrary_send`  | Allows sending emails to arbitrary emails      | `emailer:read`                                       |
-| API Keys          | `feature:api_keys`      | Allows access to manage API keys               |                                                      |
-| KoReader Sync     | `feature:koreader_sync` | Allows access to the KoReader sync integration |                                                      |
-| File Explorer     | `file:explorer`         | Allows access to the File Explorer feature     |                                                      |
-| File Upload       | `file:upload`           | Allows uploading files to the server           |                                                      |
-| File Download     | `file:download`         | Allows downloading files from the server       |                                                      |
-| Read Notifiers    | `notifier:read`         | Allows access to read configured notifiers     |                                                      |
-| Create Notifiers  | `notifier:create`       | Allows creating new notifiers                  | `notifier:read`                                      |
-| Delete Notifiers  | `notifier:delete`       | Allows deleting notifiers                      | `notifier:read`                                      |
-| Manage Notifiers  | `notifier:manage`       | Allows managing existing notifiers             | `notifier:read`, `notifier:create`,`notifier:delete` |
-| Create Library    | `library:create`        | Allows creating new libraries                  |                                                      |
-| Edit Library      | `library:edit`          | Allows editing basic details of libraries      |                                                      |
-| Scan Library      | `library:scan`          | Allows scanning libraries for new content      |                                                      |
-| Manage Library    | `library:manage`        | Allows managing the contents of libraries      | `library:edit`, `library:scan`                       |
-| Delete Library    | `library:delete`        | Allows deleting libraries                      | `library:manage`                                     |
-| Manage Users      | `user:manage`           | Allows managing users and their permissions    |                                                      |
-| Manage Server     | `server:manage`         | Allows managing server settings and features   | `user:manage`, `library:manage`                      |
+| Permission          | Enum Value             | Description                                                 |
+| ------------------- | ---------------------- | ----------------------------------------------------------- |
+| API Keys            | `ACCESS_API_KEYS`      | Allows access to read/create their own API keys             |
+| KoReader Sync       | `ACCESS_KOREADER_SYNC` | Allows access to the KoReader sync integration              |
+| Access Book Club    | `ACCESS_BOOK_CLUB`     | Allows access to the Book Club feature                      |
+| Create Book Club    | `CREATE_BOOK_CLUB`     | Allows creating new Book Clubs                              |
+| Read Emailers       | `EMAILER_READ`         | Allows access to read any emailers in the system            |
+| Create Emailers     | `EMAILER_CREATE`       | Allows creating new emailers                                |
+| Manage Emailers     | `EMAILER_MANAGE`       | Allows managing existing emailers                           |
+| Send Email          | `EMAIL_SEND`           | Allows sending emails                                       |
+| Arbitrary Email     | `EMAIL_ARBITRARY_SEND` | Allows sending emails to arbitrary addresses                |
+| Access Smart List   | `ACCESS_SMART_LIST`    | Allows access to the Smart List feature                     |
+| File Explorer       | `FILE_EXPLORER`        | Allows access to the File Explorer feature                  |
+| Upload File         | `UPLOAD_FILE`          | Allows uploading files to a library                         |
+| Download File       | `DOWNLOAD_FILE`        | Allows downloading files from a library                     |
+| Create Library      | `CREATE_LIBRARY`       | Allows creating new libraries                               |
+| Edit Library        | `EDIT_LIBRARY`         | Allows editing basic details about libraries                |
+| Scan Library        | `SCAN_LIBRARY`         | Allows scanning libraries for new files                     |
+| Manage Library      | `MANAGE_LIBRARY`       | Allows managing libraries (scan, edit, manage relations)    |
+| Edit Metadata       | `EDIT_METADATA`        | Allows editing database-level metadata for media/series     |
+| Write Back Metadata | `WRITE_BACK_METADATA`  | Allows writing database metadata back to files              |
+| Delete Library      | `DELETE_LIBRARY`       | Allows deleting libraries                                   |
+| Read Users          | `READ_USERS`           | Allows reading user information via user-specific endpoints |
+| Manage Users        | `MANAGE_USERS`         | Allows managing users (create, edit, delete)                |
+| Read Notifier       | `READ_NOTIFIER`        | Allows reading configured notifiers                         |
+| Create Notifier     | `CREATE_NOTIFIER`      | Allows creating new notifiers                               |
+| Manage Notifier     | `MANAGE_NOTIFIER`      | Allows managing existing notifiers                          |
+| Delete Notifier     | `DELETE_NOTIFIER`      | Allows deleting notifiers                                   |
+| Read Jobs           | `READ_JOBS`            | Allows reading job information                              |
+| Manage Jobs         | `MANAGE_JOBS`          | Allows managing jobs (pause, resume, delete, cancel)        |
+| Read Persisted Logs | `READ_PERSISTED_LOGS`  | Allows reading application-level logs (e.g., job logs)      |
+| Read System Logs    | `READ_SYSTEM_LOGS`     | Allows reading system logs                                  |
+| Manage Server       | `MANAGE_SERVER`        | Allows managing server settings and features                |

--- a/apps/docs/pages/guides/api.mdx
+++ b/apps/docs/pages/guides/api.mdx
@@ -88,7 +88,7 @@ Short-lived JWT access tokens are available for API access, aimed at better enab
 ### API Keys
 
 <Callout emoji="🔐">
-	This functionality is gated behind the `feature:api_keys` user permission. To learn more about
+	This functionality is gated behind the `ACCESS_API_KEYS` user permission. To learn more about
 	permissions, see the [permissions](/guides/access-control/permissions) guide.
 </Callout>
 

--- a/apps/docs/pages/guides/breaking-changes/0.1.0.mdx
+++ b/apps/docs/pages/guides/breaking-changes/0.1.0.mdx
@@ -1,0 +1,81 @@
+import { Callout, Steps } from 'nextra/components'
+
+# 0.1.0 - SeaORM and GraphQL
+
+<Callout emoji="💥">
+	See the [original announcement](https://github.com/stumpapp/stump/discussions/634) for more
+	context
+</Callout>
+
+Stump has migrated from using Prisma to SeaORM for its database layer and from REST to GraphQL for its API. This was effectively a ground-up rewrite a large portion of the entire codebase, and as such, there are several breaking changes that users should be aware of before upgrading to version 0.1.0 or later.
+
+## Incompatible Database
+
+I tried to minimize the number of breaking changes in the database, but there were some changes that were unavoidable. As a result, the database itself is not compatible with previous versions of Stump.
+
+The list of notable database changes are as follows:
+
+- Convert all Prisma-specific join tables to use more semantic naming conventions
+- Reduce the usage of UUIDs in favor of auto-incrementing integers for primary keys for smaller tables with less user-facing exposure
+- Standardize all enumerations to use `SCREAMING_SNAKE_CASE` instead of a mix of `snake_case` and `PascalCase`
+
+### Non-Recoverable Data
+
+Thankfully, the vast majority of data is migratable. However, there are some pieces that are not recoverable due to the nature of the changes. These include:
+
+- API keys
+- User-assigned permissions
+- Smart lists
+- Scheduled job configurations
+
+## Migration Steps
+
+<Callout emoji="⚠️">
+	Please report any issues you encounter during the migration process. There are so many different
+	configurations and setups that it's hard to account for all of them.
+</Callout>
+
+This section outlines the steps needed to migrate your existing Stump instance to version 0.1.0 or later. Please note that these steps only apply if you are upgrading from a version prior to 0.1.0.
+
+<Steps>
+
+### Backup Your Data
+
+Before proceeding with the migration, ensure you have a complete backup of your Stump database. This is crucial in case anything goes wrong during the migration process.
+
+### Update Stump
+
+Once you've backed up your data, you'll need to update your Stump instance. I highly recommend doing this in total isolation from your existing instance to avoid any potential data loss. We will bring over your existing configs and database in the next steps.
+
+The important part here is to ensure you have an upgraded instance running to get the new database created and migrated, which happens automatically after the first start.
+
+### Migrate Your Database
+
+The updated Stump instance includes a CLI tool to help with the migration process. Before continuing, please ensure the following:
+
+- The new Stump instance has been started at least once, has not been configured, and is fully stopped
+- The old Stump instance is fully stopped
+- The old Stump database is accessible (if running Docker, ensure both database files are mounted properly)
+
+To migrate your database using the CLI tool, run the following:
+
+```bash
+# If using Docker, exec into the container
+./stump system sea-orm-migration
+```
+
+The tool will prompt you for the necessary information to pull data from the old database and insert it into the new one. Follow the prompts carefully.
+
+</Steps>
+
+## Added Features
+
+There are several new features that were added as part of this release that I think are worth highlighting:
+
+- The alphabet filter ([#709](https://github.com/stumpapp/stump/pull/709))
+- Adjustable cover sizes ([#724](https://github.com/stumpapp/stump/pull/724))
+- Basic metadata editing and calibre tags ([#735](https://github.com/stumpapp/stump/pull/735))
+- An entire, usable mobile application:
+  - Native Kotlin/Swift Readium ebook reader
+  - On deck support
+  - Built-in file browser

--- a/apps/docs/pages/guides/features/api-keys.mdx
+++ b/apps/docs/pages/guides/features/api-keys.mdx
@@ -3,7 +3,7 @@ import { Callout } from 'nextra/components'
 # API Keys
 
 <Callout emoji="🔐">
-	This functionality is gated behind the `feature:api_keys` user permission. To learn more about
+	This functionality is gated behind the `ACCESS_API_KEYS` user permission. To learn more about
 	permissions, see the [permissions](/guides/access-control/permissions) guide.
 </Callout>
 

--- a/apps/docs/pages/guides/features/book-clubs/overview.mdx
+++ b/apps/docs/pages/guides/features/book-clubs/overview.mdx
@@ -10,7 +10,7 @@ import { Callout } from 'nextra/components'
 </Callout>
 
 <Callout emoji="🔐">
-	This functionality is gated behind the `bookclub:read` user permission. To learn more about
+	This functionality is gated behind the `ACCESS_BOOK_CLUB` user permission. To learn more about
 	permissions, see the [Permissions](/guides/access-control/permissions) guide.
 </Callout>
 
@@ -33,8 +33,8 @@ Book clubs in Stump are effectively just a group of users that all have access t
 
 There are two relevant user permissions that affect access to the book club feature as a whole:
 
-    1. Any managed account with the `bookclub:read` permission may access the book club feature. This means that they can view and join book clubs
-    2. Any managed account with the `bookclub:create` permission may create book clubs (and therefore inherently has the `bookclub:read` permission)
+    1. Any managed account with the `ACCESS_BOOK_CLUB` permission may access the book club feature. This means that they can view and join book clubs
+    2. Any managed account with the `CREATE_BOOK_CLUB` permission may create book clubs (and therefore inherently has the `bookclub:read` permission)
 
 The server owner can assign these permissions to other users in the user management settings page. For more information about that process, see the [user permissions](/guides/access-control/permissions) guide.
 

--- a/apps/docs/pages/guides/features/file-explorer.mdx
+++ b/apps/docs/pages/guides/features/file-explorer.mdx
@@ -10,7 +10,7 @@ Certain entities throughout Stump have a file explorer scoped to them, allowing 
 ## Accessing a File Explorer
 
 <Callout emoji="🔐">
-	This functionality is gated behind the `file:explorer` user permission. To learn more about
+	This functionality is gated behind the `FILE_EXPLORER` user permission. To learn more about
 	permissions, see the [Permissions](/guides/access-control/permissions) guide.
 </Callout>
 

--- a/apps/docs/pages/guides/features/smart-list.mdx
+++ b/apps/docs/pages/guides/features/smart-list.mdx
@@ -3,7 +3,7 @@ import { Callout, Steps } from 'nextra/components'
 # Smart lists
 
 <Callout emoji="🔐">
-	This functionality is gated behind the `smartlist:read` user permission. To learn more about
+	This functionality is gated behind the `ACCESS_SMART_LIST` user permission. To learn more about
 	permissions, see the [permissions](/guides/access-control/permissions) guide.
 </Callout>
 

--- a/apps/docs/pages/guides/integrations/kobo.mdx
+++ b/apps/docs/pages/guides/integrations/kobo.mdx
@@ -12,7 +12,7 @@ Automatically sync books to your Kobo device with Stump
 
 {/* prettier-ignore */}
 {/* <Callout emoji="🔐">
-This functionality is gated behind the `feature:kobo_sync` user permission. To learn more about
+This functionality is gated behind the `AccessKoreaderSync` user permission. To learn more about
 permissions, see the [permissions](/guides/access-control/permissions) guide.
 
 </Callout> */}

--- a/apps/docs/pages/guides/integrations/koreader.mdx
+++ b/apps/docs/pages/guides/integrations/koreader.mdx
@@ -3,7 +3,7 @@ import { Callout, Steps } from 'nextra/components'
 # KoReader Sync
 
 <Callout emoji="🔐">
-	This functionality is gated behind the `feature:koreader_sync` and `feature:api_keys` user
+	This functionality is gated behind the `ACCESS_KOREADER_SYNC` and `ACCESS_API_KEYS` user
 	permissions. To learn more about permissions, see the
 	[permissions](/guides/access-control/permissions) guide.
 </Callout>

--- a/apps/docs/pages/guides/mobile/app.mdx
+++ b/apps/docs/pages/guides/mobile/app.mdx
@@ -17,7 +17,8 @@ The mobile app will be a bit more trimmed down in scope compared to the built in
 
 - [x] Multi-server configurations
 - [x] OPDS support, so you can use the app with other OPDS-compatible services
-- [ ] Readers for the supported book formats (e.g., CBZ/CBR, EPUB, PDF, etc.)
+- [x] Readers for the supported book formats (e.g., CBZ/CBR, EPUB, PDF, etc.)
+- [x] A built-in file browser
 - [ ] Offline reading so you don't need an active internet connection
 
 <Callout emoji="🚀">

--- a/apps/docs/pages/guides/mobile/faq.mdx
+++ b/apps/docs/pages/guides/mobile/faq.mdx
@@ -26,7 +26,7 @@ Regardless, I am confident that it is at least a good fit for Stump, as it is a 
 
 ## Why OPDS v2?
 
-I recognize that there are many OPDS v1.2-compatible servers out there, and OPDS v2.0 is not widely adopted yet.
+I recognize that there are many OPDS v1.2-compatible servers out there and that OPDS v2.0 is not widely adopted yet.
 
 However, I **really** don't like XML - at least not from the perspective of a developer. I don't want to have to maintain an XML client for the app. There are lots of really great v1.2-compatible apps out there, so I'm only supporting OPDS v2.0.
 

--- a/apps/docs/pages/guides/mobile/reading/_meta.ts
+++ b/apps/docs/pages/guides/mobile/reading/_meta.ts
@@ -2,6 +2,6 @@ import { Meta } from 'nextra'
 
 export default {
 	formats: 'Formats',
-	'image-based': 'Comic/Manga',
+	'image-based': 'Comics/Manga',
 	books: 'Books',
 } satisfies Meta

--- a/apps/docs/pages/guides/mobile/reading/books.mdx
+++ b/apps/docs/pages/guides/mobile/reading/books.mdx
@@ -1,10 +1,97 @@
 import { Callout } from 'nextra/components'
 
-# Book Reader
+# EPUB Reader
 
 <Callout emoji="⚠️" type="warning">
-	The ebook reader provides really poor UX. It is recommended to use a different reader until this
-	is improved. It is planned for a future release!
+	The ebook reader is functional but still in active development. Some features may be missing or
+	work differently than expected. Improvements are planned for future releases.
 </Callout>
 
-> Documentation will be added when the reader is improved
+The EPUB reader in Stump's mobile app is powered by Readium, providing a native reading experience for digital books. While still being refined, it offers essential reading functionality with customizable themes and settings.
+
+## Layout and Navigation
+
+The EPUB reader features a clean, minimal interface that focuses on the reading experience:
+
+- **Center Tap**: Tap the center of the screen to show/hide the reader controls
+- **Header Controls**: Exit the reader and access quick settings
+- **Footer Controls**: Progress indicator and navigation tools
+
+## Reader Settings
+
+The EPUB reader provides several customization options accessible through the settings panel:
+
+### Visual Themes
+
+The reader includes several built-in themes for different reading preferences:
+
+- **Light**: Standard light theme with black text on white background
+- **Dark**: Dark theme for low-light reading
+- **Sepia**: Warm sepia tones for reduced eye strain
+- **Custom Themes**: Create and customize your own color schemes
+
+### Font Configuration
+
+#### Font Size
+
+Adjust the text size with a slider control to find the most comfortable reading size for your device and preferences.
+
+#### Font Family
+
+Choose from several default fonts optimized for reading:
+
+- **System**: Use your device's default font
+- **OpenDyslexic**: Designed to improve readability for people with dyslexia
+- **Literata**: A serif font optimized for digital reading
+- **Atkinson Hyperlegible**: Designed for enhanced legibility and accessibility
+- **Charis SIL**: A Unicode-based font family supporting a wide range of languages
+- **Bitter**: A slab serif font designed for comfortable screen reading
+
+#### Line Height
+
+Adjust the spacing between lines of text for improved readability and comfort.
+
+### Display Settings
+
+#### Brightness Control
+
+Fine-tune the screen brightness directly within the reader without affecting your device's global brightness setting.
+
+#### Publisher Styles
+
+Toggle whether to respect the original formatting and styles defined by the book's publisher, or use your custom theme settings throughout.
+
+## Navigation Features
+
+### Table of Contents
+
+Access the book's table of contents to jump to specific chapters or sections. The table of contents preserves the hierarchical structure of the book.
+
+### Book Overview
+
+View book metadata including:
+
+- Cover image
+- Title and author information
+- Publisher details
+- Book summary (when available)
+
+## Progress Tracking
+
+Your reading progress is automatically saved and synced across devices when connected to a Stump server.
+
+Like the image-based reader, the EPUB reader also supports:
+
+- **Incognito Mode**: Read without saving progress or location data
+- **Reading Timer**: Track time spent reading (with sync support for Stump servers)
+
+## Limitations and Known Issues
+
+<Callout emoji="ℹ️" type="info">
+	The EPUB reader is actively being improved. Current limitations include:
+</Callout>
+
+- **Annotations**: Text highlighting and note-taking are not yet supported
+- **Advanced Navigation**: Some navigation features are still in development
+- **Search**: In-book text search is not yet available
+- **Text Selection**: Limited text selection and copying functionality

--- a/apps/docs/pages/guides/mobile/reading/formats.mdx
+++ b/apps/docs/pages/guides/mobile/reading/formats.mdx
@@ -9,12 +9,12 @@ import { Callout } from 'nextra/components'
 
 The mobile app doesn't yet support all the formats that your Stump server supports. The following table provides an overview of formats and their status:
 
-| Format  | Status | Notes                             |
-| ------- | ------ | --------------------------------- |
-| CBZ/ZIP | ✅     |                                   |
-| CBR/RAR | ✅     |                                   |
-| EPUB    | ⚠️     | Poor UX, not yet suitable for use |
-| PDF     | ⚠️     | Some PDF pages are blurry         |
+| Format  | Status | Notes                                    |
+| ------- | ------ | ---------------------------------------- |
+| CBZ/ZIP | ✅     |                                          |
+| CBR/RAR | ✅     |                                          |
+| EPUB    | ⚠️     | Functional but missing features, poor UX |
+| PDF     | ⚠️     | Some PDF pages are blurry                |
 
 ## OPDS Formats
 
@@ -24,36 +24,5 @@ You may download books from your OPDS catalogs and read them offline, however on
 | ------- | --------- | ------------------------- |
 | CBZ/ZIP | ✅        |                           |
 | CBR/RAR | ✅        |                           |
-| EPUB    | ❌        | Support in the future     |
+| EPUB    | ❌        |                           |
 | PDF     | ⚠️        | Some PDF pages are blurry |
-
-## Reader Preferences
-
-Each reader has specific settings and preferences that are configurable. These settings may be set globally for all books, and overridden on a per-book basis. If you change a setting for a specific book, it will only apply to that book.
-
-There are a few settings that are common to all readers:
-
-### Incognito
-
-When enabled, the app will not save your reading progress. This wouldnt affect bookmarks or annotations, just the progress of the book.
-
-### Reading Direction
-
-You may set `LTR` (left-to-right) or `RTL` (right-to-left) reading direction.
-
-### Reading Timer
-
-When enabled, the app will track the time you spend reading each book in seconds. This will even sync across devices!
-
-<Callout emoji="ℹ️" type="info">
-	The app supports reading timers for all server configurations, but syncing is only available when
-	using a Stump server
-</Callout>
-
-#### Disabling
-
-If you disable the reading timer while reading a book, it is effectively pausing the timer. If you re-enable it, the timer will resume from where it left off. If you disable the timer globally and start reading a book, the timer will not start.
-
-#### Resetting
-
-You may reset the reading timer for a book at any time. This will reset the timer to 0 seconds

--- a/apps/docs/pages/guides/mobile/reading/image-based.mdx
+++ b/apps/docs/pages/guides/mobile/reading/image-based.mdx
@@ -16,58 +16,100 @@ The image-based reader has an overlay that presents when you click the center-po
 
 ## Preferences
 
-The following preferences are available for the image-based reader:
+Each reader has specific settings and preferences that are configurable. These settings may be set globally for all books, and overridden on a per-book basis. If you change a setting for a specific book, it will only apply to that book.
 
-### Flow
+### Reading Flow
 
-The image-based reader has a few flows that you can use to customize your reading experience:
+Controls how pages are displayed and navigated:
 
-- Paged
-- Horizontal scroll
-- Vertical scroll
+- **Paged**: Traditional page-by-page reading
+- **Scroll (Horizontal)**: Continuous horizontal scrolling
+- **Scroll (Vertical)**: Continuous vertical scrolling ⚠️ _Currently disabled_
 
 <Callout emoji="⚠️" type="warning">
 	Image zooming is funky when using the horizontal scroll flow. This is a known issue and will be
 	addressed in a future release
 </Callout>
 
-### Image Options
+### Reading Direction
 
-There are a few options specific to the images rendered you can adjust
+You may set `LTR` (left-to-right) or `RTL` (right-to-left) reading direction.
+
+<Callout emoji="ℹ️" type="info">
+	Reading direction is only available when not using continuous vertical scrolling
+</Callout>
+
+### Image Options
 
 #### Cache Policy
 
-You may specify a policy of either `Memory & Disk` (default), `Disk`, `Memory`, or `None`. This is exposed in case you have specific performance needs (or leeway) for your device. While `None` is available, it is not recommended.
+Controls how images are cached for performance:
 
-#### Double Paged
+- **Memory & Disk**: Caches images in both memory and disk storage (default)
+- **Disk**: Caches images only on disk
+- **Memory**: Caches images only in memory
+- **None**: Disables image caching (not recommended)
 
-You may specify a double page behavior of:
+#### Double Page Display
 
-- `Auto` (default) - The app will attempt to use double pages when possible (i.e. when device is landscape)
-- `Always` - Always use double pages, scaling the images to fit the screen
-- `Off` - Never use double pages
+Controls when to display two pages side-by-side:
+
+- **Auto**: Automatically determines based on page orientation and device orientation
+- **Always**: Always attempts to display two pages side-by-side
+- **Off**: Never displays two pages side-by-side
+
+#### Separate Second Page
+
+When double page display is enabled, this option controls whether the second page should be treated as a separate entity for navigation purposes.
 
 #### Image Scaling
 
-You may specify an image scaling behavior of:
+Controls how images are scaled to fit the screen:
 
-- `Fit Width` (default) - The image will be scaled to fit the width of the screen
-- `Fit Height` - The image will be scaled to fit the height of the screen
-- `None` - The image will be displayed at its original size
+- **Fit Height**: Scales images to fit the screen height
+- **Fit Width**: Scales images to fit the screen width ⚠️ _Currently disabled_
+- **None**: No scaling applied ⚠️ _Currently disabled_
 
-<Callout emoji="⚠️" type="warning">
-	This setting is not yet available and subject to change
-</Callout>
+#### Downscaling
 
-### Navigation
+When enabled, allows images to be downscaled for better performance. This can help with memory usage for large images.
+
+#### Panel Downloads
+
+Allows downloading individual panels/pages for offline reading. ⚠️ _Currently disabled/in development_
+
+### Navigation Settings
 
 #### Tap Sides to Navigate
 
-You may enable this setting to navigate to the next or previous page by tapping the left or right side of the screen, abiding by the reading direction.
+When enabled, you can tap the left and right sides of the screen to navigate between pages.
 
 #### Bottom Controls
 
-The app supports two different bottom control layouts:
+Controls the type of navigation controls shown at the bottom of the screen:
 
-1. Slider - A slider that you can drag to navigate through the book. An image preview will be displayed as you drag
-2. Image Gallery - A swipeable gallery of thumbnails that you can tap to navigate to a specific page
+- **Image Gallery**: Shows thumbnail images for navigation
+- **Slider**: Shows a simple slider for navigation
+
+### Progression Tracking
+
+#### Incognito
+
+When enabled, the app will not save your reading progress. This wouldn't affect bookmarks or annotations, just the progress of the book.
+
+#### Reading Timer
+
+When enabled, the app will track the time you spend reading each book in seconds. This will even sync across devices!
+
+<Callout emoji="ℹ️" type="info">
+	The app supports reading timers for all server configurations, but syncing is only available when
+	using a Stump server
+</Callout>
+
+##### Disabling
+
+If you disable the reading timer while reading a book, it is effectively pausing the timer. If you re-enable it, the timer will resume from where it left off. If you disable the timer globally and start reading a book, the timer will not start.
+
+##### Resetting
+
+You may reset the reading timer for a book at any time. This will reset the timer to 0 seconds

--- a/apps/docs/pages/guides/mobile/servers.mdx
+++ b/apps/docs/pages/guides/mobile/servers.mdx
@@ -42,7 +42,7 @@ The app supports 3 types of authentication:
 
 ### Login-based vs Basic Authentication
 
-On the surface, login-based and basic authentication sound similar, but the difference is that login-based authentication will not store credentials on the device. Rather, you will be prompted to log in each time you try to access the server. This has drawbacks for OPDS configurations since you will be prompted _each_ time you try to access the server. Stump servers will use short-lived JWT tokens when you log in, so you will only be prompted to log in when the token expires.
+On the surface, login-based and basic authentication sound similar, but the difference is that login-based authentication will not store credentials on the device. Rather, you will periodically be prompted to log in when you try to access the server. This has drawbacks for OPDS configurations since you will be prompted _each_ time you try to access the server. Stump servers will use short-lived JWT tokens when you log in, so you will only be prompted to log in when the token expires.
 
 <Callout emoji="ℹ️" type="info">
 	Stump will not use actual [Basic

--- a/apps/docs/pages/guides/mobile/settings.mdx
+++ b/apps/docs/pages/guides/mobile/settings.mdx
@@ -1,34 +1,95 @@
 # App Settings
 
-The mobile app has a few settings that you can configure to your liking. These settings are stored locally on your device and are not synced across devices.
+The mobile app provides comprehensive settings to customize your reading experience and app behavior. These settings are stored locally on your device and are not synced across devices.
 
 ## Preferences
 
-You may configure basic preferences like the app theme and language. A few non-standard settings are also available:
+### Theme
+
+Switch between **Light** and **Dark** themes to match your reading preference or system appearance.
+
+### Accent Color (iOS only)
+
+Customize the app's accent color using a color picker. This affects buttons, highlights, and other interactive elements throughout the app.
+
+### Language
+
+Configure the app's display language. Currently supports **English** with additional languages planned for future releases.
 
 ### Default Server
 
-A quick way to switch the currently configured default server. See the [default server](/guides/mobile/servers#default-server) guide for more information on what that is.
+Quick access to switch between your configured servers. See the [default server](/guides/mobile/servers#default-server) guide for more information about server management.
 
-### Debug Settings
+### Thumbnail Ratio
 
-A few settings are available to help aid in debugging issues or general privacy. These settings include:
+Choose how book covers and thumbnails are displayed:
 
-- **Mask URLs**: When enabled, the app will mask URLs in the UI. This is useful for screenshots or screen recordings where you don't want to expose your server URL
+- **1 : 1.6** - Taller, more cinematic aspect ratio
+- **1 : 1.5** - Default ratio, good balance for most covers
+- **1 : √2** - Square-like ratio, compact display
 
-## Reader Settings
+## Reading
 
-You may configure global settings for all readers, which can be overridden on a per-book basis. See the [readers](/guides/mobile/reading/readers) guide for more information on what these settings are.
+### Reader Settings
 
-## Data Usage
+Access comprehensive reader configuration options. This opens a dedicated settings screen where you can configure:
 
-The app has built-in mechanisms for viewing and managing the data it uses. All data is categorized by server, so you can see how much data each server is using.
+- Global reading preferences
+- Font and display settings
+- Navigation controls
+- Per-format reader options
 
-### Server Data
+These settings serve as defaults for all books and can be overridden on a per-book basis. See the [reader settings](/guides/mobile/reading/readers) guide for detailed information.
 
-Each server generally has the following data categories:
+## Stump Integration
 
-- Downloads (books, images, etc.)
-- Preferences (settings, etc.)
+### Stump Features Toggle
 
-You may clear the data for a specific server, or clear all data for all servers
+Control whether Stump-specific features are enabled in the app:
+
+- **Enabled**: Full Stump server integration with libraries, collections, and advanced features
+- **Disabled**: OPDS-only mode for basic book browsing and reading
+
+When disabled, the app operates in a simplified mode that only supports OPDS feeds, making it suitable for users who prefer a minimal reading experience or only need basic server connectivity.
+
+## Management
+
+### Data Usage
+
+Monitor and manage the app's storage usage with detailed breakdowns:
+
+- **Total Usage**: Overall storage consumed by the app
+- **Per-Server Data**: Usage categorized by each configured server
+- **Data Categories**: Downloads, cached images, preferences, and temporary files
+
+The data management screen allows you to:
+
+- View storage usage by server
+- Clear cached data selectively
+- Remove server data completely
+- Monitor download sizes
+
+## Debug & Privacy
+
+### Image Cache Management
+
+Clear cached images to free up storage space:
+
+- **Memory Cache**: Clear images stored in RAM for current session
+- **Disk Cache**: Clear permanently cached images stored on device
+
+### Reduce Animations
+
+Toggle to minimize or disable animations throughout the app. Useful for:
+
+- Improving performance on older devices
+- Reducing motion for accessibility
+- Conserving battery life
+
+### Mask URLs
+
+Privacy feature that obscures server URLs in the interface:
+
+- Useful for screenshots or screen recordings
+- Prevents accidental exposure of private server addresses
+- Maintains functionality while hiding sensitive information

--- a/apps/docs/pages/guides/opds.mdx
+++ b/apps/docs/pages/guides/opds.mdx
@@ -38,7 +38,7 @@ If you have any experiences, good or bad, using any of these clients or another 
 #### Using an API Key
 
 <Callout emoji="🔐">
-	This functionality is gated behind the `feature:api_keys` user permission. To learn more about
+	This functionality is gated behind the `ACCESS_API_KEYS` user permission. To learn more about
 	permissions, see the [permissions](/guides/access-control/permissions) guide.
 </Callout>
 

--- a/apps/docs/theme.config.tsx
+++ b/apps/docs/theme.config.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import { useRouter } from 'next/router'
 
 import Footer from './components/Footer'
@@ -10,6 +11,14 @@ export const STUMP_REPO = 'https://github.com/stumpapp/stump'
 const DOCS_PAGES_HREF = `${STUMP_REPO}/tree/main/apps/docs/pages`
 
 export default {
+	banner: {
+		key: 'sea-orm-migration',
+		content: (
+			<Link href="/guides/breaking-changes/0.1.0">
+				🎉 Stump is now using SeaORM! Please read about breaking changes 💥
+			</Link>
+		),
+	},
 	chat: {
 		link: 'https://discord.gg/63Ybb7J3as',
 	},


### PR DESCRIPTION
I didn't do a full audit of the docs website since that would be _quite_ a lot of reading, but I at the very least:

- Added a new section (accessible by clicking the announcement banner) to outline the migration process
- Updated mobile app docs to be more accurate to current state of things
- Fix permissions referenced