### PR TITLE
💄 (expo): Update settings page design

### DIFF
--- a/apps/expo/app/(tabs)/settings/index.tsx
+++ b/apps/expo/app/(tabs)/settings/index.tsx
@@ -20,57 +20,45 @@ import {
 import AppPrimaryColor from '~/components/appSettings/preferences/AppPrimaryColor'
 import DisableDismissGesture from '~/components/appSettings/preferences/DisableDismissGesture'
 import { StumpEnabled } from '~/components/appSettings/stump'
-import { Text } from '~/components/ui/text'
+import { CardList } from '~/components/ui'
 
 export default function Screen() {
 	return (
 		<ScrollView className="flex-1 bg-background" contentInsetAdjustmentBehavior="automatic">
 			<View className="flex-1 gap-8 bg-background p-4 tablet:p-6">
-				<View>
-					<Text className="mb-3 text-foreground-muted">Preferences</Text>
+				<CardList label="Preferences">
 					<AppTheme />
 					<AppPrimaryColor />
 					<AppLanguage />
 					<DefaultServer />
 					<ThumbnailRatio />
 					<ThumbnailPlaceholder />
-				</View>
+				</CardList>
 
-				<View>
-					<Text className="mb-3 text-foreground-muted">Reading</Text>
-
+				<CardList label="Reading">
 					<PreferNativePdf />
 					{Platform.OS === 'ios' && <DisableDismissGesture />}
-
 					<ReaderSettingsLink />
-				</View>
+				</CardList>
 
-				<View>
-					<Text className="mb-3 text-foreground-muted">Stump</Text>
-
-					<View className="squircle mb-2 rounded-xl bg-fill-info-secondary p-2 tablet:p-3">
-						<Text className="text-fill-info">
-							Stump features are optional, you can completely turn them off if you just want OPDS
-							support
-						</Text>
-					</View>
-
+				<CardList
+					label="Stump"
+					description="Stump features are optional, you can completely turn them off if you just want OPDS support"
+				>
 					<StumpEnabled />
-				</View>
+				</CardList>
 
-				<View>
-					<Text className="mb-3 text-foreground-muted">Management</Text>
+				<CardList label="Management">
 					<AppDataUsageLink />
-				</View>
+				</CardList>
 
-				<View>
-					<Text className="mb-3 text-foreground-muted">Debug</Text>
+				<CardList label="Debug">
 					<ImageCacheActions />
 					{__DEV__ && <DeleteDatabase />}
 					<PerformanceMonitor />
 					<ReduceAnimations />
 					<MaskURLs />
-				</View>
+				</CardList>
 
 				<ContactInformation />
 

--- a/apps/expo/app/(tabs)/settings/usage/index.tsx
+++ b/apps/expo/app/(tabs)/settings/usage/index.tsx
@@ -7,7 +7,7 @@ import { Pressable, ScrollView } from 'react-native-gesture-handler'
 import { SafeAreaView } from 'react-native-safe-area-context'
 
 import RefreshControl from '~/components/RefreshControl'
-import { CardList, Heading, Icon, ListEmptyMessage, Text } from '~/components/ui'
+import { CardList, CardRow, Heading, Icon, ListEmptyMessage, Text } from '~/components/ui'
 import { getAppUsage } from '~/lib/filesystem'
 import { formatBytes } from '~/lib/format'
 import { useDynamicHeader } from '~/lib/hooks/useDynamicHeader'
@@ -84,14 +84,12 @@ export default function Screen() {
 											})
 										}
 									>
-										<View className={'flex flex-row items-center justify-between p-4'}>
-											<Text>{server.name}</Text>
-
+										<CardRow label={server.name}>
 											<View className="flex flex-row items-center gap-2">
 												<Text>{formatBytes(serverToUsage[server.id], 0, 'MB')}</Text>
 												<Icon as={ChevronRight} className="h-5 w-5 text-foreground-muted" />
 											</View>
-										</View>
+										</CardRow>
 									</Pressable>
 								))}
 							</CardList>

--- a/apps/expo/app/server/[id]/(tabs)/browse/index.tsx
+++ b/apps/expo/app/server/[id]/(tabs)/browse/index.tsx
@@ -17,6 +17,7 @@ import { useStumpServer } from '~/components/activeServer'
 import { RecentlyAddedSeries } from '~/components/series'
 import { Heading, Text } from '~/components/ui'
 import { Icon } from '~/components/ui/icon'
