### PR TITLE
✨ Tags management page

### DIFF
--- a/crates/graphql/schema.graphql
+++ b/crates/graphql/schema.graphql
@@ -1646,6 +1646,11 @@ type Mutation {
 	"""
 	createTags(tags: [String!]!): [Tag!]!
 	"""
+	Rename a tag. Returns the updated tag, or an error if the tag was not found or the new
+	name already exists.
+	"""
+	renameTag(id: Int!, name: String!): Tag!
+	"""
 	Delete tags. Returns a list containing the deleted tags, or an error if deletion failed.
 	
 	* `tags` - A non-empty list of tags to create.

--- a/crates/graphql/src/mutation/tag.rs
+++ b/crates/graphql/src/mutation/tag.rs
@@ -2,8 +2,8 @@ use crate::{data::CoreContext, object::tag::Tag};
 use async_graphql::{Context, Object, Result};
 use models::entity::tag;
 use sea_orm::{
-	prelude::*, ActiveValue::Set, DatabaseConnection, DatabaseTransaction, QuerySelect,
-	TransactionTrait,
+	prelude::*, ActiveValue::Set, DatabaseConnection, DatabaseTransaction,
+	IntoActiveModel, QuerySelect, TransactionTrait,
 };
 use std::collections::HashSet;
 
@@ -24,6 +24,13 @@ impl TagMutation {
 	) -> Result<Vec<Tag>> {
 		let conn = ctx.data::<CoreContext>()?.conn.as_ref();
 		create_tags(conn, tags).await
+	}
+
+	/// Rename a tag. Returns the updated tag, or an error if the tag was not found or the new
+	/// name already exists.
+	async fn rename_tag(&self, ctx: &Context<'_>, id: i32, name: String) -> Result<Tag> {
+		let conn = ctx.data::<CoreContext>()?.conn.as_ref();
+		rename_tag(conn, id, name).await
 	}
 
 	/// Delete tags. Returns a list containing the deleted tags, or an error if deletion failed.
@@ -103,6 +110,36 @@ async fn create_tags(conn: &DatabaseConnection, tags: Vec<String>) -> Result<Vec
 	txn.commit().await?;
 
 	Ok(inserted_tags.into_iter().map(Tag::from).collect())
+}
+
+async fn rename_tag(conn: &DatabaseConnection, id: i32, name: String) -> Result<Tag> {
+	let name = name.trim().to_string();
+	if name.is_empty() {
+		return Err("Tag name cannot be empty".into());
+	}
+
+	let existing = tag::Entity::find()
+		.filter(tag::Column::Name.eq(name.clone()))
+		.one(conn)
+		.await?;
+	if let Some(existing) = existing {
+		if existing.id != id {
+			return Err(format!("A tag with name '{}' already exists", name).into());
+		}
+		// Name is unchanged, just return it
+		return Ok(Tag::from(existing));
+	}
+
+	let model = tag::Entity::find_by_id(id)
+		.one(conn)
+		.await?
+		.ok_or("Tag not found")?;
+
+	let mut active_model = model.into_active_model();
+	active_model.name = Set(name);
+	let updated = active_model.update(conn).await?;
+
+	Ok(Tag::from(updated))
 }
 
 #[cfg(test)]
@@ -197,5 +234,91 @@ mod tests {
 		let tags = vec!["hello".to_string(), "hello".to_string()];
 		let unique_tags = get_unique_tags(&txn, tags).await.unwrap();
 		assert_eq!(unique_tags, vec!["hello".to_string()]);
+	}
+
+	#[tokio::test]
+	async fn test_rename_tag() {
+		let original = tag::Model {
+			id: 1,
+			name: "old_name".to_string(),
+		};
+		let renamed = tag::Model {
+			id: 1,
+			name: "new_name".to_string(),
+		};
+
+		// Query 1: find by name (no conflict) -> empty
+		// Query 2: find by id -> original
+		// Query 3: update -> renamed
+		let conn = MockDatabase::new(sea_orm::DatabaseBackend::Sqlite)
+			.append_query_results::<tag::Model, Vec<_>, Vec<Vec<_>>>(vec![
+				vec![],
+				vec![original],
+				vec![renamed.clone()],
+			])
+			.append_exec_results(vec![MockExecResult {
+				last_insert_id: 1,
+				rows_affected: 1,
+			}])
+			.into_connection();
+
+		let result = rename_tag(&conn, 1, "new_name".to_string()).await.unwrap();
+		assert_eq!(result, Tag { model: renamed });
+	}
+
+	#[tokio::test]
+	async fn test_rename_tag_empty_name() {
+		let conn = MockDatabase::new(sea_orm::DatabaseBackend::Sqlite).into_connection();
+
+		let result = rename_tag(&conn, 1, "   ".to_string()).await;
+		assert!(result.is_err());
+	}
+
+	#[tokio::test]
+	async fn test_rename_tag_conflict() {
+		let conflicting = tag::Model {
+			id: 2,
+			name: "taken".to_string(),
+		};
+
+		// Query 1: find by name -> found with different id
+		let conn = MockDatabase::new(sea_orm::DatabaseBackend::Sqlite)
+			.append_query_results::<tag::Model, Vec<_>, Vec<Vec<_>>>(vec![vec![
+				conflicting,
+			]])
+			.into_connection();
+
+		let result = rename_tag(&conn, 1, "taken".to_string()).await;
+		assert!(result.is_err());
+	}
+
+	#[tokio::test]
+	async fn test_rename_tag_unchanged() {
+		let existing = tag::Model {
+			id: 1,
+			name: "same".to_string(),
+		};
+
+		// Query 1: find by name -> found with same id (no-op)
+		let conn = MockDatabase::new(sea_orm::DatabaseBackend::Sqlite)
+			.append_query_results::<tag::Model, Vec<_>, Vec<Vec<_>>>(vec![vec![
+				existing.clone()
+			]])
+			.into_connection();
+
+		let result = rename_tag(&conn, 1, "same".to_string()).await.unwrap();
+		assert_eq!(result, Tag { model: existing });
+	}
+
+	#[tokio::test]
+	async fn test_rename_tag_not_found() {
+		// Query 1: find by name -> empty (no conflict)
+		// Query 2: find by id -> empty (not found)
+		let conn = MockDatabase::new(sea_orm::DatabaseBackend::Sqlite)
+			.append_query_results::<tag::Model, Vec<_>, Vec<Vec<_>>>(vec![vec![], vec![]])
+			.into_connection();
+
+		let result = rename_tag(&conn, 999, "new_name".to_string()).await;
+		assert!(result.is_err());
 	}
 }

