### PR TITLE
🐛 (expo): Fix toc active chapter not highlighting

### DIFF
--- a/apps/expo/components/book/reader/epub/LocationsSheetContent.tsx
+++ b/apps/expo/components/book/reader/epub/LocationsSheetContent.tsx
@@ -14,7 +14,7 @@ import { useColors } from '~/lib/constants'
 import { useColorScheme } from '~/lib/useColorScheme'
 import { cn } from '~/lib/utils'
 import { usePreferencesStore } from '~/stores'
-import { flattenToc, type TableOfContentsItem, useEpubLocationStore } from '~/stores/epub'
+import { type TableOfContentsItem, useEpubLocationStore } from '~/stores/epub'
 import { useEpubSheetStore } from '~/stores/epubSheet'
 
 import AnnotationsAndBookmarks from './AnnotationsAndBookmarks'
@@ -36,7 +36,6 @@ export default function LocationsSheetContent() {
 	const book = useEpubLocationStore((store) => store.book)
 	const toc = useEpubLocationStore((store) => store.toc)
 	const embeddedMetadata = useEpubLocationStore((store) => store.embeddedMetadata)
-	const position = useEpubLocationStore((store) => store.position)
 	const currentChapter = useEpubLocationStore((store) => store.currentChapter)
 
 	const requestHeaders = useEpubLocationStore((store) => store.requestHeaders)
@@ -49,23 +48,9 @@ export default function LocationsSheetContent() {
 
 	const flatTocWithLevels = flattenTocWithLevels(toc)
 
-	const findNextItem = (item: TableOfContentsItem) => {
-		const flatToc = flattenToc(toc)
-		const index = flatToc.indexOf(item)
-		return flatToc[index + 1]
-	}
-
-	const checkIsActive = (item: TableOfContentsItem) => {
-		const nextItem = findNextItem(item)
-		if (item.position) {
-			const isAfterChapterStart = position >= item.position
-			const isBeforeChapterEnd = nextItem?.position ? position < nextItem?.position : true
-			return isAfterChapterStart && isBeforeChapterEnd
-		}
+	const activeTocItemIndex = flatTocWithLevels.findIndex(({ item }) => {
 		return item.label === currentChapter
-	}
-
-	const activeTocItemIndex = flatTocWithLevels.findIndex(({ item }) => checkIsActive(item))
+	})
 
 	const scrollToCurrentChapter = useCallback(
 		({ animated }: { animated: boolean }) =>

--- a/apps/expo/stores/epub.ts
+++ b/apps/expo/stores/epub.ts
@@ -97,12 +97,16 @@ export const flattenToc = (toc: TableOfContentsItem[]): TableOfContentsItem[] =>
 export const resolveTocItemByPosition = (position: ReadiumLocation['position']) => {
 	const toc = useEpubLocationStore.getState().toc
 	const flatToc = flattenToc(toc)
-	return flatToc.find((item, index) => {
+	// if `isNextItemMissingPosition` is true, then two toc items will meet the criteria:
+	// 1. A toc item where its nextItem has no associated position number, and it's before the current chapter, and
+	// 2. The actual toc item for the current chapter. So we use findLast
+	return flatToc.findLast((item, index) => {
 		const nextItem = flatToc[index + 1]
 		if (item.position && position) {
-			const isAfterChapterStart = position >= item.position
-			const isBeforeChapterEnd = nextItem?.position ? position < nextItem?.position : true
-			return isAfterChapterStart && isBeforeChapterEnd
+			const isCurrentChapterOrBefore = item.position <= position
+			const isCurrentChapterOrAfter = nextItem?.position ? position < nextItem.position : false
+			const isNextItemMissingPosition = nextItem?.position == undefined
+			return isCurrentChapterOrBefore && (isCurrentChapterOrAfter || isNextItemMissingPosition)
 		}
 	})
 }


### PR DESCRIPTION
Removed the duplicate logic for getting the current chapter item, and updated the remaining one to fix a bug where the current chapter item wouldn't highlight