+import { IS_IOS_24_PLUS } from '~/lib/constants'
 import { cn } from '~/lib/utils'
 
 const ITEMS = [
@@ -127,11 +128,7 @@ export default function Screen() {
 }
 
 const Divider = () => (
-	<View
-		className={cn('h-px w-full bg-edge')}
-		style={{
-			// px-4 is 16, icon is 24, so 16 + 24 = 40 to edge of icon, then add 8px padding
-			marginLeft: Platform.OS === 'android' ? 0 : 48,
-		}}
-	/>
+	// ios: left padding (px-4) + icon width (w-6) + gap between icon and text (gap-4) = ml-14
+	// give ios 26+ right margin too = mr-4
+	<View className={cn('ios:ml-14 h-px bg-edge', IS_IOS_24_PLUS && 'mr-4')} />
 )

--- a/apps/expo/components/appSettings/AppSettingsRow.tsx
+++ b/apps/expo/components/appSettings/AppSettingsRow.tsx
@@ -1,17 +1,14 @@
-import { BadgeQuestionMark, LucideIcon } from 'lucide-react-native'
-import { forwardRef, Fragment } from 'react'
-import { Platform, Pressable, View } from 'react-native'
+import { LucideIcon } from 'lucide-react-native'
+import { forwardRef } from 'react'
+import { Pressable, View } from 'react-native'
 
-import { cn } from '~/lib/utils'
-
-import { Text } from '../ui'
-import { Icon } from '../ui/icon'
+import { CardRow } from '../ui'
 
 type Props = {
 	icon: LucideIcon
 	title: string
+	disabled?: boolean
 	onPress?: () => void
-	divide?: boolean
 	isLink?: boolean
 } & React.ComponentProps<typeof View>
 
@@ -19,40 +16,23 @@ type Props = {
 // link to website vs action etc
 
 const AppSettingsRow = forwardRef<View, Props>(
-	({ icon, title, children, className, divide = true, isLink, ...props }, ref) => {
+	({ icon, title, disabled, children, isLink, ...props }, ref) => {
 		return (
-			<Fragment>
-				<Pressable {...props} ref={ref}>
-					{({ pressed }) => (
-						<View
-							className={cn('flex-row items-center justify-between py-3', className)}
-							style={{ opacity: pressed && isLink ? 0.7 : 1 }}
-						>
-							<View className="flex-row items-center gap-4">
-								<View className="squircle flex h-8 w-8 items-center justify-center rounded-xl bg-background-surface">
-									<Icon as={icon || BadgeQuestionMark} className="h-6 w-6 text-foreground-muted" />
-								</View>
-								<Text className="text-lg">{title}</Text>
-							</View>
-							{children}
-						</View>
-					)}
-				</Pressable>
-
-				{divide && <Divider />}
-			</Fragment>
+			<Pressable {...props} ref={ref}>
+				{({ pressed }) => (
+					<CardRow
+						icon={icon}
+						label={title}
+						style={pressed && isLink && { opacity: 0.7 }}
+						disabled={disabled}
+					>
+						{children}
+					</CardRow>
+				)}
+			</Pressable>
 		)
 	},
 )
 AppSettingsRow.displayName = 'AppSettingsRow'
 
 export default AppSettingsRow
-
-const Divider = () => (
-	<View
-		className={cn('h-px w-full bg-edge')}
-		style={{
-			marginLeft: Platform.OS === 'android' ? 0 : 42,
-		}}
-	/>
-)

--- a/apps/expo/components/appSettings/ContactInformation.tsx
+++ b/apps/expo/components/appSettings/ContactInformation.tsx
@@ -1,16 +1,14 @@
 import { ArrowUpRight, Github, Mail } from 'lucide-react-native'
-import { Linking, View } from 'react-native'
+import { Linking } from 'react-native'
 
-import { Icon, icons, Text } from '../ui'
+import { CardList, Icon, icons } from '../ui'
 import AppSettingsRow from './AppSettingsRow'
 
 const { Discord } = icons
 
 export default function ContactInformation() {
 	return (
-		<View>
-			<Text className="mb-3 text-foreground-muted">Contact</Text>
-
+		<CardList label="Contact">
 			<AppSettingsRow
 				icon={Mail}
 				title="Email"
@@ -27,7 +25,7 @@ export default function ContactInformation() {
 				isLink
 				onPress={() => Linking.openURL('https://discord.gg/63Ybb7J3as')}
 			>
-				<ArrowUpRight size={20} className="text-foreground-muted" />
+				<Icon as={ArrowUpRight} size={20} className="text-foreground-muted" />
 			</AppSettingsRow>
 
 			<AppSettingsRow
@@ -36,8 +34,8 @@ export default function ContactInformation() {
 				isLink
 				onPress={() => Linking.openURL('https://github.com/stumpapp/stump/issues/new/choose')}
 			>
-				<ArrowUpRight size={20} className="text-foreground-muted" />
+				<Icon as={ArrowUpRight} size={20} className="text-foreground-muted" />
 			</AppSettingsRow>
-		</View>
+		</CardList>
 	)
 }

--- a/apps/expo/components/appSettings/preferences/AppLanguage.tsx
+++ b/apps/expo/components/appSettings/preferences/AppLanguage.tsx
@@ -7,7 +7,7 @@ import AppSettingsRow from '../AppSettingsRow'
 
 export default function AppLanguage() {
 	return (
-		<AppSettingsRow icon={Languages} title="Language">
+		<AppSettingsRow icon={Languages} title="Language" disabled>
 			<View className="flex flex-row items-center gap-2">
 				<Text className="text-foreground-muted">English</Text>
 				<Icon as={ChevronsUpDown} className="h-5 text-foreground-muted" />

--- a/apps/expo/components/book/overview/InfoRow.tsx
+++ b/apps/expo/components/book/overview/InfoRow.tsx
@@ -1,7 +1,4 @@
-import { View } from 'react-native'
-
-import { Text } from '~/components/ui'
-import { cn } from '~/lib/utils'
+import { CardRow, Text } from '~/components/ui'
 
 type Props = {
 	label: string
@@ -11,16 +8,15 @@ type Props = {
 	className?: string
 }
 
-export default function InfoRow({ label, value, longValue, numberOfLines, className }: Props) {
+export default function InfoRow({ label, value, longValue, numberOfLines }: Props) {
 	return (
-		<View className={cn('flex flex-row items-start justify-between gap-x-4 px-4 py-3', className)}>
-			<Text className="shrink-0 text-foreground-muted">{label}</Text>
+		<CardRow label={label}>
 			<Text
-				className="flex-1 text-right"
+				className="flex-1 text-right text-lg text-foreground-muted"
 				numberOfLines={(numberOfLines ?? longValue) ? 4 : undefined}
 			>
 				{value}
 			</Text>
-		</View>
+		</CardRow>
 	)
 }

--- a/apps/expo/components/book/reader/settings/DoublePageSelect.tsx
+++ b/apps/expo/components/book/reader/settings/DoublePageSelect.tsx
@@ -16,44 +16,40 @@ export default function DoublePageSelect({ behavior, onChange }: Props) {
 	const [isOpen, setIsOpen] = useState(false)
 
 	return (
-		<View className="flex flex-row items-center justify-between p-4">
-			<Text>Double Paged</Text>
+		<DropdownMenu.Root onOpenChange={setIsOpen}>
+			<DropdownMenu.Trigger>
+				<View className={cn('flex-row items-center gap-1.5', { 'opacity-80': isOpen })}>
+					<Text>{BEHAVIOR_TEXT[behavior]}</Text>
+					<Icon as={ChevronsUpDown} className="h-5 text-foreground-muted" />
+				</View>
+			</DropdownMenu.Trigger>
 
-			<DropdownMenu.Root onOpenChange={setIsOpen}>
-				<DropdownMenu.Trigger>
-					<View className={cn('flex-row items-center gap-1.5', { 'opacity-80': isOpen })}>
-						<Text>{BEHAVIOR_TEXT[behavior]}</Text>
-						<Icon as={ChevronsUpDown} className="h-5 text-foreground-muted" />
-					</View>
-				</DropdownMenu.Trigger>
+			<DropdownMenu.Content>
+				<DropdownMenu.CheckboxItem
+					key="auto"
+					value={behavior === 'auto'}
+					onValueChange={() => onChange('auto')}
+				>
+					<DropdownMenu.ItemTitle>Auto</DropdownMenu.ItemTitle>
+				</DropdownMenu.CheckboxItem>
 
-				<DropdownMenu.Content>
-					<DropdownMenu.CheckboxItem
-						key="auto"
-						value={behavior === 'auto'}
-						onValueChange={() => onChange('auto')}
-					>
-						<DropdownMenu.ItemTitle>Auto</DropdownMenu.ItemTitle>
-					</DropdownMenu.CheckboxItem>
+				<DropdownMenu.CheckboxItem
+					key="always"
+					value={behavior === 'always'}
+					onValueChange={() => onChange('always')}
+				>
+					<DropdownMenu.ItemTitle>Always</DropdownMenu.ItemTitle>
+				</DropdownMenu.CheckboxItem>
 
-					<DropdownMenu.CheckboxItem
-						key="always"
-						value={behavior === 'always'}
-						onValueChange={() => onChange('always')}
-					>
-						<DropdownMenu.ItemTitle>Always</DropdownMenu.ItemTitle>
-					</DropdownMenu.CheckboxItem>
-
-					<DropdownMenu.CheckboxItem
-						key="off"
-						value={behavior === 'off'}
-						onValueChange={() => onChange('off')}
-					>
-						<DropdownMenu.ItemTitle>Off</DropdownMenu.ItemTitle>
-					</DropdownMenu.CheckboxItem>
-				</DropdownMenu.Content>
-			</DropdownMenu.Root>
-		</View>
+				<DropdownMenu.CheckboxItem
+					key="off"
+					value={behavior === 'off'}
+					onValueChange={() => onChange('off')}
+				>
+					<DropdownMenu.ItemTitle>Off</DropdownMenu.ItemTitle>
+				</DropdownMenu.CheckboxItem>
+			</DropdownMenu.Content>
+		</DropdownMenu.Root>
 	)
 }
 

--- a/apps/expo/components/book/reader/settings/FootControlsSelect.tsx
+++ b/apps/expo/components/book/reader/settings/FootControlsSelect.tsx
@@ -16,36 +16,32 @@ export default function FooterControlsSelect({ variant, onChange }: Props) {
 	const [isOpen, setIsOpen] = useState(false)
 
 	return (
-		<View className="flex flex-row items-center justify-between p-4">
-			<Text>Bottom Controls</Text>
+		<DropdownMenu.Root onOpenChange={setIsOpen}>
+			<DropdownMenu.Trigger>
+				<View className={cn('flex-row items-center gap-1.5', { 'opacity-80': isOpen })}>
+					<Text>{VARIANT_TEXT[variant]}</Text>
+					<Icon as={ChevronsUpDown} className="h-5 text-foreground-muted" />
+				</View>
+			</DropdownMenu.Trigger>
 
-			<DropdownMenu.Root onOpenChange={setIsOpen}>
-				<DropdownMenu.Trigger>
-					<View className={cn('flex-row items-center gap-1.5', { 'opacity-80': isOpen })}>
-						<Text>{VARIANT_TEXT[variant]}</Text>
-						<Icon as={ChevronsUpDown} className="h-5 text-foreground-muted" />
-					</View>
-				</DropdownMenu.Trigger>
+			<DropdownMenu.Content>
+				<DropdownMenu.CheckboxItem
+					key="images"
+					value={variant === 'images'}
+					onValueChange={() => onChange('images')}
+				>
+					<DropdownMenu.ItemTitle>{VARIANT_TEXT.images}</DropdownMenu.ItemTitle>
+				</DropdownMenu.CheckboxItem>
 
-				<DropdownMenu.Content>
-					<DropdownMenu.CheckboxItem
-						key="images"
-						value={variant === 'images'}
-						onValueChange={() => onChange('images')}
-					>
-						<DropdownMenu.ItemTitle>{VARIANT_TEXT.images}</DropdownMenu.ItemTitle>
-					</DropdownMenu.CheckboxItem>
-
-					<DropdownMenu.CheckboxItem
-						key="slider"
-						value={variant === 'slider'}
-						onValueChange={() => onChange('slider')}
-					>
-						<DropdownMenu.ItemTitle>{VARIANT_TEXT.slider}</DropdownMenu.ItemTitle>
-					</DropdownMenu.CheckboxItem>
-				</DropdownMenu.Content>
-			</DropdownMenu.Root>
-		</View>
+				<DropdownMenu.CheckboxItem
+					key="slider"
+					value={variant === 'slider'}
+					onValueChange={() => onChange('slider')}
+				>
+					<DropdownMenu.ItemTitle>{VARIANT_TEXT.slider}</DropdownMenu.ItemTitle>
+				</DropdownMenu.CheckboxItem>
+			</DropdownMenu.Content>
+		</DropdownMenu.Root>
 	)
 }
 

--- a/apps/expo/components/book/reader/settings/ImageScalingSelect.tsx
+++ b/apps/expo/components/book/reader/settings/ImageScalingSelect.tsx
@@ -16,55 +16,51 @@ export default function ImageScalingSelect({ behavior, onChange }: Props) {
 	const [isOpen, setIsOpen] = useState(false)
 
 	return (
-		<View className="flex flex-row items-center justify-between p-4">
-			<Text>Scaling</Text>
+		<DropdownMenu.Root onOpenChange={setIsOpen}>
+			<DropdownMenu.Trigger>
+				<View className={cn('flex-row items-center gap-1.5', { 'opacity-80': isOpen })}>
+					<Text>{BEHAVIOR_TEXT[behavior]}</Text>
+					<Icon as={ChevronsUpDown} className="h-5 text-foreground-muted" />
+				</View>
+			</DropdownMenu.Trigger>
 
-			<DropdownMenu.Root onOpenChange={setIsOpen}>
-				<DropdownMenu.Trigger>
-					<View className={cn('flex-row items-center gap-1.5', { 'opacity-80': isOpen })}>
-						<Text>{BEHAVIOR_TEXT[behavior]}</Text>
-						<Icon as={ChevronsUpDown} className="h-5 text-foreground-muted" />
-					</View>
-				</DropdownMenu.Trigger>
+			<DropdownMenu.Content>
+				<DropdownMenu.CheckboxItem
+					key="auto"
+					value={behavior === ReadingImageScaleFit.Auto}
+					onValueChange={() => onChange(ReadingImageScaleFit.Auto)}
+				>
+					<DropdownMenu.ItemTitle>Auto</DropdownMenu.ItemTitle>
+				</DropdownMenu.CheckboxItem>
 
-				<DropdownMenu.Content>
-					<DropdownMenu.CheckboxItem
-						key="auto"
-						value={behavior === ReadingImageScaleFit.Auto}
-						onValueChange={() => onChange(ReadingImageScaleFit.Auto)}
-					>
-						<DropdownMenu.ItemTitle>Auto</DropdownMenu.ItemTitle>
-					</DropdownMenu.CheckboxItem>
+				<DropdownMenu.CheckboxItem
+					key="height"
+					value={behavior === ReadingImageScaleFit.Height}
+					onValueChange={() => onChange(ReadingImageScaleFit.Height)}
+					disabled
+				>
+					<DropdownMenu.ItemTitle>Fit Height</DropdownMenu.ItemTitle>
+				</DropdownMenu.CheckboxItem>
 
-					<DropdownMenu.CheckboxItem
-						key="height"
-						value={behavior === ReadingImageScaleFit.Height}
-						onValueChange={() => onChange(ReadingImageScaleFit.Height)}
-						disabled
-					>
-						<DropdownMenu.ItemTitle>Fit Height</DropdownMenu.ItemTitle>
-					</DropdownMenu.CheckboxItem>
+				<DropdownMenu.CheckboxItem
+					key="width"
+					value={behavior === ReadingImageScaleFit.Width}
+					onValueChange={() => onChange(ReadingImageScaleFit.Width)}
+					disabled
+				>
+					<DropdownMenu.ItemTitle>Fit Width</DropdownMenu.ItemTitle>
+				</DropdownMenu.CheckboxItem>
 
-					<DropdownMenu.CheckboxItem
-						key="width"
-						value={behavior === ReadingImageScaleFit.Width}
-						onValueChange={() => onChange(ReadingImageScaleFit.Width)}
-						disabled
-					>
-						<DropdownMenu.ItemTitle>Fit Width</DropdownMenu.ItemTitle>
-					</DropdownMenu.CheckboxItem>
-
-					<DropdownMenu.CheckboxItem
-						key="none"
-						value={behavior === ReadingImageScaleFit.None}
-						onValueChange={() => onChange(ReadingImageScaleFit.None)}
-						disabled
-					>
-						<DropdownMenu.ItemTitle>None</DropdownMenu.ItemTitle>
-					</DropdownMenu.CheckboxItem>
-				</DropdownMenu.Content>
-			</DropdownMenu.Root>
-		</View>
+				<DropdownMenu.CheckboxItem
+					key="none"
+					value={behavior === ReadingImageScaleFit.None}
+					onValueChange={() => onChange(ReadingImageScaleFit.None)}
+					disabled
+				>
+					<DropdownMenu.ItemTitle>None</DropdownMenu.ItemTitle>
+				</DropdownMenu.CheckboxItem>
+			</DropdownMenu.Content>
+		</DropdownMenu.Root>
 	)
 }
 

--- a/apps/expo/components/book/reader/settings/ReaderSettings.tsx
+++ b/apps/expo/components/book/reader/settings/ReaderSettings.tsx
@@ -2,8 +2,7 @@ import { ReadingMode } from '@stump/graphql'
 import { useCallback, useMemo } from 'react'
 import { View } from 'react-native'
 
-import { CardList, Switch, Text } from '~/components/ui'
-import { cn } from '~/lib/utils'
+import { CardList, CardRow, Switch } from '~/components/ui'
 import { BookPreferences, GlobalSettings, useReaderStore } from '~/stores/reader'
 
 import DoublePageSelect from './DoublePageSelect'
@@ -65,75 +64,79 @@ export default function ReaderSettings({ forBook, forServer }: Props) {
 	return (
 		<View className="flex-1 gap-8">
 			<CardList label="Mode">
-				<ReadingModeSelect
-					mode={activeSettings.readingMode}
-					onChange={(mode) => onPreferenceChange({ readingMode: mode })}
-				/>
-				{activeSettings.readingMode !== ReadingMode.ContinuousVertical && (
+				<CardRow label="Flow">
+					<ReadingModeSelect
+						mode={activeSettings.readingMode}
+						onChange={(mode) => onPreferenceChange({ readingMode: mode })}
+					/>
+				</CardRow>
+
+				<CardRow
+					label="Direction"
+					disabled={activeSettings.readingMode === ReadingMode.ContinuousVertical}
+				>
 					<ReadingDirectionSelect
 						direction={activeSettings.readingDirection}
 						onChange={(direction) => onPreferenceChange({ readingDirection: direction })}
 					/>
-				)}
+				</CardRow>
 			</CardList>
 
 			<CardList label="Image Options">
-				<DoublePageSelect
-					behavior={activeSettings.doublePageBehavior || 'auto'}
-					onChange={(behavior) => onPreferenceChange({ doublePageBehavior: behavior })}
-				/>
+				<CardRow label="Double Paged">
+					<DoublePageSelect
+						behavior={activeSettings.doublePageBehavior || 'auto'}
+						onChange={(behavior) => onPreferenceChange({ doublePageBehavior: behavior })}
+					/>
+				</CardRow>
 
-				<View
-					className={cn('flex flex-row items-center justify-between p-4', {
-						'opacity-50': activeSettings.doublePageBehavior === 'off',
-					})}
+				<CardRow
+					label="Separate Second Page"
+					disabled={activeSettings.doublePageBehavior === 'off'}
 				>
-					<Text>Separate Second Page</Text>
-
 					<Switch
 						checked={
 							activeSettings.secondPageSeparate && activeSettings.doublePageBehavior !== 'off'
 						}
 						onCheckedChange={(value) => onPreferenceChange({ secondPageSeparate: value })}
 					/>
-				</View>
+				</CardRow>
 
-				<ImageScalingSelect
-					behavior={activeSettings.imageScaling.scaleToFit}
-					onChange={(fit) => onPreferenceChange({ imageScaling: { scaleToFit: fit } })}
-				/>
+				<CardRow label="Scaling">
+					<ImageScalingSelect
+						behavior={activeSettings.imageScaling.scaleToFit}
+						onChange={(fit) => onPreferenceChange({ imageScaling: { scaleToFit: fit } })}
+					/>
+				</CardRow>
 
-				<View className="flex flex-row items-center justify-between p-4">
-					<Text>Downscaling</Text>
-
+				<CardRow label="Downscaling">
 					<Switch
 						checked={allowDownscaling}
 						onCheckedChange={(value) => onPreferenceChange({ allowDownscaling: value })}
 					/>
-				</View>
+				</CardRow>
 
 				{/* TODO: https://docs.expo.dev/versions/latest/sdk/media-library/ */}
-				<View className="flex flex-row items-center justify-between p-4 opacity-50">
-					<Text>Panel Downloads</Text>
-
+				<CardRow label="Panel Downloads" disabled>
 					<Switch checked={false} onCheckedChange={() => {}} />
-				</View>
+				</CardRow>
 			</CardList>
 
 			<CardList label="Navigation">
-				<View className="flex flex-row items-center justify-between p-4">
-					<Text>Tap Sides to Navigate</Text>
+				<CardRow label="Tap Sides to Navigate">
 					<Switch
 						variant="brand"
 						checked={activeSettings.tapSidesToNavigate ?? true}
 						onCheckedChange={(checked) => onPreferenceChange({ tapSidesToNavigate: checked })}
 					/>
-				</View>
+				</CardRow>
 
-				<FooterControlsSelect
-					variant={activeSettings.footerControls || 'images'}
-					onChange={(variant) => onPreferenceChange({ footerControls: variant })}
-				/>
+				<CardRow label="Bottom Controls">
+					<FooterControlsSelect
+						variant={activeSettings.footerControls || 'images'}
+						onChange={(variant) => onPreferenceChange({ footerControls: variant })}
+					/>
+				</CardRow>
 			</CardList>
 		</View>
 	)

--- a/apps/expo/components/book/reader/settings/ReadingDirectionSelect.tsx
+++ b/apps/expo/components/book/reader/settings/ReadingDirectionSelect.tsx
@@ -16,35 +16,31 @@ export default function ReadingDirectionSelect({ direction, onChange }: Props) {
 	const [isOpen, setIsOpen] = useState(false)
 
 	return (
-		<View className="flex flex-row items-center justify-between p-4">
-			<Text>Direction</Text>
+		<DropdownMenu.Root onOpenChange={setIsOpen}>
+			<DropdownMenu.Trigger>
+				<View className={cn('flex-row items-center gap-1.5', { 'opacity-80': isOpen })}>
+					<Text>{direction.toUpperCase()}</Text>
+					<Icon as={ChevronsUpDown} className="h-5 text-foreground-muted" />
+				</View>
+			</DropdownMenu.Trigger>
 
-			<DropdownMenu.Root onOpenChange={setIsOpen}>
-				<DropdownMenu.Trigger>
-					<View className={cn('flex-row items-center gap-1.5', { 'opacity-80': isOpen })}>
-						<Text>{direction.toUpperCase()}</Text>
-						<Icon as={ChevronsUpDown} className="h-5 text-foreground-muted" />
-					</View>
-				</DropdownMenu.Trigger>
+			<DropdownMenu.Content>
+				<DropdownMenu.CheckboxItem
+					key="ltr"
+					value={direction === ReadingDirection.Ltr}
+					onValueChange={() => onChange(ReadingDirection.Ltr)}
+				>
+					<DropdownMenu.ItemTitle>Left to Right</DropdownMenu.ItemTitle>
+				</DropdownMenu.CheckboxItem>
 
-				<DropdownMenu.Content>
-					<DropdownMenu.CheckboxItem
-						key="ltr"
-						value={direction === ReadingDirection.Ltr}
-						onValueChange={() => onChange(ReadingDirection.Ltr)}
-					>
-						<DropdownMenu.ItemTitle>Left to Right</DropdownMenu.ItemTitle>
-					</DropdownMenu.CheckboxItem>
-
-					<DropdownMenu.CheckboxItem
-						key="rtl"
-						value={direction === ReadingDirection.Rtl}
-						onValueChange={() => onChange(ReadingDirection.Rtl)}
-					>
-						<DropdownMenu.ItemTitle>Right to Left</DropdownMenu.ItemTitle>
-					</DropdownMenu.CheckboxItem>
-				</DropdownMenu.Content>
-			</DropdownMenu.Root>
-		</View>
+				<DropdownMenu.CheckboxItem
+					key="rtl"
+					value={direction === ReadingDirection.Rtl}
+					onValueChange={() => onChange(ReadingDirection.Rtl)}
+				>
+					<DropdownMenu.ItemTitle>Right to Left</DropdownMenu.ItemTitle>
+				</DropdownMenu.CheckboxItem>
+			</DropdownMenu.Content>
+		</DropdownMenu.Root>
 	)
 }

--- a/apps/expo/components/book/reader/settings/ReadingModeSelect.tsx
+++ b/apps/expo/components/book/reader/settings/ReadingModeSelect.tsx
@@ -16,44 +16,40 @@ export default function ReadingModeSelect({ mode, onChange }: Props) {
 	const [isOpen, setIsOpen] = useState(false)
 
 	return (
-		<View className="flex flex-row items-center justify-between p-4">
-			<Text>Flow</Text>
+		<DropdownMenu.Root onOpenChange={setIsOpen}>
+			<DropdownMenu.Trigger>
+				<View className={cn('flex-row items-center gap-1.5', { 'opacity-80': isOpen })}>
+					<Text>{READ_FLOW[mode]}</Text>
+					<Icon as={ChevronsUpDown} className="h-5 text-foreground-muted" />
+				</View>
+			</DropdownMenu.Trigger>
 
-			<DropdownMenu.Root onOpenChange={setIsOpen}>
-				<DropdownMenu.Trigger>
-					<View className={cn('flex-row items-center gap-1.5', { 'opacity-80': isOpen })}>
-						<Text>{READ_FLOW[mode]}</Text>
-						<Icon as={ChevronsUpDown} className="h-5 text-foreground-muted" />
-					</View>
-				</DropdownMenu.Trigger>
+			<DropdownMenu.Content>
+				<DropdownMenu.CheckboxItem
+					key="paged"
+					value={mode === ReadingMode.Paged}
+					onValueChange={() => onChange(ReadingMode.Paged)}
+				>
+					<DropdownMenu.ItemTitle>Paged</DropdownMenu.ItemTitle>
+				</DropdownMenu.CheckboxItem>
 
-				<DropdownMenu.Content>
-					<DropdownMenu.CheckboxItem
-						key="paged"
-						value={mode === ReadingMode.Paged}
-						onValueChange={() => onChange(ReadingMode.Paged)}
-					>
-						<DropdownMenu.ItemTitle>Paged</DropdownMenu.ItemTitle>
-					</DropdownMenu.CheckboxItem>
+				<DropdownMenu.CheckboxItem
+					key="continuous:horizontal"
+					value={mode === ReadingMode.ContinuousHorizontal}
+					onValueChange={() => onChange(ReadingMode.ContinuousHorizontal)}
+				>
+					<DropdownMenu.ItemTitle>Scroll (Horizontal)</DropdownMenu.ItemTitle>
+				</DropdownMenu.CheckboxItem>
 
-					<DropdownMenu.CheckboxItem
-						key="continuous:horizontal"
-						value={mode === ReadingMode.ContinuousHorizontal}
-						onValueChange={() => onChange(ReadingMode.ContinuousHorizontal)}
-					>
-						<DropdownMenu.ItemTitle>Scroll (Horizontal)</DropdownMenu.ItemTitle>
-					</DropdownMenu.CheckboxItem>
-
-					<DropdownMenu.CheckboxItem
-						key="continuous:vertical"
-						value={mode === ReadingMode.ContinuousVertical}
-						onValueChange={() => onChange(ReadingMode.ContinuousVertical)}
-					>
-						<DropdownMenu.ItemTitle>Scroll (Vertical)</DropdownMenu.ItemTitle>
-					</DropdownMenu.CheckboxItem>
-				</DropdownMenu.Content>
-			</DropdownMenu.Root>
-		</View>
+				<DropdownMenu.CheckboxItem
+					key="continuous:vertical"
+					value={mode === ReadingMode.ContinuousVertical}
+					onValueChange={() => onChange(ReadingMode.ContinuousVertical)}
+				>
+					<DropdownMenu.ItemTitle>Scroll (Vertical)</DropdownMenu.ItemTitle>
+				</DropdownMenu.CheckboxItem>
+			</DropdownMenu.Content>
+		</DropdownMenu.Root>
 	)
 }
 

--- a/apps/expo/components/ui/card.tsx
+++ b/apps/expo/components/ui/card.tsx
@@ -1,5 +1,5 @@
 import { CircleAlert, LucideIcon } from 'lucide-react-native'
-import React, { Fragment } from 'react'
+import React from 'react'
 import { Platform, View, ViewProps } from 'react-native'
 
 import { Icon, Text } from '~/components/ui'
@@ -12,40 +12,81 @@ type CardListProps = ViewProps & {
 	 */
 	label?: string
 	/**
+	 * A description displayed under the card
+	 */
+	description?: string
+	/**
 	 * Customise the icon and text to display when the list is empty
 	 */
 	listEmptyStyle?: ListEmptyMessageProps
 }
 
-export function CardList({ label, listEmptyStyle, children, className, ...props }: CardListProps) {
-	const items = React.Children.toArray(children).filter((child) => child)
+type RowProps = ViewProps & {
+	label?: string
+	icon?: LucideIcon
+	disabled?: boolean
+}
+
+export function CardList({
+	label,
+	description,
+	listEmptyStyle,
+	children,
+	className,
+	...props
+}: CardListProps) {
+	const count = React.Children.count(children)
 
 	return (
-		<View className={cn('gap-1', className)} {...props}>
-			{label && <Text className="px-2 text-lg font-semibold text-foreground-muted">{label}</Text>}
-			{items.length === 0 ? (
-				<ListEmptyMessage {...listEmptyStyle} />
-			) : (
-				<Card>
-					{items.map((child, index) => (
-						<Fragment key={index}>
-							{index !== 0 && <CardDivider />}
-							{child}
-						</Fragment>
-					))}
-				</Card>
+		<View className={cn('gap-2', className)} {...props}>
+			{label && (
+				<Text className="ios:px-4 px-2 text-lg font-semibold text-foreground-muted">{label}</Text>
 			)}
+
+			{count === 0 ? <ListEmptyMessage {...listEmptyStyle} /> : <Background>{children}</Background>}
+
+			{description && <Text className="ios:px-4 px-2 text-foreground-muted">{description}</Text>}
 		</View>
 	)
 }
 
-const Card = ({ className, ...props }: ViewProps) => {
+export function CardRow({ label, icon, disabled, children, className, ...props }: RowProps) {
+	return (
+		// We shift up by 1px to hide the first divider in a list
+		<View className="-mt-[1px]">
+			<Divider hasIcon={!!icon} />
+
+			<View
+				className={cn(
+					'flex flex-row items-center justify-between gap-x-4 px-4 py-3.5',
+					disabled && 'pointer-events-none opacity-50',
+					className,
+				)}
+				{...props}
+			>
+				{label && (
+					<View className="flex-row items-center justify-center gap-4">
+						{icon && (
+							<View className="squircle flex h-8 w-8 items-center justify-center rounded-xl bg-white/75 dark:bg-black/40">
+								<Icon as={icon} className="h-6 w-6 text-foreground-muted" />
+							</View>
+						)}
+						<Text className="text-lg">{label}</Text>
+					</View>
+				)}
+				{children}
+			</View>
+		</View>
+	)
+}
+
+function Background({ className, ...props }: ViewProps) {
 	return (
 		<View
 			className={cn(
-				'squircle flex',
-				Platform.OS === 'ios' ? 'rounded-3xl' : 'rounded-2xl border border-edge',
-				IS_IOS_24_PLUS ? 'bg-black/10 dark:bg-white/10' : 'bg-background-surface',
+				// We hide the overflow so that the first divider gets hidden
+				'squircle flex overflow-hidden bg-black/5 dark:bg-white/10',
+				Platform.OS === 'ios' ? 'rounded-[2rem]' : 'rounded-2xl border border-edge',
 				className,
 			)}
 			{...props}
@@ -53,13 +94,15 @@ const Card = ({ className, ...props }: ViewProps) => {
 	)
 }
 
-const CardDivider = ({ className, ...props }: ViewProps) => {
+function Divider({ hasIcon, className, ...props }: { hasIcon?: boolean } & ViewProps) {
 	return (
 		<View
 			className={cn(
 				'h-px',
-				Platform.OS === 'ios' && 'ml-4',
-				IS_IOS_24_PLUS ? 'mx-4 bg-black/10 dark:bg-white/10' : 'bg-edge',
+				Platform.OS === 'ios' ? 'ml-4 bg-black/10 dark:bg-white/10' : 'bg-edge',
+				IS_IOS_24_PLUS && 'mr-4',
+				// gap between icon and text (gap-4) + icon width (w-8) + initial ios padding (ml-4)
+				hasIcon && Platform.OS === 'ios' && 'ml-16',
 				className,
 			)}
 			{...props}


### PR DESCRIPTION
Updates the settings page to the same design.

Also the card stuff is updated so it should now actually give you the same padding for the rows and divider and font size and stuff if you use `CardRow` (I did notice some of the new epub settings in the other branch had different size text)