### PR TITLE
:memo: Add missing server options to the docs

### DIFF
--- a/apps/docs/pages/guides/configuration/server-options.md
+++ b/apps/docs/pages/guides/configuration/server-options.md
@@ -2,7 +2,7 @@
 
 > Stump will use default options if you don't manually configure them. When following this guide, keep in mind you only need to provide values for things you wish to override.
 
-Stump uses something called environment variables to set all of the various configuration properties. These environment variables are controlled has a custom TOML-based configuration, which is located by default at `$STUMP_CONFIG_DIR/Stump.toml`. `STUMP_CONFIG_DIR` itself is an environment variable that defaults to `.stump` your home directory, e.g., `/Users/oromei/.stump`.
+Stump uses something called environment variables to set all the various configuration properties. These environment variables are controlled has a custom TOML-based configuration, which is located by default at `$STUMP_CONFIG_DIR/Stump.toml`. `STUMP_CONFIG_DIR` itself is an environment variable that defaults to `.stump` your home directory, e.g., `/Users/oromei/.stump`.
 
 If you're using Stump with Docker, you'll want to specify environment variables in either the `docker run` or `docker-compose.yml` file to override the default configuration. See the [Docker](/installation/docker) guide for more information.
 
@@ -30,7 +30,61 @@ The directory where Stump will look for email templates. This is only required i
 | ------ | ------------------------ |
 | String | `{config_dir}/templates` |
 
