### PR TITLE
🐛 (expo): fix table of contents on press navigation

### DIFF
--- a/apps/expo/components/book/reader/epub/LocationsSheetContent.tsx
+++ b/apps/expo/components/book/reader/epub/LocationsSheetContent.tsx
@@ -174,7 +174,7 @@ const TableOfContentsListItem = ({ item }: { item: TableOfContentsItem }) => {
 				? {
 						fragments: [fragment],
 					}
-				: undefined,
+				: {},
 		})
 
 		closeSheet('locations')


### PR DESCRIPTION
On tap it didn't go to the chapter for any of my books I tested, but now it does. I think this was also an issue mentioned in #885 too. You could also merge this into the bug hunt branch instead.

---

This is kinda unrelated but there is a really annoying bug (on ios only I think, from briefly checking android studio) where if you swipe horizontally [on these parts](https://github.com/user-attachments/assets/0858d133-c51e-4d42-adf3-eb9ebced5a1c), it changes chapter rather than page. I was using that bug to change chapters quickly when the toc didn't work lol but maybe you can fix it now that I don't need it.