### PR TITLE
🐛 (expo): fix default stump server entry

### DIFF
--- a/apps/expo/app/(tabs)/index/index.tsx
+++ b/apps/expo/app/(tabs)/index/index.tsx
@@ -25,7 +25,8 @@ export default function Screen() {
 	const [deletingServer, setDeletingServer] = useState<SavedServer | null>(null)
 
 	const allOPDSServers = [...stumpServers.filter((server) => server.stumpOPDS), ...opdsServers]
-	const defaultServer = allOPDSServers.find((server) => server.defaultServer)
+
+	const defaultServer = savedServers.find((server) => server.defaultServer)
 
 	const [didMount, setDidMount] = useState(false)
 	useEffect(() => {


### PR DESCRIPTION
Should fix issue 1 of #885. If you had opds disabled on a stump server it wouldn't auto enter on startup. 

I personally don't think if you have a stump server you need to be able to have it's opds version open as default, but I could add that selection option.