-#### PDFIUM_PATH
+### ENABLE_KOREADER_SYNC
+
+Whether or not to enable the KoReader sync integration. This is a special integration that allows KoReader to sync with Stump. To learn more about this integration, visit the [KoReader](/guides/integrations/koreader) guide.
+
+| Type    | Default Value |
+| ------- | ------------- |
+| Boolean | `false`       |
+
+### ENABLE_OPDS_PROGRESSION
+
+Whether or not OPDS page access should automatically track reading progression. When disabled, accessing pages via OPDS won't update reading progress, which prevents inaccurate tracking when clients preload or cache multiple pages at once. This is particularly useful for OPDS clients that load more than one page at a time.
+
+| Type    | Default Value |
+| ------- | ------------- |
+| Boolean | `false`       |
+
+### ENABLE_SWAGGER_UI
+
+Whether or not to enable Swagger UI. To learn more about what Swagger UI is, visit [swagger.io](https://swagger.io/).
+
+| Type    | Default Value |
+| ------- | ------------- |
+| Boolean | `false`       |
+
+### ENABLE_UPLOAD
+
+| Type    | Default Value |
+| ------- | ------------- |
+| Boolean | `false`       |
+
+### HASH_COST
+
+Controls the computational cost used when hashing user passwords.
+
+| Type    | Default Value |
+| ------- | ------------- |
+| Integer | `12`          |
+
+### MAX_FILE_UPLOAD_SIZE
+
+The maximum allowed size, in bytes, of files uploaded via the upload interface. This configuration variable will have no effect unless `ENABLE_UPLOAD` is `true`.
+
+| Type    | Default Value      |
+| ------- | ------------------ |
+| Integer | `20971520` (20 MB) |
+
+### MAX_IMAGE_UPLOAD_SIZE
+
+The maximum size, in bytes, for images uploaded as thumbnails for users, libraries, series, or media.
+
+| Type    | Default Value      |
+| ------- | ------------------ |
+| Integer | `20971520` (20 MB) |
+
+### PDFIUM_PATH
 
 The path to the PDFium binary. This is only required if you want PDF support and you're running Stump outside of Docker, since the PDFium binary is included in the Docker image. You'll want to find and download the PDFium binary for your platform from [here](https://github.com/bblanchon/pdfium-binaries/releases), and then set this environment variable to the path of the binary.
 
@@ -38,7 +92,7 @@ The path to the PDFium binary. This is only required if you want PDF support and
 | ------ | ----------------------------- |
 | String | `/lib/libpdfium.so` in Docker |
 
-#### SESSION_EXPIRY_CLEANUP_INTERVAL
+### SESSION_EXPIRY_CLEANUP_INTERVAL
 
 The time (_in seconds_) between each session expiry cleanup check. The check will remove any expired sessions from the database.
 
@@ -46,7 +100,7 @@ The time (_in seconds_) between each session expiry cleanup check. The check wil
 | ------- | ------------- |
 | Integer | `60`          |
 
-#### SESSION_TTL
+### SESSION_TTL
 
 The time-to-live for session cookies. This is the amount of time that a session cookie will be valid for _in seconds_. The default value is `259200`, or 3 days. You can set this to a different value if you want sessions to expire sooner or later, depending on your needs.
 
@@ -66,14 +120,6 @@ This corresponds to the `allowed_origins` configuration option in the `Stump.tom
 
 **Be sure to replace `{machine_ip}` and `{configured_port}` with the appropriate values for your environment.**
 
-### STUMP_CONFIG_DIR
-
-The directory where Stump will look for its configuration file.
-
-| Type   | Default Value |
-| ------ | ------------- |
-| String | `~/.stump`    |
-
 ### STUMP_CLIENT_DIR
 
 The directory the contains the web bundle for the web UI
@@ -82,38 +128,21 @@ The directory the contains the web bundle for the web UI
 | ------ | ------------- |
 | String | `./dist`      |
 
-### STUMP_PROFILE
+### STUMP_CONFIG_DIR
 
-The profile to use when running Stump. This should really be left alone and **not** manually set.
+The directory where Stump will look for its configuration file.
 
 | Type   | Default Value |
 | ------ | ------------- |
-| String | `release`     |
+| String | `~/.stump`    |
 
-### STUMP_PORT
+### STUMP_DB_PATH
 
-The port for the Stump server.
+Overrides the path where Stump stores its database file. By default this path is same as parent directory of `STUMP_CONFIG_DIR`. If set the database would be put at `STUMP_DB_PATH/stump.db`.
 
-| Type    | Default Value |
-| ------- | ------------- |
-| Integer | `10801`       |
-
-### STUMP_VERBOSITY
-
-The verbosity level for Stump logs. Verbosity levels are integers that correspond to a list of log levels that will be visible, and are inclusive of all the levels below them.
-
-For example, if you set the verbosity level to `1`, you will see `INFO`, `WARN`, and `ERROR` messages. If you set the verbosity level to `2`, you will see `DEBUG`, `INFO`, `WARN`, and `ERROR` messages, and so on. The default verbosity level is `1`.
-
-You may turn off logging entirely by setting the verbosity level to `0`. However, this is not recommended, as it will make it difficult to debug issues with Stump if they arise. I generally recommend setting the verbosity to `1`, as it allows you to see info-level messages, warnings, and errors.
-
-The available verbosity levels are:
-
-| Option | Visible Log Levels                        |
-| ------ | ----------------------------------------- |
-| `0`    | `NONE`                                    |
-| `1`    | `INFO`, `WARN`, `ERROR`                   |
-| `2`    | `DEBUG`, `INFO`, `WARN`, `ERROR`          |
-| `3`    | `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR` |
+| Type   | Default Value |
+| ------ | ------------- |
+| String |               |
 
 ### STUMP_MAX_SCANNER_CONCURRENCY
 
@@ -135,48 +164,92 @@ The maximum number of images which may be generated concurrently by the thumbnai
 | ------- | ------------- |
 | Integer | `50`          |
 
-### ENABLE_SWAGGER_UI
+### STUMP_PDF_CACHE_PAGES
 
-Whether or not to enable Swagger UI. To learn more about what Swagger UI is, visit [swagger.io](https://swagger.io/).
-
-| Type    | Default Value |
-| ------- | ------------- |
-| Boolean | `false`       |
-
-### ENABLE_KOREADER_SYNC
-
-Whether or not to enable the KoReader sync integration. This is a special integration that allows KoReader to sync with Stump. To learn more about this integration, visit the [KoReader](/guides/integrations/koreader) guide.
+Controls whether rendered PDF pages are cached.
 
 | Type    | Default Value |
 | ------- | ------------- |
-| Boolean | `false`       |
+| Boolean | `true`        |
 
-### ENABLE_OPDS_PROGRESSION
+### STUMP_PDF_HIGH_QUALITY
 
-Whether or not OPDS page access should automatically track reading progression. When disabled, accessing pages via OPDS won't update reading progress, which prevents inaccurate tracking when clients preload or cache multiple pages at once. This is particularly useful for OPDS clients that load more than one page at a time.
-
-| Type    | Default Value |
-| ------- | ------------- |
-| Boolean | `false`       |
-
-### ENABLE_UPLOAD
+Enables higher-quality PDF rendering at the cost of increased resource usage.
 
 | Type    | Default Value |
 | ------- | ------------- |
-| Boolean | `false`       |
+| Boolean | `true`        |
 
-### MAX_IMAGE_UPLOAD_SIZE
+### STUMP_PDF_MAX_DIMENSION
 
-The maximum size, in bytes, for images uploaded as thumbnails for users, libraries, series, or media.
+Controls the maximum width or height (in pixels) for rendered PDF images.
 
-| Type    | Default Value      |
-| ------- | ------------------ |
-| Integer | `20971520` (20 MB) |
+| Type    | Default Value |
+| ------- | ------------- |
+| Integer | `1200`        |
 
-### MAX_FILE_UPLOAD_SIZE
+### STUMP_PDF_PRERENDER_RANGE
 
-The maximum allowed size, in bytes, of files uploaded via the upload interface. This configuration variable will have no effect unless `ENABLE_UPLOAD` is `true`.
+Controls how many pages before and after the current page should be pre-rendered.
 
-| Type    | Default Value      |
-| ------- | ------------------ |
-| Integer | `20971520` (20 MB) |
+| Type    | Default Value |
+| ------- | ------------- |
+| Integer | `5`           |
+
+### STUMP_PDF_RENDER_DPI
+
+Sets the DPI (dots per inch) used when rendering PDF pages. High values increases image clarity at the cost of memory usage and render time.
+
+| Type    | Default Value |
+| ------- | ------------- |
+| Integer | `150`         |
+
+### STUMP_PDF_RENDER_FORMAT
+
+Specifies the images format used when rendering PDF pages.
+
+| Type   | Default Value |
+| ------ | ------------- |
+| String | `webp`        |
+
+### STUMP_PORT
+
+The port for the Stump server.
+
+| Type    | Default Value |
+| ------- | ------------- |
+| Integer | `10801`       |
+
+### STUMP_PRETTY_LOGS
+
+Controls whether logs are formatted in a human-friendly, pretty-printed style.
+
+| Type    | Default Value |
+| ------- | ------------- |
+| Boolean | `true`        |
+
+### STUMP_PROFILE
+
+The profile to use when running Stump. This should really be left alone and **not** manually set.
+
+| Type   | Default Value |
+| ------ | ------------- |
+| String | `release`     |
+
+### STUMP_VERBOSITY
+
+The verbosity level for Stump logs. Verbosity levels are integers that correspond to a list of log levels that will be visible, and are inclusive of all the levels below them.
+
+For example, if you set the verbosity level to `1`, you will see `INFO`, `WARN`, and `ERROR` messages. If you set the verbosity level to `2`, you will see `DEBUG`, `INFO`, `WARN`, and `ERROR` messages, and so on. The default verbosity level is `1`.
+
+You may turn off logging entirely by setting the verbosity level to `0`. However, this is not recommended, as it will make it difficult to debug issues with Stump if they arise. I generally recommend setting the verbosity to `1`, as it allows you to see info-level messages, warnings, and errors.
+
+The available verbosity levels are:
+
+| Option | Visible Log Levels                        |
+| ------ | ----------------------------------------- |
+| `0`    | `NONE`                                    |
+| `1`    | `INFO`, `WARN`, `ERROR`                   |
+| `2`    | `DEBUG`, `INFO`, `WARN`, `ERROR`          |
+| `3`    | `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR` |
+


### PR DESCRIPTION
## Changes

- A lot of server options were missing from documentation.
- Arranged the options in alphabetical order

