### PR TITLE
➖ Replace `once_cell::Lazy` with `std::sync::LazyLock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8355,7 +8355,6 @@ dependencies = [
  "local-ip-address",
  "maplit",
  "models",
- "once_cell",
  "openidconnect",
  "openssl",
  "prefixed-api-key",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,6 @@ lettre = { version = "0.11.18", default-features = false, features = [
 ] }
 md5 = "0.8.0"
 num-traits = "0.2.19"
-once_cell = "1.21.3"
 prefixed-api-key = { version = "0.3.0", features = ["sha2"] }
 rand = "0.9.2"
 regex = "1.11.3"

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -30,7 +30,6 @@ itertools.workspace = true
 jsonwebtoken = "9.3.0"
 linemux = { git = "https://github.com/jmagnuson/linemux.git", rev = "acaafc602afac5d7a9cd3e087dafc937cac1e364" }
 local-ip-address = "0.6.2"
-once_cell.workspace = true
 openidconnect = "4.0.1"
 prefixed-api-key = { workspace = true}
 rand = { workspace = true }

--- a/apps/server/src/config/jwt.rs
+++ b/apps/server/src/config/jwt.rs
@@ -1,7 +1,8 @@
+use std::sync::LazyLock;
+
 use chrono::{DateTime, Duration, FixedOffset, Utc};
 use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
 use models::entity::refresh_token;
-use once_cell::sync::Lazy;
 use rand::distr::{Alphanumeric, SampleString};
 use sea_orm::{prelude::*, ActiveValue, IntoActiveModel};
 use serde::{Deserialize, Serialize};
@@ -16,12 +17,12 @@ use crate::{
 ///
 /// Note: _Technically_ it will only be initialized after the first attempt to use it, not
 /// necessarily when the server starts. I don't see an issue with this, but it's worth noting.
-static ACCESS_TOKEN_SECRET: Lazy<String> =
-	Lazy::new(|| Alphanumeric.sample_string(&mut rand::rng(), 60));
+static ACCESS_TOKEN_SECRET: LazyLock<String> =
+	LazyLock::new(|| Alphanumeric.sample_string(&mut rand::rng(), 60));
 
 /// The secret used to sign the refresh tokens, recycles every time the server is restarted*
-static REFRESH_TOKEN_SECRET: Lazy<String> =
-	Lazy::new(|| Alphanumeric.sample_string(&mut rand::rng(), 60));
+static REFRESH_TOKEN_SECRET: LazyLock<String> =
+	LazyLock::new(|| Alphanumeric.sample_string(&mut rand::rng(), 60));
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
Remove the dependency on `once_cell` by replacing its uses with the `std` equivalents