### PR TITLE
:sparkles: (expo): Search history and favorite searches

### DIFF
--- a/apps/expo/app/opds-legacy/[id]/(tabs)/search/index.tsx
+++ b/apps/expo/app/opds-legacy/[id]/(tabs)/search/index.tsx
@@ -5,9 +5,11 @@ import { NativeSyntheticEvent, Platform, TextInputChangeEventData, View } from '
 
 import { useActiveServer } from '~/components/activeServer'
 import Owl from '~/components/Owl'
+import { SearchHistoryAndFavorites } from '~/components/search/SearchHistoryAndFavorites'
 import { Text } from '~/components/ui'
 import { useOPDSLegacyFeedContext } from '~/context/opdsLegacy'
 import { IS_IOS_24_PLUS, useColors } from '~/lib/constants'
+import { useSearchStore } from '~/stores/search'
 
 export default function Screen() {
 	const {
@@ -15,28 +17,35 @@ export default function Screen() {
 	} = useActiveServer()
 	const { searchDoc } = useOPDSLegacyFeedContext()
 
+	const trackSearch = useSearchStore((store) => store.trackSearch)
+
 	const navigation = useNavigation()
 	const router = useRouter()
 	const colors = useColors()
 
 	const [searchQuery, setSearchQuery] = useState('')
+	const [isInputFocused, setIsInputFocused] = useState(false)
 
 	const onSearchChange = useCallback((query: string) => {
 		setSearchQuery(query)
 	}, [])
 	const setQuery = debounce(onSearchChange, 200)
 
+	const navigateToQuery = useCallback(
+		(query: string) => {
+			trackSearch(query, serverID)
+			router.push({
+				pathname: `/opds-legacy/[id]/search/[query]`,
+				params: { id: serverID, query },
+			})
+		},
+		[serverID, router, trackSearch],
+	)
+
 	const onSearch = useCallback(() => {
 		if (!searchQuery || !searchDoc) return
-
-		router.push({
-			pathname: `/opds-legacy/[id]/search/[query]`,
-			params: {
-				id: serverID,
-				query: searchQuery,
-			},
-		})
-	}, [serverID, router, searchQuery, searchDoc])
+		navigateToQuery(searchQuery)
+	}, [searchQuery, searchDoc, navigateToQuery])
 
 	useLayoutEffect(() => {
 		navigation.setOptions({
@@ -49,6 +58,9 @@ export default function Screen() {
 					setQuery(e.nativeEvent.text),
 				shouldShowHintSearchIcon: true,
 				onSearchButtonPress: () => onSearch(),
+				onFocus: () => setIsInputFocused(true),
+				onBlur: () => setIsInputFocused(false),
+				onCancelButtonPress: () => setIsInputFocused(false),
 				headerIconColor: colors.foreground.subtle,
 				hintTextColor: colors.foreground.muted,
 				tintColor: colors.fill.danger.DEFAULT,
@@ -57,19 +69,23 @@ export default function Screen() {
 		})
 	}, [navigation, setQuery, onSearch, colors])
 
-	return (
-		<View className="flex-1 items-center justify-center gap-4 bg-background p-4 tablet:p-7">
-			<Owl owl="search" />
+	if (!isInputFocused) {
+		return (
+			<View className="flex-1 items-center justify-center gap-4 bg-background p-4 tablet:p-7">
+				<Owl owl="search" />
 
-			<View className="gap-2 px-4 tablet:max-w-lg">
-				<Text size="xl" className="text-center font-semibold leading-tight">
-					Search the feed
-				</Text>
+				<View className="gap-2 px-4 tablet:max-w-lg">
+					<Text size="xl" className="text-center font-semibold leading-tight">
+						Search the feed
+					</Text>
 
-				<Text size="lg" className="text-center text-foreground-muted">
-					Enter a search query to find content in this OPDS feed
-				</Text>
+					<Text size="lg" className="text-center text-foreground-muted">
+						Enter a search query to find content in this OPDS feed
+					</Text>
+				</View>
 			</View>
-		</View>
-	)
+		)
+	}
+
+	return <SearchHistoryAndFavorites onSelect={navigateToQuery} />
 }

--- a/apps/expo/app/opds/[id]/(tabs)/search/index.tsx
+++ b/apps/expo/app/opds/[id]/(tabs)/search/index.tsx
@@ -5,9 +5,11 @@ import { NativeSyntheticEvent, Platform, TextInputChangeEventData, View } from '
 
 import { useActiveServer } from '~/components/activeServer'
 import Owl from '~/components/Owl'
+import { SearchHistoryAndFavorites } from '~/components/search/SearchHistoryAndFavorites'
 import { Text } from '~/components/ui'
 import { useOPDSFeedContext } from '~/context/opds'
 import { IS_IOS_24_PLUS, useColors } from '~/lib/constants'
+import { useSearchStore } from '~/stores/search'
 
 export default function Screen() {
 	const {
@@ -15,28 +17,35 @@ export default function Screen() {
 	} = useActiveServer()
 	const { searchURL } = useOPDSFeedContext()
 
+	const trackSearch = useSearchStore((store) => store.trackSearch)
+
 	const navigation = useNavigation()
 	const router = useRouter()
 	const colors = useColors()
 
 	const [searchQuery, setSearchQuery] = useState('')
+	const [isInputFocused, setIsInputFocused] = useState(false)
 
 	const onSearchChange = useCallback((query: string) => {
 		setSearchQuery(query)
 	}, [])
 	const setQuery = debounce(onSearchChange, 200)
 
+	const navigateToQuery = useCallback(
+		(query: string) => {
+			trackSearch(query, serverID)
+			router.push({
+				pathname: `/opds/[id]/search/[query]`,
+				params: { id: serverID, query },
+			})
+		},
+		[serverID, router, trackSearch],
+	)
+
 	const onSearch = useCallback(() => {
 		if (!searchQuery || !searchURL) return
-
-		router.push({
-			pathname: `/opds/[id]/search/[query]`,
-			params: {
-				id: serverID,
-				query: searchQuery,
-			},
-		})
-	}, [serverID, router, searchQuery, searchURL])
+		navigateToQuery(searchQuery)
+	}, [searchQuery, searchURL, navigateToQuery])
 
 	useLayoutEffect(() => {
 		navigation.setOptions({
@@ -49,6 +58,9 @@ export default function Screen() {
 					setQuery(e.nativeEvent.text),
 				shouldShowHintSearchIcon: true,
 				onSearchButtonPress: () => onSearch(),
+				onFocus: () => setIsInputFocused(true),
+				onBlur: () => setIsInputFocused(false),
+				onCancelButtonPress: () => setIsInputFocused(false),
 				headerIconColor: colors.foreground.subtle,
 				hintTextColor: colors.foreground.muted,
 				tintColor: colors.fill.danger.DEFAULT,
@@ -57,19 +69,23 @@ export default function Screen() {
 		})
 	}, [navigation, setQuery, onSearch, colors])
 
-	return (
-		<View className="flex-1 items-center justify-center gap-4 bg-background p-4 tablet:p-7">
-			<Owl owl="search" />
+	if (!isInputFocused) {
+		return (
+			<View className="flex-1 items-center justify-center gap-4 bg-background p-4 tablet:p-7">
+				<Owl owl="search" />
 
-			<View className="gap-2 px-4 tablet:max-w-lg">
-				<Text size="xl" className="text-center font-semibold leading-tight">
-					Search the feed
-				</Text>
+				<View className="gap-2 px-4 tablet:max-w-lg">
+					<Text size="xl" className="text-center font-semibold leading-tight">
+						Search the feed
+					</Text>
 
-				<Text size="lg" className="text-center text-foreground-muted">
-					Enter a search query to find content in this OPDS feed
-				</Text>
+					<Text size="lg" className="text-center text-foreground-muted">
+						Enter a search query to find content in this OPDS feed
+					</Text>
+				</View>
 			</View>
-		</View>
-	)
+		)
+	}
+
+	return <SearchHistoryAndFavorites onSelect={navigateToQuery} />
 }

--- a/apps/expo/app/server/[id]/(tabs)/search/index.tsx
+++ b/apps/expo/app/server/[id]/(tabs)/search/index.tsx
@@ -2,54 +2,58 @@ import { useSDK } from '@stump/client'
 import { useQueryClient } from '@tanstack/react-query'
 import { useNavigation, useRouter } from 'expo-router'
 import debounce from 'lodash/debounce'
-import { useCallback, useLayoutEffect, useState } from 'react'
+import { useCallback, useLayoutEffect, useMemo, useState } from 'react'
 import { Platform, TextInputChangeEventData, View } from 'react-native'
 import { NativeSyntheticEvent } from 'react-native'
 
 import { useActiveServer } from '~/components/activeServer'
 import Owl from '~/components/Owl'
+import { SearchHistoryAndFavorites } from '~/components/search/SearchHistoryAndFavorites'
 import { Text } from '~/components/ui'
 import { IS_IOS_24_PLUS, useColors } from '~/lib/constants'
+import { useSearchStore } from '~/stores/search'
 
 import { prefetchBookSearch } from '../../books/search[q]'
-
-// TODO: Put in a stack and push for search
 
 export default function Screen() {
 	const {
 		activeServer: { id: serverID },
 	} = useActiveServer()
 	const { sdk } = useSDK()
+	const trackSearch = useSearchStore((store) => store.trackSearch)
 
 	const client = useQueryClient()
 	const navigation = useNavigation()
 	const router = useRouter()
 
 	const [searchQuery, setSearchQuery] = useState('')
+	const [isInputFocused, setIsInputFocused] = useState(false)
 
 	const onSearchChange = useCallback(
 		(query: string) => {
 			prefetchBookSearch(sdk, client, query)
-			// prefetchSeriesSearch(sdk, client, searchQuery)
-			// prefetchLibrarySearch(sdk, client, searchQuery)
 			setSearchQuery(query)
 		},
 		[sdk, client],
 	)
-	const setQuery = debounce(onSearchChange, 200)
+	const setQuery = useMemo(() => debounce(onSearchChange, 200), [onSearchChange])
 	const colors = useColors()
+
+	const navigateToQuery = useCallback(
+		(query: string) => {
+			trackSearch(query, serverID)
+			router.push({
+				pathname: `/server/[id]/search/[query]`,
+				params: { id: serverID, query },
+			})
+		},
+		[serverID, router, trackSearch],
+	)
 
 	const onSearch = useCallback(() => {
 		if (!searchQuery) return
-
-		router.push({
-			pathname: `/server/[id]/search/[query]`,
-			params: {
-				id: serverID,
-				query: searchQuery,
-			},
-		})
-	}, [serverID, router, searchQuery])
+		navigateToQuery(searchQuery)
+	}, [searchQuery, navigateToQuery])
 
 	useLayoutEffect(() => {
 		navigation.setOptions({
@@ -62,6 +66,9 @@ export default function Screen() {
 					setQuery(e.nativeEvent.text),
 				shouldShowHintSearchIcon: true,
 				onSearchButtonPress: () => onSearch(),
+				onFocus: () => setIsInputFocused(true),
+				onBlur: () => setIsInputFocused(false),
+				onCancelButtonPress: () => setIsInputFocused(false),
 				headerIconColor: colors.foreground.subtle,
 				hintTextColor: colors.foreground.muted,
 				tintColor: colors.fill.danger.DEFAULT,
@@ -70,19 +77,21 @@ export default function Screen() {
 		})
 	}, [navigation, setQuery, onSearch, colors])
 
-	return (
-		<View className="flex-1 items-center justify-center gap-4 bg-background p-4 tablet:p-7">
-			<Owl owl="search" />
-
-			<View className="gap-2 px-4 tablet:max-w-lg">
-				<Text size="xl" className="text-center font-semibold leading-tight">
-					Search the server
-				</Text>
-
-				<Text size="lg" className="text-center text-foreground-muted">
-					Enter a search query to find content on this server
-				</Text>
+	if (!isInputFocused) {
+		return (
+			<View className="flex-1 items-center justify-center gap-4 bg-background p-4 tablet:p-7">
+				<Owl owl="search" />
+				<View className="gap-2 px-4 tablet:max-w-lg">
+					<Text size="xl" className="text-center font-semibold leading-tight">
+						Search the server
+					</Text>
+					<Text size="lg" className="text-center text-foreground-muted">
+						Enter a search query to find content on this server
+					</Text>
+				</View>
 			</View>
-		</View>
-	)
+		)
+	}
+
+	return <SearchHistoryAndFavorites onSelect={navigateToQuery} />
 }

--- a/apps/expo/components/search/SearchHistoryAndFavorites.tsx
+++ b/apps/expo/components/search/SearchHistoryAndFavorites.tsx
@@ -1,0 +1,134 @@
+import { Bookmark, BookmarkX, Clock, Trash } from 'lucide-react-native'
+import { Pressable, ScrollView, View } from 'react-native'
+
+import { useActiveServer } from '~/components/activeServer'
+import { Icon, ListLabel, Text } from '~/components/ui'
+import { ContextMenu } from '~/components/ui/context-menu/context-menu'
+import { useColors } from '~/lib/constants'
+import { useCuratedSearch, useSearchStore } from '~/stores/search'
+
+import { Divider } from '../Divider'
+
+type Props = {
+	onSelect: (query: string) => void
+}
+
+export function SearchHistoryAndFavorites({ onSelect }: Props) {
+	const {
+		activeServer: { id: serverID },
+	} = useActiveServer()
+	const { favoriteSearches, searchHistory } = useCuratedSearch()
+	const { favoriteSearch, unfavoriteSearch, clearSearchHistory, removeFromHistory } =
+		useSearchStore()
+	const colors = useColors()
+
+	const hasFavorites = favoriteSearches.length > 0
+	const hasHistory = searchHistory.length > 0
+	const favoriteQuerySet = new Set(favoriteSearches.map((r) => r.query))
+
+	if (!hasFavorites && !hasHistory) {
+		return (
+			<View className="flex-1 items-center justify-center px-4 pt-20">
+				<Text size="lg" className="text-center text-foreground-muted">
+					Your favorites and recent searches will appear here
+				</Text>
+			</View>
+		)
+	}
+
+	return (
+		<ScrollView
+			className="flex-1 bg-background"
+			contentInsetAdjustmentBehavior="automatic"
+			keyboardShouldPersistTaps="handled"
+		>
+			{hasFavorites && (
+				<View className="px-4 pt-6">
+					<ListLabel className="mb-1">Favorites</ListLabel>
+					{favoriteSearches.map((record, index) => (
+						<View key={record.query}>
+							{index > 0 && <Divider />}
+							<ContextMenu
+								onPress={() => onSelect(record.query)}
+								groups={[
+									{
+										items: [
+											{
+												label: 'Unfavorite',
+												icon: { ios: 'bookmark.slash', android: BookmarkX },
+												onPress: () => unfavoriteSearch(record.query, serverID),
+												role: 'destructive',
+											},
+										],
+									},
+								]}
+							>
+								<View className="flex-row items-center gap-3 py-3">
+									<Icon as={Bookmark} size={16} color={colors.fill.brand.DEFAULT} />
+									<Text className="flex-1">{record.query}</Text>
+								</View>
+							</ContextMenu>
+						</View>
+					))}
+				</View>
+			)}
+
+			{hasHistory && (
+				<View className="px-4 pt-6">
+					<View className="mb-1 flex-row items-center justify-between">
+						<ListLabel>Recently Searched</ListLabel>
+						<Pressable onPress={() => clearSearchHistory(serverID)} hitSlop={10}>
+							<Text className="text-fill-danger">Clear</Text>
+						</Pressable>
+					</View>
+					{searchHistory.map((record, index) => (
+						<View key={record.query}>
+							{index > 0 && <Divider />}
+							<ContextMenu
+								onPress={() => onSelect(record.query)}
+								groups={[
+									{
+										items: [
+											...(!favoriteQuerySet.has(record.query)
+												? [
+														{
+															label: 'Favorite',
+															icon: {
+																ios: 'bookmark.fill' as const,
+																android: Bookmark,
+															},
+															onPress: () => favoriteSearch(record.query, serverID),
+														},
+													]
+												: [
+														{
+															label: 'Unfavorite',
+															icon: {
+																ios: 'bookmark.slash' as const,
+																android: BookmarkX,
+															},
+															onPress: () => unfavoriteSearch(record.query, serverID),
+														},
+													]),
+											{
+												label: 'Remove',
+												icon: { ios: 'trash', android: Trash },
+												onPress: () => removeFromHistory(record.query, serverID),
+												role: 'destructive' as const,
+											},
+										],
+									},
+								]}
+							>
+								<View className="flex-row items-center gap-3 py-3">
+									<Icon as={Clock} size={16} color={colors.foreground.muted} />
+									<Text className="flex-1">{record.query}</Text>
+								</View>
+							</ContextMenu>
+						</View>
+					))}
+				</View>
+			)}
+		</ScrollView>
+	)
+}

--- a/apps/expo/stores/search.ts
+++ b/apps/expo/stores/search.ts
@@ -1,19 +1,29 @@
 import { create } from 'zustand'
 import { createJSONStorage, persist } from 'zustand/middleware'
 
-import { ZustandMMKVStorage } from './store'
 import { useActiveServer } from '~/components/activeServer'
+
+import { ZustandMMKVStorage } from './store'
+
+// Note: Not used to cap favorites
+const MAX_HISTORY_PER_SERVER = 10
 
 export type SearchRecord = {
 	query: string
 	serverId: string
 }
 
+// Note: I didn't bother to key to the server since I don't really expect folks
+// to favorite more than a few and I cap the history per server. Idk, lazy won here
+// but if we need to refactor for efficiency it wouldn't be a huge deal
 export type SearchStore = {
 	searchHistory: SearchRecord[]
 	favoriteSearches: SearchRecord[]
 	trackSearch: (query: string, serverId: string) => void
 	favoriteSearch: (query: string, serverId: string) => void
+	unfavoriteSearch: (query: string, serverId: string) => void
+	clearSearchHistory: (serverId: string) => void
+	removeFromHistory: (query: string, serverId: string) => void
 }
 
 export const useSearchStore = create<SearchStore>()(
@@ -29,7 +39,7 @@ export const useSearchStore = create<SearchStore>()(
 						...state.searchHistory.filter(
 							(record) => !(record.query === query && record.serverId === serverId),
 						),
-					],
+					].slice(0, MAX_HISTORY_PER_SERVER),
 				}))
 			},
 			favoriteSearch: (query, serverId) => {
@@ -43,6 +53,25 @@ export const useSearchStore = create<SearchStore>()(
 					],
 				}))
 			},
