### PR TITLE
:bug: Fix OPDS pagination infinite loop caused by `next_page()` bug

### DIFF
--- a/crates/graphql/src/pagination.rs
+++ b/crates/graphql/src/pagination.rs
@@ -84,11 +84,7 @@ impl OffsetPagination {
 	}
 
 	pub fn next_page(&self) -> u64 {
-		if self.zero_based.unwrap_or(false) {
-			self.page + 1
-		} else {
-			self.page
-		}
+		self.page + 1
 	}
 
 	pub fn previous_page(&self) -> Option<u64> {
@@ -401,5 +397,54 @@ pub async fn get_paginated_results<
 		},
 		Pagination::Offset(info) => get_paginated_offset_results(query, conn, info).await,
 		Pagination::None(_) => get_paginated_none_results(query, conn).await,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	mod offset_pagination {
+		use super::*;
+
+		#[test]
+		fn next_page_returns_current_page_plus_one_when_one_based() {
+			let pagination = OffsetPagination {
+				page: 1,
+				page_size: Some(20),
+				zero_based: Some(false),
+			};
+			assert_eq!(pagination.next_page(), 2);
+		}
+
+		#[test]
+		fn next_page_returns_current_page_plus_one_when_zero_based() {
+			let pagination = OffsetPagination {
+				page: 0,
+				page_size: Some(20),
+				zero_based: Some(true),
+			};
+			assert_eq!(pagination.next_page(), 1);
+		}
+
+		#[test]
+		fn next_page_works_for_page_5_one_based() {
+			let pagination = OffsetPagination {
+				page: 5,
+				page_size: Some(20),
+				zero_based: Some(false),
+			};
+			assert_eq!(pagination.next_page(), 6);
+		}
+
+		#[test]
+		fn next_page_works_for_page_5_zero_based() {
+			let pagination = OffsetPagination {
+				page: 5,
+				page_size: Some(20),
+				zero_based: Some(true),
+			};
+			assert_eq!(pagination.next_page(), 6);
+		}
 	}
 }


### PR DESCRIPTION
Fix a bug in `OffsetPagination::next_page()` where the method returns the current page instead of the next page when using 1-based pagination (the default). This caused OPDS 2.0 clients to enter an infinite loop when following pagination links.

## Problem

When `zero_based` is `false` (the default, 1-based pagination), the `next_page()` method returned `self.page` instead of `self.page + 1`. This resulted in the OPDS 2.0 `next` link always pointing to the current page (e.g., `?page=1` -> `?page=1`).

## Solution

Simplified the method to always return `self.page + 1`, as the next page calculation does not depend on whether pagination is 0-based or 1-based.

## Changes

- Fixed `OffsetPagination::next_page()` to correctly return the next page number
- Added unit tests for `next_page()` covering both 0-based and 1-based pagination scenarios
