### PR TITLE
🐛 (expo): Fix download item heights

### DIFF
--- a/apps/expo/components/downloads/DownloadRowItem.tsx
+++ b/apps/expo/components/downloads/DownloadRowItem.tsx
@@ -8,7 +8,6 @@ import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-na
 import { imageMeta, syncStatus } from '~/db'
 import { useColors } from '~/lib/constants'
 import { formatBytesSeparate } from '~/lib/format'
-import { useListItemSize } from '~/lib/hooks'
 import { useSelectionStore } from '~/stores/selection'
 
 import { ThumbnailImage } from '../image'
@@ -16,6 +15,7 @@ import { Heading, Progress, Text } from '../ui'
 import { Icon } from '../ui/icon'
 import { SyncIcon } from './sync-icon/SyncIcon'
 import { DownloadedFile } from './types'
+import { useDownloadRowItemSize } from './useDownloadRowItemSize'
 import { getThumbnailPath } from './utils'
 
 type Props = {
@@ -34,7 +34,7 @@ export default function DownloadRowItem({ downloadedFile }: Props) {
 
 	const colors = useColors()
 
-	const { width, height } = useListItemSize()
+	const { width, height } = useDownloadRowItemSize()
 
 	const selectionStore = useSelectionStore((state) => ({
 		isSelectionMode: state.isSelecting,
@@ -137,13 +137,13 @@ export default function DownloadRowItem({ downloadedFile }: Props) {
 							uri: getThumbnailPath(downloadedFile),
 						}}
 						resizeMode="stretch"
-						size={{ height: height / 2, width: width / 2 }}
+						size={{ height, width }}
 						placeholderData={thumbnailData}
 					/>
 
-					<View className="flex-1 justify-center py-2">
+					<View className="flex-1 justify-center py-1.5">
 						<View className="flex flex-1 flex-row justify-between gap-2">
-							<View className="flex shrink gap-1">
+							<View className="flex shrink gap-0.5">
 								<Heading numberOfLines={2}>{downloadedFile.bookName || 'Untitled'}</Heading>
 								<Text className="text-foreground-muted">{renderSubtitle()}</Text>
 							</View>

--- a/apps/expo/components/downloads/useDownloadRowItemSize.ts
+++ b/apps/expo/components/downloads/useDownloadRowItemSize.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react'
+
+import { useDisplay } from '~/lib/hooks'
+import { usePreferencesStore } from '~/stores'
+
+export function useDownloadRowItemSize() {
+	const { isTablet } = useDisplay()
+	const thumbnailRatio = usePreferencesStore((state) => state.thumbnailRatio)
+
+	const itemHeight = useMemo(() => (isTablet ? 120 : 105), [isTablet])
+	const itemWidth = useMemo(() => itemHeight * thumbnailRatio, [itemHeight, thumbnailRatio])
+
+	return {
+		height: itemHeight,
+		width: itemWidth,
+	}
+}


### PR DESCRIPTION
The `DownloadRowItem`'s have different heights depending on the title having one or two lines, which makes things look uneven when using thumbnail ratio 1:1.41 or 1:1.5:

<details>
<summary> Before vs After </summary>

<table>
<thead>
<tr>
<th align="center"><strong>Before</strong></th>
<th align="center"><strong>&nbsp;After&nbsp;&nbsp;</strong></th>
</tr>
</thead>
<tbody>
<tr>
<td align="center">
<img width="1170" height="1342" alt="1" src="https://github.com/user-attachments/assets/9472b6f2-91a1-4e0e-b355-f77649861699" />
</td>
<td align="center"> 
<img width="1170" height="1342" alt="3" src="https://github.com/user-attachments/assets/d3dfb927-37f3-4943-9de9-a7f183056bfc" />
</td>
</tr>
<tr>
<td align="center">
<img width="1170" height="1342" alt="2" src="https://github.com/user-attachments/assets/26da2e5a-2e3b-43a4-95a0-379fe16a690b" />
</td>
<td align="center"> 
<img width="1170" height="1342" alt="4" src="https://github.com/user-attachments/assets/d5583348-639c-4fca-be19-f4f7e4bb6772" />
</td>
</tr>
<tr>
<td colspan="2" align="center">
In "After" the thumbnails/download row items look taller because I use thumbnail 1:1.41, but if you use 1:1.5 they're near identical to before (~2px taller). All explained below.
</td>
</tr>
</tbody>
</table>

</details>

Up until now all widths have been fixed with height varying based on the thumbnail ratio, because that worked well for the grids and horizontal lists. But these should probably use a fixed height with varying widths, so I've done that. 

Now with all thumbnails being the same height regardless of aspect ratio, the actual fix is just to reduce the padding slightly, but there are other ways if you prefer (like reducing text size or line spacing).

---

Also I've used `useMemo` the same way it's used in `useListItemSize`, but they're cheap calculations so doesn't it actually hurt performance? Maybe we can just enable the [React Compiler](https://docs.expo.dev/guides/react-compiler/ ) at some point to not need to think about these things ever again?