+			unfavoriteSearch: (query, serverId) => {
+				set((state) => ({
+					favoriteSearches: state.favoriteSearches.filter(
+						(record) => !(record.query === query && record.serverId === serverId),
+					),
+				}))
+			},
+			clearSearchHistory: (serverId) => {
+				set((state) => ({
+					searchHistory: state.searchHistory.filter((record) => record.serverId !== serverId),
+				}))
+			},
+			removeFromHistory: (query, serverId) => {
+				set((state) => ({
+					searchHistory: state.searchHistory.filter(
+						(record) => !(record.query === query && record.serverId === serverId),
+					),
+				}))
+			},
 		}),
 		{
 			name: 'search-store',
@@ -52,22 +81,13 @@ export const useSearchStore = create<SearchStore>()(
 	),
 )
 
-export function useSearchHistory() {
+export function useCuratedSearch() {
 	const {
 		activeServer: { id: serverId },
 	} = useActiveServer()
-	const searchHistory = useSearchStore((state) =>
-		state.searchHistory.filter((record) => record.serverId === serverId),
-	)
-	return searchHistory
-}
-
-export function useFavoriteSearches() {
-	const {
-		activeServer: { id: serverId },
-	} = useActiveServer()
-	const favoriteSearches = useSearchStore((state) =>
-		state.favoriteSearches.filter((record) => record.serverId === serverId),
-	)
-	return favoriteSearches
+	const curatedSearches = useSearchStore((state) => ({
+		searchHistory: state.searchHistory.filter((record) => record.serverId === serverId),
+		favoriteSearches: state.favoriteSearches.filter((record) => record.serverId === serverId),
+	}))
+	return curatedSearches
 }


### PR DESCRIPTION
Resolves #959

I would say this is the first iteration of this feature, I didn't want to get rid of the cute little owl on the search pages and so arguably sacrificed UX a tiny bit by not showing the history/favorites until you focus the search input. I'll have a think on how to improve it, but may just merge as-is for now.