### PR TITLE
:adhesive_bandage: Ensure OIDC migration remaps preferences

### DIFF
--- a/crates/cli/src/commands/account.rs
+++ b/crates/cli/src/commands/account.rs
@@ -561,6 +561,19 @@ where
 			.await?;
 	}
 
+	// if we do not swap the user_preferences_id the account "breaks" because no preferences exist.
+	// i added a fix for that, however the migration should still to the remap as it is correct
+	if let Some(local_prefs_id) = local_user.user_preferences_id {
+		user_preferences::Entity::update_many()
+			.col_expr(
+				user_preferences::Column::UserId,
+				sea_orm::sea_query::Expr::value(Some(oidc_user.id.clone())),
+			)
+			.filter(user_preferences::Column::Id.eq(local_prefs_id))
+			.exec(&txn)
+			.await?;
+	}
+
 	post_message("Deleting local account...");
 	user::Entity::delete_by_id(local_user.id).exec(&txn).await?;
 
@@ -644,7 +657,7 @@ mod tests {
 			let model = user.unwrap_or_else(|| Self::active_model());
 
 			let user = model.insert(db).await.expect("could not insert user");
-			let _user_preferences = user_preferences::ActiveModel {
+			let user_preferences = user_preferences::ActiveModel {
 				user_id: Set(Some(user.id.clone())),
 				..Default::default()
 			}
@@ -652,7 +665,21 @@ mod tests {
 			.await
 			.expect("could not insert user preferences");
 
-			user
+			user::Entity::update_many()
+				.col_expr(
+					user::Column::UserPreferencesId,
+					sea_orm::sea_query::Expr::value(Some(user_preferences.id)),
+				)
+				.filter(user::Column::Id.eq(user.id.clone()))
+				.exec(db)
+				.await
+				.expect("could not update user with preferences id");
+
+			user::Entity::find_by_id(user.id)
+				.one(db)
+				.await
+				.expect("could not find updated user")
+				.expect("user should exist after update")
 		}
 	}
 
@@ -975,6 +1002,22 @@ mod tests {
 			updated_oidc_user.is_server_owner,
 			"OIDC user should be server owner"
 		);
+
+		if let Some(prefs_id) = updated_oidc_user.user_preferences_id {
+			let preferences = user_preferences::Entity::find_by_id(prefs_id)
+				.one(&db)
+				.await
+				.expect("Failed to query user preferences")
+				.expect("User preferences should exist");
+			// see https://discord.com/channels/972593831172272148/1490415985524609264/1491118111401705494
+			assert_eq!(
+				preferences.user_id,
+				Some(oidc_user.id.clone()),
+				"User preferences should point back to OIDC user"
+			);
+		} else {
+			panic!("OIDC user should have preferences");
+		}
 
 		let reading_sessions = reading_session::Entity::find()
 			.filter(reading_session::Column::UserId.eq(&oidc_user.id))

--- a/crates/graphql/src/object/user.rs
+++ b/crates/graphql/src/object/user.rs
@@ -8,7 +8,7 @@ use models::{
 	},
 	shared::{enums::UserPermission, permission_set::PermissionSet},
 };
-use sea_orm::{prelude::*, QueryOrder};
+use sea_orm::{prelude::*, ActiveValue, QueryOrder};
 
 use crate::{
 	data::{CoreContext, ServiceContext},
@@ -86,11 +86,32 @@ impl User {
 	async fn preferences(&self, ctx: &Context<'_>) -> Result<UserPreferences> {
 		let conn = ctx.data::<CoreContext>()?.conn.as_ref();
 
-		let preferences = user_preferences::Entity::find()
+		let preferences = match user_preferences::Entity::find()
 			.filter(user_preferences::Column::UserId.eq(&self.model.id))
 			.one(conn)
 			.await?
-			.ok_or("User preferences not found")?;
+		{
+			Some(prefs) => prefs,
+			None => {
+				// this is a bit of an edge case, originally cropping up after an oidc account migration where the cli command
+				// did not remap the preferences back to the user. this manifested in an error after login, effectively bricking the
+				// account. obv not ideal, so while i don't expect this to be common id rather just recreate in this scenario and
+				// let the user reconfig their preferences. worst case is a dangling preferences record
+				// see https://discord.com/channels/972593831172272148/1490415985524609264/1491118111401705494
+				tracing::warn!(
+					user = self.model.username,
+					"Failed to load preferences for user. Recreating with defaults..."
+				);
+				let new_preferences = user_preferences::ActiveModel {
+					user_id: ActiveValue::Set(Some(self.model.id.clone())),
+					..Default::default()
+				}
+				.insert(conn)
+				.await?;
+
+				new_preferences
+			},
+		};
 
 		Ok(preferences.into())
 	}


### PR DESCRIPTION
if preferences are not remapped, previously it would break the accounts ability to log in. i have also added logic to just recreate if missing upon access in gql so should be fixed on both fronts