### PR TITLE
🔨 Use the same Rust version from the Nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -136,11 +136,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1773371126,
-        "narHash": "sha256-SGnZQO8hnynR90Lo/1MVrTScsOPx9i26XjqSqoFOZ4E=",
+        "lastModified": 1775099554,
+        "narHash": "sha256-3xBsGnGDLOFtnPZ1D3j2LU19wpAlYefRKTlkv648rU0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "475826b105eb52f39bd3281f60c052299e64d085",
+        "rev": "8d6387ed6d8e6e6672fd3ed4b61b59d44b124d99",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -29,19 +29,20 @@
           openssl
         ];
 
+        rustVersion = (builtins.fromTOML (builtins.readFile ./rust-toolchain.toml)).toolchain.channel;
+        rustToolchain = pkgs.rust-bin.stable.${rustVersion}.default.override {
+          extensions = [ "rust-src" "rust-analyzer" ];
+        };
+
         packages = with pkgs; [
           git
 
           # node
           (nodePackages.yarn.override { withNode = false; })
-          nodejs_20
+          nodejs_22
 
           # rust
-          rustfmt
-          rust-analyzer
-          clippy
-          rustc
-          cargo
+          rustToolchain
           cargo-deny
           cargo-edit
           cargo-watch
@@ -59,20 +60,9 @@
         ];
 
         genericShellConfig = {
-          buildInputs = packages ++ [
-            (
-              # Needed for rust-analyzer
-              pkgs.rust-bin.stable.latest.default.override {
-                extensions = [ "rust-src" ];
-              })
-          ];
+          buildInputs = packages;
 
-          # Needed for rust-analyzer
-          RUST_SRC_PATH = "${
-              pkgs.rust-bin.stable.latest.default.override {
-                extensions = [ "rust-src" ];
-              }
-            }/lib/rustlib/src/rust/library";
+          RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
 
           shellHook = ''
             export LD_LIBRARY_PATH=${


### PR DESCRIPTION
The Nix flake was previously using its own Rust version, floating depending on whatever nixpkgs currently had. This re-uses the version from rust-toolchain.toml instead, making sure there's no inconsistencies.