--- a/packages/browser/src/components/TagSelect.tsx
+++ b/packages/browser/src/components/TagSelect.tsx
@@ -31,18 +31,22 @@ export default function TagSelect({ label, description, selected = [], onChange 
 	} = useSuspenseGraphQL(query, sdk.cacheKey('tags'))
 
 	const [options, setOptions] = useState<TagOption[]>(
-		tags.map((tag) => ({ label: tag.name, value: tag.name.toLowerCase() })),
+		tags
+			.map((tag) => ({ label: tag.name, value: tag.name.toLowerCase() }))
+			.sort((a, b) => a.label.localeCompare(b.label)),
 	)
 
 	useEffect(() => {
 		setOptions((curr) =>
-			tags.map((tag) => {
-				const exists = curr.find((option) => option.label === tag.name)
-				if (!exists) {
-					return { label: tag.name, value: tag.name.toLowerCase() }
-				}
-				return exists
-			}),
+			tags
+				.map((tag) => {
+					const exists = curr.find((option) => option.label === tag.name)
+					if (!exists) {
+						return { label: tag.name, value: tag.name.toLowerCase() }
+					}
+					return exists
+				})
+				.sort((a, b) => a.label.localeCompare(b.label)),
 		)
 
 		// Remove any selected tags that no longer exist
@@ -73,7 +77,7 @@ export default function TagSelect({ label, description, selected = [], onChange 
 			label={label || 'Tags'}
 			description={description}
 			options={options}
-			value={selected.map(({ value }) => value)}
+			value={[...selected].sort((a, b) => a.label.localeCompare(b.label)).map(({ value }) => value)}
 			onChange={handleChange}
 			onAddOption={(option) => setOptions((curr) => [...curr, option])}
 			isMultiSelect

--- a/packages/browser/src/components/TagSelect.tsx
+++ b/packages/browser/src/components/TagSelect.tsx
@@ -44,6 +44,13 @@ export default function TagSelect({ label, description, selected = [], onChange 
 				return exists
 			}),
 		)
+
+		// Remove any selected tags that no longer exist
+		const tagNames = new Set(tags.map((tag) => tag.name.toLowerCase()))
+		const filtered = selected.filter((s) => tagNames.has(s.value))
+		if (filtered.length !== selected.length) {
+			onChange(filtered.length > 0 ? filtered : undefined)
+		}
 	}, [tags])
 
 	const handleChange = useCallback(

--- a/packages/browser/src/scenes/settings/SettingsRouter.tsx
+++ b/packages/browser/src/scenes/settings/SettingsRouter.tsx
@@ -20,6 +20,7 @@ const GeneralServerSettingsScene = lazy(
 )
 const ServerLogsScene = lazy(() => import('./server/logs/ServerLogsScene.tsx'))
 const JobSettingsScene = lazy(() => import('./server/jobs/JobSettingsScene.tsx'))
+const TagSettingsScene = lazy(() => import('./server/tags'))
 
 /**
  * The main router for the settings scene(s). Mostly just a collection of nested routers
@@ -42,6 +43,10 @@ export default function SettingsRouter() {
 		() => checkPermission(UserPermission.EmailerManage),
 		[checkPermission],
 	)
+	const canManageLibrary = useMemo(
+		() => checkPermission(UserPermission.ManageLibrary),
+		[checkPermission],
+	)
 
 	return (
 		<Routes>
@@ -59,6 +64,7 @@ export default function SettingsRouter() {
 				{canManageServer && <Route path="jobs" element={<JobSettingsScene />} />}
 				{canManageUsers && <Route path="users/*" element={<UsersRouter />} />}
 				{canManageEmail && <Route path="email/*" element={<EmailSettingsRouter />} />}
+				{canManageLibrary && <Route path="tags" element={<TagSettingsScene />} />}
 
 				<Route path="*" element={<Navigate to="account" replace />} />
 			</Route>

--- a/packages/browser/src/scenes/settings/routes.ts
+++ b/packages/browser/src/scenes/settings/routes.ts
@@ -11,6 +11,7 @@ import {
 	PcCase,
 	ScrollText,
 	Server,
+	Tag,
 	UserCircle,
 	Users,
 } from 'lucide-react'
@@ -154,6 +155,13 @@ export const createRouteGroups = (client: QueryClient, api: Api): RouteGroup[] =
 				localeKey: 'server/notifications',
 				permissions: [UserPermission.ReadNotifier],
 				to: '/settings/notifications',
+			},
+			{
+				icon: Tag,
+				label: 'Tags',
+				localeKey: 'server/tags',
+				permissions: [UserPermission.ManageLibrary],
+				to: '/settings/tags',
 			},
 		],
 		label: 'Management',

--- a/packages/browser/src/scenes/settings/server/tags/CreateTagModal.tsx
+++ b/packages/browser/src/scenes/settings/server/tags/CreateTagModal.tsx
@@ -1,0 +1,103 @@
+import { useGraphQLMutation, useSDK } from '@stump/client'
+import { Button, Dialog, Input } from '@stump/components'
+import { graphql } from '@stump/graphql'
+import { useLocaleContext } from '@stump/i18n'
+import { useQueryClient } from '@tanstack/react-query'
+import { useCallback, useEffect, useState } from 'react'
+import { toast } from 'sonner'
+
+const mutation = graphql(`
+	mutation CreateTagModal($tags: [String!]!) {
+		createTags(tags: $tags) {
+			id
+			name
+		}
+	}
+`)
+
+export default function CreateTagModal() {
+	const [isOpen, setIsOpen] = useState(false)
+	const [name, setName] = useState('')
+
+	const client = useQueryClient()
+	const { t } = useLocaleContext()
+	const { sdk } = useSDK()
+
+	const { mutate: createTags, isPending } = useGraphQLMutation(mutation, {
+		onSuccess: () => {
+			client.refetchQueries({
+				exact: false,
+				predicate: ({ queryKey }) => queryKey.includes(sdk.cacheKeys.tags),
+			})
+			setIsOpen(false)
+		},
+		onError: (error) => {
+			console.error('Failed to create tag', error)
+			toast.error(String(error))
+		},
+	})
+
+	const handleCreate = useCallback(() => {
+		const trimmed = name.trim()
+		if (trimmed) {
+			createTags({ tags: [trimmed] })
+		}
+	}, [name, createTags])
+
+	useEffect(() => {
+		if (!isOpen) {
+			const timeout = setTimeout(() => setName(''), 150)
+			return () => clearTimeout(timeout)
+		}
+	}, [isOpen])
+
+	return (
+		<Dialog open={isOpen} onOpenChange={isPending ? undefined : setIsOpen}>
+			<Dialog.Trigger asChild>
+				<Button size="sm" variant="secondary">
+					{t(getKey('trigger'))}
+				</Button>
+			</Dialog.Trigger>
+
+			<Dialog.Content size="sm">
+				<Dialog.Header>
+					<Dialog.Title>{t(getKey('modal.heading'))}</Dialog.Title>
+					<Dialog.Description>{t(getKey('modal.description'))}</Dialog.Description>
+				</Dialog.Header>
+
+				<form
+					onSubmit={(e) => {
+						e.preventDefault()
+						handleCreate()
+					}}
+				>
+					<Input
+						label={t(getKey('modal.name.label'))}
+						placeholder={t(getKey('modal.name.placeholder'))}
+						value={name}
+						onChange={(e) => setName(e.target.value)}
+						autoFocus
+					/>
+				</form>
+
+				<Dialog.Footer>
+					<Button disabled={isPending} onClick={() => setIsOpen(false)} size="sm">
+						{t('common.cancel')}
+					</Button>
+
+					<Button
+						disabled={isPending || !name.trim()}
+						variant="primary"
+						size="sm"
+						onClick={handleCreate}
+					>
+						{t(getKey('modal.submit'))}
+					</Button>
+				</Dialog.Footer>
+			</Dialog.Content>
+		</Dialog>
+	)
+}
+
+const LOCALE_BASE = 'settingsScene.server/tags.sections.createTag'
+const getKey = (key: string) => `${LOCALE_BASE}.${key}`

--- a/packages/browser/src/scenes/settings/server/tags/DeleteTagConfirmModal.tsx
+++ b/packages/browser/src/scenes/settings/server/tags/DeleteTagConfirmModal.tsx
@@ -1,0 +1,60 @@
+import { useGraphQLMutation, useSDK } from '@stump/client'
+import { ConfirmationModal } from '@stump/components'
+import { graphql, Tag } from '@stump/graphql'
+import { useLocaleContext } from '@stump/i18n'
+import { useQueryClient } from '@tanstack/react-query'
+import { useCallback } from 'react'
+
+const mutation = graphql(`
+	mutation DeleteTagConfirmModal($tags: [String!]!) {
+		deleteTags(tags: $tags) {
+			id
+			name
+		}
+	}
+`)
+
+type Props = {
+	tag: Tag | null
+	onClose: () => void
+}
+
+export default function DeleteTagConfirmModal({ tag, onClose }: Props) {
+	const { sdk } = useSDK()
+	const { t } = useLocaleContext()
+
+	const client = useQueryClient()
+
+	const { mutate: deleteTags, isPending } = useGraphQLMutation(mutation, {
+		onSuccess: () => {
+			client.refetchQueries({
+				exact: false,
+				predicate: ({ queryKey }) => queryKey.includes(sdk.cacheKeys.tags),
+			})
+			onClose()
+		},
+	})
+
+	const handleConfirm = useCallback(() => {
+		if (tag) {
+			deleteTags({ tags: [tag.name] })
+		}
+	}, [tag, deleteTags])
+
+	return (
+		<ConfirmationModal
+			title={t(getKey('title'))}
+			description={t(getKey('description'))}
+			confirmText={t(getKey('confirm'))}
+			confirmVariant="danger"
+			isOpen={!!tag}
+			onClose={onClose}
+			onConfirm={handleConfirm}
+			confirmIsLoading={isPending}
+			trigger={null}
+		/>
+	)
+}
+
+const LOCALE_BASE = 'settingsScene.server/tags.sections.deleteTag'
+const getKey = (key: string) => `${LOCALE_BASE}.${key}`

--- a/packages/browser/src/scenes/settings/server/tags/RenameTagModal.tsx
+++ b/packages/browser/src/scenes/settings/server/tags/RenameTagModal.tsx
@@ -1,0 +1,99 @@
+import { useGraphQLMutation, useSDK } from '@stump/client'
+import { Button, Dialog, Input } from '@stump/components'
+import { graphql, Tag } from '@stump/graphql'
+import { useLocaleContext } from '@stump/i18n'
+import { useQueryClient } from '@tanstack/react-query'
+import { useCallback, useEffect, useState } from 'react'
+import { toast } from 'sonner'
+
+const mutation = graphql(`
+	mutation RenameTagModal($id: Int!, $name: String!) {
+		renameTag(id: $id, name: $name) {
+			id
+			name
+		}
+	}
+`)
+
+type Props = {
+	tag: Tag | null
+	onClose: () => void
+}
+
+export default function RenameTagModal({ tag, onClose }: Props) {
+	const [name, setName] = useState('')
+
+	const client = useQueryClient()
+	const { t } = useLocaleContext()
+	const { sdk } = useSDK()
+
+	const { mutate: renameTag, isPending } = useGraphQLMutation(mutation, {
+		onSuccess: () => {
+			client.refetchQueries({
+				exact: false,
+				predicate: ({ queryKey }) => queryKey.includes(sdk.cacheKeys.tags),
+			})
+			onClose()
+		},
+		onError: (error) => {
+			console.error('Failed to rename tag', error)
+			toast.error(String(error))
+		},
+	})
+
+	const handleRename = useCallback(() => {
+		if (tag && name.trim()) {
+			renameTag({ id: tag.id, name: name.trim() })
+		}
+	}, [tag, name, renameTag])
+
+	useEffect(() => {
+		if (tag) {
+			setName(tag.name)
+		}
+	}, [tag])
+
+	return (
+		<Dialog open={!!tag} onOpenChange={isPending ? undefined : (open) => !open && onClose()}>
+			<Dialog.Content size="sm">
+				<Dialog.Header>
+					<Dialog.Title>{t(getKey('heading'))}</Dialog.Title>
+					<Dialog.Description>{t(getKey('description'))}</Dialog.Description>
+				</Dialog.Header>
+
+				<form
+					onSubmit={(e) => {
+						e.preventDefault()
+						handleRename()
+					}}
+				>
+					<Input
+						label={t(getKey('name.label'))}
+						placeholder={t(getKey('name.placeholder'))}
+						value={name}
+						onChange={(e) => setName(e.target.value)}
+						autoFocus
+					/>
+				</form>
+
+				<Dialog.Footer>
+					<Button disabled={isPending} onClick={onClose} size="sm">
+						{t('common.cancel')}
+					</Button>
+
+					<Button
+						disabled={isPending || !name.trim() || name.trim() === tag?.name}
+						variant="primary"
+						size="sm"
+						onClick={handleRename}
+					>
+						{t(getKey('submit'))}
+					</Button>
+				</Dialog.Footer>
+			</Dialog.Content>
+		</Dialog>
+	)
+}
+
+const LOCALE_BASE = 'settingsScene.server/tags.sections.renameTag.modal'
+const getKey = (key: string) => `${LOCALE_BASE}.${key}`

--- a/packages/browser/src/scenes/settings/server/tags/TagSettingsScene.tsx
+++ b/packages/browser/src/scenes/settings/server/tags/TagSettingsScene.tsx
@@ -1,0 +1,38 @@
+import { Heading, Text } from '@stump/components'
+import { useLocaleContext } from '@stump/i18n'
+import { Suspense } from 'react'
+
+import { ContentContainer, SceneContainer } from '@/components/container'
+
+import CreateTagModal from './CreateTagModal'
+import TagTable from './TagTable'
+
+export default function TagSettingsScene() {
+	const { t } = useLocaleContext()
+
+	return (
+		<SceneContainer>
+			<ContentContainer>
+				<div className="flex flex-col gap-4">
+					<div className="flex items-end justify-between">
+						<div>
+							<Heading size="sm">{t(getKey('title'))}</Heading>
+							<Text size="sm" variant="muted" className="mt-1">
+								{t(getKey('description'))}
+							</Text>
+						</div>
+
+						<CreateTagModal />
+					</div>
+
+					<Suspense>
+						<TagTable />
+					</Suspense>
+				</div>
+			</ContentContainer>
+		</SceneContainer>
+	)
+}
+
+const LOCALE_BASE = 'settingsScene.server/tags.sections.table'
+const getKey = (key: string) => `${LOCALE_BASE}.${key}`

--- a/packages/browser/src/scenes/settings/server/tags/TagTable.tsx
+++ b/packages/browser/src/scenes/settings/server/tags/TagTable.tsx
@@ -14,6 +14,7 @@ import { useMemo, useState } from 'react'
 import { getCommonPinningStyles } from '@/components/table/Table'
 
 import DeleteTagConfirmModal from './DeleteTagConfirmModal'
+import RenameTagModal from './RenameTagModal'
 
 const query = graphql(`
 	query TagTable {
@@ -39,6 +40,7 @@ export default function TagTable() {
 	)
 
 	const [deletingTag, setDeletingTag] = useState<Tag | null>(null)
+	const [renamingTag, setRenamingTag] = useState<Tag | null>(null)
 
 	const columns = useMemo(
 		() => [
@@ -64,6 +66,9 @@ export default function TagTable() {
 
 							<Dropdown.Content align="end">
 								<Dropdown.Group>
+									<Dropdown.Item onClick={() => setRenamingTag(tag)}>
+										<span>{t(getActionKey('rename'))}</span>
+									</Dropdown.Item>
 									<Dropdown.Item onClick={() => setDeletingTag(tag)}>
 										<span>{t('common.delete')}</span>
 									</Dropdown.Item>
@@ -112,6 +117,7 @@ export default function TagTable() {
 
 	return (
 		<>
+			<RenameTagModal tag={renamingTag} onClose={() => setRenamingTag(null)} />
 			<DeleteTagConfirmModal tag={deletingTag} onClose={() => setDeletingTag(null)} />
 
 			<Card className="overflow-x-auto">
@@ -170,4 +176,5 @@ const columnHelper = createColumnHelper<Tag>()
 
 const LOCALE_BASE = 'settingsScene.server/tags.sections.table'
 const getColumnKey = (key: string) => `${LOCALE_BASE}.columns.${key}`
+const getActionKey = (key: string) => `${LOCALE_BASE}.actionMenu.${key}`
 const getKey = (key: string) => `${LOCALE_BASE}.${key}`

--- a/packages/browser/src/scenes/settings/server/tags/TagTable.tsx
+++ b/packages/browser/src/scenes/settings/server/tags/TagTable.tsx
@@ -1,0 +1,173 @@
+import { useSDK, useSuspenseGraphQL } from '@stump/client'
+import { Button, Card, Dropdown, Text } from '@stump/components'
+import { graphql, Tag } from '@stump/graphql'
+import { useLocaleContext } from '@stump/i18n'
+import {
+	createColumnHelper,
+	flexRender,
+	getCoreRowModel,
+	useReactTable,
+} from '@tanstack/react-table'
+import { Ellipsis, Slash, Tag as TagIcon } from 'lucide-react'
+import { useMemo, useState } from 'react'
+
+import { getCommonPinningStyles } from '@/components/table/Table'
+
+import DeleteTagConfirmModal from './DeleteTagConfirmModal'
+
+const query = graphql(`
+	query TagTable {
+		tags {
+			id
+			name
+		}
+	}
+`)
+
+export default function TagTable() {
+	const { sdk } = useSDK()
+
+	const {
+		data: { tags },
+	} = useSuspenseGraphQL(query, sdk.cacheKey('tags'))
+
+	const { t } = useLocaleContext()
+
+	const sortedTags = useMemo(
+		() => [...(tags || [])].sort((a, b) => a.name.localeCompare(b.name)),
+		[tags],
+	)
+
+	const [deletingTag, setDeletingTag] = useState<Tag | null>(null)
+
+	const columns = useMemo(
+		() => [
+			columnHelper.accessor('name', {
+				header: () => (
+					<Text size="sm" variant="secondary">
+						{t(getColumnKey('name'))}
+					</Text>
+				),
+				cell: ({ getValue }) => <Text size="sm">{getValue()}</Text>,
+			}),
+			columnHelper.display({
+				id: 'actions',
+				header: () => null,
+				cell: ({ row: { original: tag } }) => (
+					<div className="flex items-center justify-center">
+						<Dropdown modal={false}>
+							<Dropdown.Trigger asChild>
+								<Button size="icon" variant="ghost">
+									<Ellipsis className="h-4 w-4 text-foreground" />
+								</Button>
+							</Dropdown.Trigger>
+
+							<Dropdown.Content align="end">
+								<Dropdown.Group>
+									<Dropdown.Item onClick={() => setDeletingTag(tag)}>
+										<span>{t('common.delete')}</span>
+									</Dropdown.Item>
+								</Dropdown.Group>
+							</Dropdown.Content>
+						</Dropdown>
+					</div>
+				),
+				size: 20,
+			}),
+		],
+		[t],
+	)
+
+	const table = useReactTable({
+		columns,
+		data: sortedTags,
+		getCoreRowModel: getCoreRowModel(),
+		state: {
+			columnPinning: { right: ['actions'] },
+		},
+	})
+	const { rows } = table.getRowModel()
+
+	if (!tags?.length) {
+		return (
+			<Card className="flex items-center justify-center border-dashed border-edge-subtle p-6">
+				<div className="flex flex-col space-y-3">
+					<div className="relative flex justify-center">
+						<span className="flex items-center justify-center rounded-lg bg-background-surface p-2">
+							<TagIcon className="h-6 w-6 text-foreground-muted" />
+							<Slash className="absolute h-6 w-6 scale-x-[-1] transform text-foreground opacity-80" />
+						</span>
+					</div>
+
+					<div className="text-center">
+						<Text>{t(getKey('empty.title'))}</Text>
+						<Text size="sm" variant="muted">
+							{t(getKey('empty.action'))}
+						</Text>
+					</div>
+				</div>
+			</Card>
+		)
+	}
+
+	return (
+		<>
+			<DeleteTagConfirmModal tag={deletingTag} onClose={() => setDeletingTag(null)} />
+
+			<Card className="overflow-x-auto">
+				<table
+					className="min-w-full"
+					style={{
+						width: table.getCenterTotalSize(),
+					}}
+				>
+					<thead className="border-b border-edge">
+						<tr>
+							{table.getFlatHeaders().map((header) => (
+								<th
+									key={header.id}
+									className="sticky !top-0 z-[2] h-10 bg-background-surface/50 px-2 shadow-sm"
+									style={getCommonPinningStyles(header.column)}
+								>
+									<div
+										className="flex items-center"
+										style={{
+											width: header.getSize(),
+										}}
+									>
+										{flexRender(header.column.columnDef.header, header.getContext())}
+									</div>
+								</th>
+							))}
+						</tr>
+					</thead>
+
+					<tbody className="divide divide-y divide-edge">
+						{rows.map((row) => (
+							<tr key={row.id}>
+								{row.getVisibleCells().map((cell) => (
+									<td
+										className="h-14 bg-background px-2 last:px-0"
+										key={cell.id}
+										style={{
+											width: cell.column.getSize(),
+											...getCommonPinningStyles(cell.column),
+										}}
+									>
+										{flexRender(cell.column.columnDef.cell, cell.getContext())}
+									</td>
+								))}
+							</tr>
+						))}
+					</tbody>
+				</table>
+			</Card>
+		</>
+	)
+}
+
+const columnHelper = createColumnHelper<Tag>()
+
+const LOCALE_BASE = 'settingsScene.server/tags.sections.table'
+const getColumnKey = (key: string) => `${LOCALE_BASE}.columns.${key}`
+const getKey = (key: string) => `${LOCALE_BASE}.${key}`

--- a/packages/browser/src/scenes/settings/server/tags/index.ts
+++ b/packages/browser/src/scenes/settings/server/tags/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TagSettingsScene'

--- a/packages/graphql/src/client/gql.ts
+++ b/packages/graphql/src/client/gql.ts
@@ -265,6 +265,9 @@ type Documents = {
     "\n\tsubscription LiveLogsFeed {\n\t\ttailLogFile\n\t}\n": typeof types.LiveLogsFeedDocument,
     "\n\tmutation DeleteLogs {\n\t\tdeleteLogs {\n\t\t\tdeleted\n\t\t}\n\t}\n": typeof types.DeleteLogsDocument,
     "\n\tquery PersistedLogs(\n\t\t$filter: LogFilterInput!\n\t\t$pagination: Pagination!\n\t\t$orderBy: [LogModelOrderBy!]!\n\t) {\n\t\tlogs(filter: $filter, pagination: $pagination, orderBy: $orderBy) {\n\t\t\tnodes {\n\t\t\t\tid\n\t\t\t\ttimestamp\n\t\t\t\tlevel\n\t\t\t\tmessage\n\t\t\t\tjobId\n\t\t\t\tcontext\n\t\t\t}\n\t\t\tpageInfo {\n\t\t\t\t__typename\n\t\t\t\t... on OffsetPaginationInfo {\n\t\t\t\t\ttotalPages\n\t\t\t\t\tcurrentPage\n\t\t\t\t\tpageSize\n\t\t\t\t\tpageOffset\n\t\t\t\t\tpageOffset\n\t\t\t\t\tzeroBased\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n": typeof types.PersistedLogsDocument,
+    "\n\tmutation CreateTagModal($tags: [String!]!) {\n\t\tcreateTags(tags: $tags) {\n\t\t\tid\n\t\t\tname\n\t\t}\n\t}\n": typeof types.CreateTagModalDocument,
+    "\n\tmutation DeleteTagConfirmModal($tags: [String!]!) {\n\t\tdeleteTags(tags: $tags) {\n\t\t\tid\n\t\t\tname\n\t\t}\n\t}\n": typeof types.DeleteTagConfirmModalDocument,
+    "\n\tquery TagTable {\n\t\ttags {\n\t\t\tid\n\t\t\tname\n\t\t}\n\t}\n": typeof types.TagTableDocument,
     "\n\tquery UserStats {\n\t\tuserCount\n\t\ttopReaders(take: 1) {\n\t\t\tid\n\t\t\tusername\n\t\t\tfinishedReadingSessionsCount\n\t\t}\n\t\tactiveReadingSessionCount\n\t\tfinishedReadingSessionCount\n\t}\n": typeof types.UserStatsDocument,
     "\n\tmutation CreateOrUpdateUserFormUpdateUser($id: ID!, $input: UpdateUserInput!) {\n\t\tupdateUser(id: $id, input: $input) {\n\t\t\tid\n\t\t\tusername\n\t\t\tageRestriction {\n\t\t\t\tage\n\t\t\t\trestrictOnUnset\n\t\t\t}\n\t\t\tpermissions\n\t\t\tmaxSessionsAllowed\n\t\t}\n\t}\n": typeof types.CreateOrUpdateUserFormUpdateUserDocument,
     "\n\tmutation CreateOrUpdateUserFormCreateUser($input: CreateUserInput!) {\n\t\tcreateUser(input: $input) {\n\t\t\tid\n\t\t}\n\t}\n": typeof types.CreateOrUpdateUserFormCreateUserDocument,
@@ -542,6 +545,9 @@ const documents: Documents = {
     "\n\tsubscription LiveLogsFeed {\n\t\ttailLogFile\n\t}\n": types.LiveLogsFeedDocument,
     "\n\tmutation DeleteLogs {\n\t\tdeleteLogs {\n\t\t\tdeleted\n\t\t}\n\t}\n": types.DeleteLogsDocument,
     "\n\tquery PersistedLogs(\n\t\t$filter: LogFilterInput!\n\t\t$pagination: Pagination!\n\t\t$orderBy: [LogModelOrderBy!]!\n\t) {\n\t\tlogs(filter: $filter, pagination: $pagination, orderBy: $orderBy) {\n\t\t\tnodes {\n\t\t\t\tid\n\t\t\t\ttimestamp\n\t\t\t\tlevel\n\t\t\t\tmessage\n\t\t\t\tjobId\n\t\t\t\tcontext\n\t\t\t}\n\t\t\tpageInfo {\n\t\t\t\t__typename\n\t\t\t\t... on OffsetPaginationInfo {\n\t\t\t\t\ttotalPages\n\t\t\t\t\tcurrentPage\n\t\t\t\t\tpageSize\n\t\t\t\t\tpageOffset\n\t\t\t\t\tpageOffset\n\t\t\t\t\tzeroBased\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n": types.PersistedLogsDocument,
+    "\n\tmutation CreateTagModal($tags: [String!]!) {\n\t\tcreateTags(tags: $tags) {\n\t\t\tid\n\t\t\tname\n\t\t}\n\t}\n": types.CreateTagModalDocument,
+    "\n\tmutation DeleteTagConfirmModal($tags: [String!]!) {\n\t\tdeleteTags(tags: $tags) {\n\t\t\tid\n\t\t\tname\n\t\t}\n\t}\n": types.DeleteTagConfirmModalDocument,
+    "\n\tquery TagTable {\n\t\ttags {\n\t\t\tid\n\t\t\tname\n\t\t}\n\t}\n": types.TagTableDocument,
     "\n\tquery UserStats {\n\t\tuserCount\n\t\ttopReaders(take: 1) {\n\t\t\tid\n\t\t\tusername\n\t\t\tfinishedReadingSessionsCount\n\t\t}\n\t\tactiveReadingSessionCount\n\t\tfinishedReadingSessionCount\n\t}\n": types.UserStatsDocument,
     "\n\tmutation CreateOrUpdateUserFormUpdateUser($id: ID!, $input: UpdateUserInput!) {\n\t\tupdateUser(id: $id, input: $input) {\n\t\t\tid\n\t\t\tusername\n\t\t\tageRestriction {\n\t\t\t\tage\n\t\t\t\trestrictOnUnset\n\t\t\t}\n\t\t\tpermissions\n\t\t\tmaxSessionsAllowed\n\t\t}\n\t}\n": types.CreateOrUpdateUserFormUpdateUserDocument,
     "\n\tmutation CreateOrUpdateUserFormCreateUser($input: CreateUserInput!) {\n\t\tcreateUser(input: $input) {\n\t\t\tid\n\t\t}\n\t}\n": types.CreateOrUpdateUserFormCreateUserDocument,
@@ -1569,6 +1575,18 @@ export function graphql(source: "\n\tmutation DeleteLogs {\n\t\tdeleteLogs {\n\t
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(source: "\n\tquery PersistedLogs(\n\t\t$filter: LogFilterInput!\n\t\t$pagination: Pagination!\n\t\t$orderBy: [LogModelOrderBy!]!\n\t) {\n\t\tlogs(filter: $filter, pagination: $pagination, orderBy: $orderBy) {\n\t\t\tnodes {\n\t\t\t\tid\n\t\t\t\ttimestamp\n\t\t\t\tlevel\n\t\t\t\tmessage\n\t\t\t\tjobId\n\t\t\t\tcontext\n\t\t\t}\n\t\t\tpageInfo {\n\t\t\t\t__typename\n\t\t\t\t... on OffsetPaginationInfo {\n\t\t\t\t\ttotalPages\n\t\t\t\t\tcurrentPage\n\t\t\t\t\tpageSize\n\t\t\t\t\tpageOffset\n\t\t\t\t\tpageOffset\n\t\t\t\t\tzeroBased\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n"): typeof import('./graphql').PersistedLogsDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n\tmutation CreateTagModal($tags: [String!]!) {\n\t\tcreateTags(tags: $tags) {\n\t\t\tid\n\t\t\tname\n\t\t}\n\t}\n"): typeof import('./graphql').CreateTagModalDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n\tmutation DeleteTagConfirmModal($tags: [String!]!) {\n\t\tdeleteTags(tags: $tags) {\n\t\t\tid\n\t\t\tname\n\t\t}\n\t}\n"): typeof import('./graphql').DeleteTagConfirmModalDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n\tquery TagTable {\n\t\ttags {\n\t\t\tid\n\t\t\tname\n\t\t}\n\t}\n"): typeof import('./graphql').TagTableDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/graphql/src/client/gql.ts
+++ b/packages/graphql/src/client/gql.ts
@@ -267,6 +267,7 @@ type Documents = {
     "\n\tquery PersistedLogs(\n\t\t$filter: LogFilterInput!\n\t\t$pagination: Pagination!\n\t\t$orderBy: [LogModelOrderBy!]!\n\t) {\n\t\tlogs(filter: $filter, pagination: $pagination, orderBy: $orderBy) {\n\t\t\tnodes {\n\t\t\t\tid\n\t\t\t\ttimestamp\n\t\t\t\tlevel\n\t\t\t\tmessage\n\t\t\t\tjobId\n\t\t\t\tcontext\n\t\t\t}\n\t\t\tpageInfo {\n\t\t\t\t__typename\n\t\t\t\t... on OffsetPaginationInfo {\n\t\t\t\t\ttotalPages\n\t\t\t\t\tcurrentPage\n\t\t\t\t\tpageSize\n\t\t\t\t\tpageOffset\n\t\t\t\t\tpageOffset\n\t\t\t\t\tzeroBased\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n": typeof types.PersistedLogsDocument,
     "\n\tmutation CreateTagModal($tags: [String!]!) {\n\t\tcreateTags(tags: $tags) {\n\t\t\tid\n\t\t\tname\n\t\t}\n\t}\n": typeof types.CreateTagModalDocument,
     "\n\tmutation DeleteTagConfirmModal($tags: [String!]!) {\n\t\tdeleteTags(tags: $tags) {\n\t\t\tid\n\t\t\tname\n\t\t}\n\t}\n": typeof types.DeleteTagConfirmModalDocument,
+    "\n\tmutation RenameTagModal($id: Int!, $name: String!) {\n\t\trenameTag(id: $id, name: $name) {\n\t\t\tid\n\t\t\tname\n\t\t}\n\t}\n": typeof types.RenameTagModalDocument,
     "\n\tquery TagTable {\n\t\ttags {\n\t\t\tid\n\t\t\tname\n\t\t}\n\t}\n": typeof types.TagTableDocument,
     "\n\tquery UserStats {\n\t\tuserCount\n\t\ttopReaders(take: 1) {\n\t\t\tid\n\t\t\tusername\n\t\t\tfinishedReadingSessionsCount\n\t\t}\n\t\tactiveReadingSessionCount\n\t\tfinishedReadingSessionCount\n\t}\n": typeof types.UserStatsDocument,
     "\n\tmutation CreateOrUpdateUserFormUpdateUser($id: ID!, $input: UpdateUserInput!) {\n\t\tupdateUser(id: $id, input: $input) {\n\t\t\tid\n\t\t\tusername\n\t\t\tageRestriction {\n\t\t\t\tage\n\t\t\t\trestrictOnUnset\n\t\t\t}\n\t\t\tpermissions\n\t\t\tmaxSessionsAllowed\n\t\t}\n\t}\n": typeof types.CreateOrUpdateUserFormUpdateUserDocument,
@@ -547,6 +548,7 @@ const documents: Documents = {
     "\n\tquery PersistedLogs(\n\t\t$filter: LogFilterInput!\n\t\t$pagination: Pagination!\n\t\t$orderBy: [LogModelOrderBy!]!\n\t) {\n\t\tlogs(filter: $filter, pagination: $pagination, orderBy: $orderBy) {\n\t\t\tnodes {\n\t\t\t\tid\n\t\t\t\ttimestamp\n\t\t\t\tlevel\n\t\t\t\tmessage\n\t\t\t\tjobId\n\t\t\t\tcontext\n\t\t\t}\n\t\t\tpageInfo {\n\t\t\t\t__typename\n\t\t\t\t... on OffsetPaginationInfo {\n\t\t\t\t\ttotalPages\n\t\t\t\t\tcurrentPage\n\t\t\t\t\tpageSize\n\t\t\t\t\tpageOffset\n\t\t\t\t\tpageOffset\n\t\t\t\t\tzeroBased\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n": types.PersistedLogsDocument,
     "\n\tmutation CreateTagModal($tags: [String!]!) {\n\t\tcreateTags(tags: $tags) {\n\t\t\tid\n\t\t\tname\n\t\t}\n\t}\n": types.CreateTagModalDocument,
     "\n\tmutation DeleteTagConfirmModal($tags: [String!]!) {\n\t\tdeleteTags(tags: $tags) {\n\t\t\tid\n\t\t\tname\n\t\t}\n\t}\n": types.DeleteTagConfirmModalDocument,
+    "\n\tmutation RenameTagModal($id: Int!, $name: String!) {\n\t\trenameTag(id: $id, name: $name) {\n\t\t\tid\n\t\t\tname\n\t\t}\n\t}\n": types.RenameTagModalDocument,
     "\n\tquery TagTable {\n\t\ttags {\n\t\t\tid\n\t\t\tname\n\t\t}\n\t}\n": types.TagTableDocument,
     "\n\tquery UserStats {\n\t\tuserCount\n\t\ttopReaders(take: 1) {\n\t\t\tid\n\t\t\tusername\n\t\t\tfinishedReadingSessionsCount\n\t\t}\n\t\tactiveReadingSessionCount\n\t\tfinishedReadingSessionCount\n\t}\n": types.UserStatsDocument,
     "\n\tmutation CreateOrUpdateUserFormUpdateUser($id: ID!, $input: UpdateUserInput!) {\n\t\tupdateUser(id: $id, input: $input) {\n\t\t\tid\n\t\t\tusername\n\t\t\tageRestriction {\n\t\t\t\tage\n\t\t\t\trestrictOnUnset\n\t\t\t}\n\t\t\tpermissions\n\t\t\tmaxSessionsAllowed\n\t\t}\n\t}\n": types.CreateOrUpdateUserFormUpdateUserDocument,
@@ -1583,6 +1585,10 @@ export function graphql(source: "\n\tmutation CreateTagModal($tags: [String!]!) 
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(source: "\n\tmutation DeleteTagConfirmModal($tags: [String!]!) {\n\t\tdeleteTags(tags: $tags) {\n\t\t\tid\n\t\t\tname\n\t\t}\n\t}\n"): typeof import('./graphql').DeleteTagConfirmModalDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n\tmutation RenameTagModal($id: Int!, $name: String!) {\n\t\trenameTag(id: $id, name: $name) {\n\t\t\tid\n\t\t\tname\n\t\t}\n\t}\n"): typeof import('./graphql').RenameTagModalDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/graphql/src/client/graphql.ts
+++ b/packages/graphql/src/client/graphql.ts
@@ -5853,6 +5853,25 @@ export type PersistedLogsQueryVariables = Exact<{
 
 export type PersistedLogsQuery = { __typename?: 'Query', logs: { __typename?: 'PaginatedLogResponse', nodes: Array<{ __typename?: 'Log', id: number, timestamp: any, level: LogLevel, message: string, jobId?: string | null, context?: string | null }>, pageInfo: { __typename: 'CursorPaginationInfo' } | { __typename: 'OffsetPaginationInfo', totalPages: number, currentPage: number, pageSize: number, pageOffset: number, zeroBased: boolean } } };
 
+export type CreateTagModalMutationVariables = Exact<{
+  tags: Array<Scalars['String']['input']> | Scalars['String']['input'];
+}>;
+
+
+export type CreateTagModalMutation = { __typename?: 'Mutation', createTags: Array<{ __typename?: 'Tag', id: number, name: string }> };
+
+export type DeleteTagConfirmModalMutationVariables = Exact<{
+  tags: Array<Scalars['String']['input']> | Scalars['String']['input'];
+}>;
+
+
+export type DeleteTagConfirmModalMutation = { __typename?: 'Mutation', deleteTags: Array<{ __typename?: 'Tag', id: number, name: string }> };
+
+export type TagTableQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type TagTableQuery = { __typename?: 'Query', tags: Array<{ __typename?: 'Tag', id: number, name: string }> };
+
 export type UserStatsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -11176,6 +11195,30 @@ export const PersistedLogsDocument = new TypedDocumentString(`
   }
 }
     `) as unknown as TypedDocumentString<PersistedLogsQuery, PersistedLogsQueryVariables>;
+export const CreateTagModalDocument = new TypedDocumentString(`
+    mutation CreateTagModal($tags: [String!]!) {
+  createTags(tags: $tags) {
+    id
+    name
+  }
+}
+    `) as unknown as TypedDocumentString<CreateTagModalMutation, CreateTagModalMutationVariables>;
+export const DeleteTagConfirmModalDocument = new TypedDocumentString(`
+    mutation DeleteTagConfirmModal($tags: [String!]!) {
+  deleteTags(tags: $tags) {
+    id
+    name
+  }
+}
+    `) as unknown as TypedDocumentString<DeleteTagConfirmModalMutation, DeleteTagConfirmModalMutationVariables>;
+export const TagTableDocument = new TypedDocumentString(`
+    query TagTable {
+  tags {
+    id
+    name
+  }
+}
+    `) as unknown as TypedDocumentString<TagTableQuery, TagTableQueryVariables>;
 export const UserStatsDocument = new TypedDocumentString(`
     query UserStats {
   userCount

--- a/packages/graphql/src/client/graphql.ts
+++ b/packages/graphql/src/client/graphql.ts
@@ -1723,6 +1723,11 @@ export type Mutation = {
   removeBookClubMember: BookClubMember;
   /** Remove your own suggestion (only before it's resolved) */
   removeSuggestion: BookClubBookSuggestion;
+  /**
+   * Rename a tag. Returns the updated tag, or an error if the tag was not found or the new
+   * name already exists.
+   */
+  renameTag: Tag;
   /** Reorder uncompleted books in the club's queue. Completed books cannot be reordered since they are effectively archived */
   reorderBooks: BookClub;
   resetLibraryMetadata: Library;
@@ -2203,6 +2208,12 @@ export type MutationRemoveBookClubMemberArgs = {
 
 export type MutationRemoveSuggestionArgs = {
   suggestionId: Scalars['ID']['input'];
+};
+
+
+export type MutationRenameTagArgs = {
+  id: Scalars['Int']['input'];
+  name: Scalars['String']['input'];
 };
 
 
@@ -5866,6 +5877,14 @@ export type DeleteTagConfirmModalMutationVariables = Exact<{
 
 
 export type DeleteTagConfirmModalMutation = { __typename?: 'Mutation', deleteTags: Array<{ __typename?: 'Tag', id: number, name: string }> };
+
+export type RenameTagModalMutationVariables = Exact<{
+  id: Scalars['Int']['input'];
+  name: Scalars['String']['input'];
+}>;
+
+
+export type RenameTagModalMutation = { __typename?: 'Mutation', renameTag: { __typename?: 'Tag', id: number, name: string } };
 
 export type TagTableQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -11211,6 +11230,14 @@ export const DeleteTagConfirmModalDocument = new TypedDocumentString(`
   }
 }
     `) as unknown as TypedDocumentString<DeleteTagConfirmModalMutation, DeleteTagConfirmModalMutationVariables>;
+export const RenameTagModalDocument = new TypedDocumentString(`
+    mutation RenameTagModal($id: Int!, $name: String!) {
+  renameTag(id: $id, name: $name) {
+    id
+    name
+  }
+}
+    `) as unknown as TypedDocumentString<RenameTagModalMutation, RenameTagModalMutationVariables>;
 export const TagTableDocument = new TypedDocumentString(`
     query TagTable {
   tags {

--- a/packages/i18n/src/locales/en-US.json
+++ b/packages/i18n/src/locales/en-US.json
@@ -2159,6 +2159,9 @@
 					},
 					"columns": {
 						"name": "Name"
+					},
+					"actionMenu": {
+						"rename": "Rename"
 					}
 				},
 				"createTag": {
@@ -2171,6 +2174,17 @@
 							"placeholder": "Enter tag name"
 						},
 						"submit": "Create"
+					}
+				},
+				"renameTag": {
+					"modal": {
+						"heading": "Rename tag",
+						"description": "Change the name of this tag across all assigned items",
+						"name": {
+							"label": "Name",
+							"placeholder": "Enter new tag name"
+						},
+						"submit": "Rename"
 					}
 				},
 				"deleteTag": {

--- a/packages/i18n/src/locales/en-US.json
+++ b/packages/i18n/src/locales/en-US.json
@@ -1254,6 +1254,7 @@
 				"access": "Access",
 				"email": "Email",
 				"notifications": "Notifications",
+				"tags": "Tags",
 				"label": "Management"
 			}
 		},
@@ -2142,6 +2143,41 @@
 				"helmet": "Update emailer",
 				"title": "Update emailer",
 				"description": "Update the details of this SMTP emailer"
+			}
+		},
+		"server/tags": {
+			"helmet": "Tag management",
+			"title": "Tags",
+			"description": "Create and manage tags for organizing your content",
+			"sections": {
+				"table": {
+					"title": "Tags",
+					"description": "All tags available on this server",
+					"empty": {
+						"title": "No tags",
+						"action": "Create your first tag to get started"
+					},
+					"columns": {
+						"name": "Name"
+					}
+				},
+				"createTag": {
+					"trigger": "Create tag",
+					"modal": {
+						"heading": "Create new tag",
+						"description": "Tags can be assigned to books, series, and libraries",
+						"name": {
+							"label": "Name",
+							"placeholder": "Enter tag name"
+						},
+						"submit": "Create"
+					}
+				},
+				"deleteTag": {
+					"title": "Delete tag",
+					"description": "This tag will be removed from all books, series, and libraries. This cannot be undone.",
+					"confirm": "Delete"
+				}
 			}
 		}
 	},


### PR DESCRIPTION
This adds a new Settings page, gated behind the `ManageLibrary` permission, providing a CRUD for tags. It also fixes some minor issues on the existing `TagSelect`.

Relates to #151.

<img width="1782" height="892" alt="image" src="https://github.com/user-attachments/assets/7877baca-3fe6-4412-b9b6-9ba43eb3dfe6" />
