### PR TITLE
💄 (expo): Hide epub controls after location change

### DIFF
--- a/apps/expo/components/book/reader/epub/ReadiumFooter.tsx
+++ b/apps/expo/components/book/reader/epub/ReadiumFooter.tsx
@@ -23,19 +23,19 @@ export default function ReadiumFooter() {
 
 	const insets = useSafeAreaInsets()
 
-	const translateY = useSharedValue(400)
+	const opacity = useSharedValue(0)
 	useEffect(() => {
-		translateY.value = withTiming(visible ? 0 : 400 * 1, {
-			duration: 300,
+		opacity.value = withTiming(visible ? 1 : 0, {
+			duration: 250,
 		})
-	}, [visible, translateY, height, insets.bottom])
+	}, [visible, opacity, height, insets.bottom])
 
 	const animatedStyles = useAnimatedStyle(() => {
 		return {
 			bottom: insets.bottom + (Platform.OS === 'android' ? 12 : 0),
 			left: insets.left,
 			right: insets.right,
-			transform: [{ translateY: translateY.value }],
+			opacity: opacity.value,
 		}
 	})
 

--- a/apps/expo/components/book/reader/epub/ReadiumHeader.tsx
+++ b/apps/expo/components/book/reader/epub/ReadiumHeader.tsx
@@ -33,19 +33,19 @@ export default function ReadiumHeader() {
 
 	const insets = useSafeAreaInsets()
 
-	const translateY = useSharedValue(-400)
+	const opacity = useSharedValue(0)
 	useEffect(() => {
-		translateY.value = withTiming(visible ? 0 : 400 * -1, {
-			duration: 300,
+		opacity.value = withTiming(visible ? 1 : 0, {
+			duration: 250,
 		})
-	}, [visible, translateY, height, insets.top])
+	}, [visible, opacity, height, insets.top])
 
 	const animatedStyles = useAnimatedStyle(() => {
 		return {
 			top: insets.top + (Platform.OS === 'android' ? 0 : 0),
 			left: insets.left,
 			right: insets.right,
-			transform: [{ translateY: translateY.value }],
+			opacity: opacity.value,
 		}
 	})
 


### PR DESCRIPTION
I have introduced two different ways that will hide the controls:
1. After the location finishes changing, the controls hide
2. After being shown for 6 seconds, the controls hide. This made sense to me to add because it moves you over to the intended look of the reader.

---

The secondary purpose of this change was to make sure reading time is counted because I accidentally read a lot with the controls open, but (2) means time spent in sheets is mostly counted. I could also make sure it isn't if you'd like, probably just add like `isSettingsSheetOpen` etc to the sheet store and check it.

If/when the overlay is changed to use the single floating button with nested controls, then the way reading time is tracked should be properly changed to not rely on the controls being open, but to pause when the nested controls are shown and unpause when the sheets / nested controls are dismissed