### PR TITLE
🐛 Fix premature library creation

### DIFF
--- a/packages/browser/src/scenes/createLibrary/CreateLibraryForm.tsx
+++ b/packages/browser/src/scenes/createLibrary/CreateLibraryForm.tsx
@@ -159,6 +159,15 @@ export default function CreateLibraryForm({ existingLibraries, onSubmit, isLoadi
 		}
 	}
 
+	/**
+	 * Prevent a submit event triggering when the enter key is pressed on an input
+	 */
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLFormElement>) => {
+		if (e.key === 'Enter' && e.target instanceof HTMLInputElement) {
+			e.preventDefault()
+		}
+	}
+
 	// Note: The submit button is always rendered because I noticed that conditional rendering
 	// causes the form to trigger a submit event. FYI
 	return (
@@ -175,7 +184,7 @@ export default function CreateLibraryForm({ existingLibraries, onSubmit, isLoadi
 					}}
 				/>
 			)}
-			<Form form={form} onSubmit={onSubmit} id="createLibraryForm">
+			<Form form={form} onSubmit={onSubmit} id="createLibraryForm" onKeyDown={handleKeyDown}>
 				<ContentContainer className="mt-0">
 					{renderStep()}
 


### PR DESCRIPTION
Solves #757. Would you prefer this in nightly?

I thought at first it was because of this:

https://github.com/stumpapp/stump/blob/ec3447292ee9f5cd99f925c7b4d941f16291c04a/packages/browser/src/scenes/createLibrary/CreateLibraryForm.tsx#L171-L172

because making it conditional fixed it for the first step (i.e. for the Name and Path inputs) but didn't fix it for the other steps (e.g. the Ignore rules input box and the thumbnail generation scale factor input box, etc).

Also I didn't see the issue in the note but it doesn't really matter