### PR TITLE
🔧 rerun build script when `GIT_REV` or `BUILD_CHANNEL` changes

### DIFF
--- a/apps/server/build.rs
+++ b/apps/server/build.rs
@@ -2,6 +2,9 @@ use chrono::prelude::{DateTime, Utc};
 use std::{process::Command, time::SystemTime};
 
 fn main() {
+	println!("cargo:rerun-if-env-changed=GIT_REV");
+	println!("cargo:rerun-if-env-changed=BUILD_CHANNEL");
+
 	let system_time = SystemTime::now();
 	let date_time: DateTime<Utc> = system_time.into();
 	let compiled_at = format!("{}", date_time.format("%+"));

--- a/core/build.rs
+++ b/core/build.rs
@@ -2,6 +2,8 @@ use chrono::prelude::{DateTime, Utc};
 use std::{process::Command, time::SystemTime};
 
 fn main() {
+	println!("cargo:rerun-if-env-changed=GIT_REV");
+
 	let system_time = SystemTime::now();
 	let date_time: DateTime<Utc> = system_time.into();
 	let compiled_at = format!("{}", date_time.format("%+"));


### PR DESCRIPTION
this _should_ fix some of the stale issues i have been plagued with

- https://docs.rs/cargo-emit/latest/cargo_emit/macro.rerun_if_env_changed.html