### PR TITLE
:wrench: Increase GraphQL `limit_depth` to 15

### DIFF
--- a/crates/graphql/src/schema.rs
+++ b/crates/graphql/src/schema.rs
@@ -28,7 +28,7 @@ pub async fn build_schema(ctx: CoreContext) -> AppSchema {
 	)
 	// AccessRole is used in a serialized json for SmartList so we need to register it manually
 	.register_output_type::<AccessRole>()
-	.limit_depth(10)
+	.limit_depth(15)
 	.data(ctx);
 
 	add_data_loaders(schema_builder, conn).finish()


### PR DESCRIPTION
Right now the graphql playground displays an error:

    Query is nested too deep.

And is unable to display documentation.

<img width="1244" height="664" alt="image" src="https://github.com/user-attachments/assets/030dcf87-0715-472b-934b-119b05c20974" />

The `limit_depth` call was added in https://github.com/stumpapp/stump/commit/c5d9de9eb80e5d7ff8971e1f713f7b8e82e0d678 , and the playground seems have been broken since then.