### PR TITLE
✨ Add tag assignment to books management

### DIFF
--- a/crates/graphql/schema.graphql
+++ b/crates/graphql/schema.graphql
@@ -1651,6 +1651,11 @@ type Mutation {
 	"""
 	renameTag(id: Int!, name: String!): Tag!
 	"""
+	Set the tags for a media item. Creates any tags that don't exist yet, links new ones,
+	and unlinks removed ones. Returns the updated media item.
+	"""
+	setMediaTags(id: ID!, tags: [String!]!): Media!
+	"""
 	Delete tags. Returns a list containing the deleted tags, or an error if deletion failed.
 	
 	* `tags` - A non-empty list of tags to delete.

--- a/crates/graphql/schema.graphql
+++ b/crates/graphql/schema.graphql
@@ -1653,7 +1653,7 @@ type Mutation {
 	"""
 	Delete tags. Returns a list containing the deleted tags, or an error if deletion failed.
 	
-	* `tags` - A non-empty list of tags to create.
+	* `tags` - A non-empty list of tags to delete.
 	"""
 	deleteTags(tags: [String!]!): [Tag!]!
 	uploadBooks(input: UploadBooksInput!): Boolean!

--- a/crates/graphql/src/mutation/library.rs
+++ b/crates/graphql/src/mutation/library.rs
@@ -243,56 +243,23 @@ impl LibraryMutation {
 		.await?;
 
 		if let Some(tags) = tags {
-			let existing_tags = tag::Entity::find()
-				.filter(tag::Column::Name.is_in(tags.clone()))
-				.all(&txn)
+			let (to_connect, _) = super::tag::sync_tags(&txn, &tags, &[]).await?;
+
+			if !to_connect.is_empty() {
+				library_tag::Entity::insert_many(
+					to_connect
+						.into_iter()
+						.map(|tag_id| library_tag::ActiveModel {
+							library_id: Set(created_library.id.clone()),
+							tag_id: Set(tag_id),
+							..Default::default()
+						})
+						.collect::<Vec<library_tag::ActiveModel>>(),
+				)
+				.on_conflict_do_nothing()
+				.exec(&txn)
 				.await?;
-
-			tracing::trace!(existing_tags = existing_tags.len(), "Found existing tags");
-
-			let tags_to_create = tags
-				.iter()
-				.filter(|tag| !existing_tags.iter().any(|t| t.name == **tag))
-				.map(|tag| tag::ActiveModel {
-					name: Set(tag.clone()),
-					..Default::default()
-				})
-				.collect::<Vec<_>>();
-
-			tracing::trace!(
-				tags_to_create = tags_to_create.len(),
-				"Found tags to create"
-			);
-
-			let created_tags = if !tags_to_create.is_empty() {
-				tag::Entity::insert_many(tags_to_create)
-					.exec_with_returning_many(&txn)
-					.await?
-			} else {
-				vec![]
-			};
-
-			let to_link = existing_tags
-				.iter()
-				.chain(created_tags.iter())
-				.map(|tag| tag.id)
-				.collect::<Vec<_>>();
-
-			library_tag::Entity::insert_many(
-				to_link
-					.into_iter()
-					.map(|tag_id| library_tag::ActiveModel {
-						library_id: Set(created_library.id.clone()),
-						tag_id: Set(tag_id),
-						..Default::default()
-					})
-					.collect::<Vec<library_tag::ActiveModel>>(),
-			)
-			.on_conflict_do_nothing()
-			.exec(&txn)
-			.await?;
-		} else {
-			tracing::debug!("No tags provided, skipping tag creation");
+			}
 		}
 
 		txn.commit().await?;
@@ -461,92 +428,36 @@ impl LibraryMutation {
 		.update(&txn)
 		.await?;
 
-		match tags {
-			Some(tags) if tags.is_empty() && existing_tags.is_empty() => {
-				tracing::debug!("No change in tags, skipping tag update");
-			},
-			Some(tags) => {
-				let tags_not_in_existing = tags
-					.iter()
-					.filter(|tag| !existing_tags.iter().any(|t| t.name == **tag))
-					.collect::<Vec<_>>();
+		if let Some(tags) = tags {
+			let (to_connect, to_disconnect) =
+				super::tag::sync_tags(&txn, &tags, &existing_tags).await?;
 
-				let tags_to_add_which_already_exist = tag::Entity::find()
-					.filter(tag::Column::Name.is_in(tags_not_in_existing.clone()))
-					.all(&txn)
+			if !to_disconnect.is_empty() {
+				library_tag::Entity::delete_many()
+					.filter(library_tag::Column::TagId.is_in(to_disconnect).and(
+						library_tag::Column::LibraryId.eq(updated_library.id.clone()),
+					))
+					.exec(&txn)
 					.await?;
+			}
 
-				let tags_to_create = tags_not_in_existing
-					.iter()
-					.filter(|tag| {
-						!tags_to_add_which_already_exist
-							.iter()
-							.any(|t| t.name == ***tag)
-					})
-					.map(|tag| tag::ActiveModel {
-						name: Set(tag.to_string()),
-						..Default::default()
-					})
-					.collect::<Vec<_>>();
-
-				tracing::trace!(
-					to_create = tags_to_create.len(),
-					to_link = tags_to_add_which_already_exist.len(),
-					"Creating and linking tags to library",
-				);
-
-				let created_tags = if !tags_to_create.is_empty() {
-					tag::Entity::insert_many(tags_to_create)
-						.exec_with_returning_many(&txn)
-						.await?
-				} else {
-					vec![]
-				};
-
-				let tags_to_connect = tags_to_add_which_already_exist
-					.iter()
-					.chain(created_tags.iter())
-					.map(|tag| tag.id)
-					.collect::<Vec<_>>();
-
-				let tags_to_disconnect = existing_tags
-					.iter()
-					.filter(|tag| !tags.iter().any(|t| t == &tag.name))
-					.map(|tag| tag.id)
-					.collect::<Vec<_>>();
-
-				if !tags_to_disconnect.is_empty() {
-					let affected_rows = library_tag::Entity::delete_many()
-						.filter(library_tag::Column::Id.is_in(tags_to_disconnect).and(
-							library_tag::Column::LibraryId.eq(updated_library.id.clone()),
-						))
-						.exec(&txn)
-						.await?
-						.rows_affected;
-					tracing::debug!(affected_rows, "Deleted tags from library");
-				}
-
-				if !tags_to_connect.is_empty() {
-					let library_id = updated_library.id.clone();
-					let to_link = tags_to_connect
+			if !to_connect.is_empty() {
+				let library_id = updated_library.id.clone();
+				library_tag::Entity::insert_many(
+					to_connect
 						.into_iter()
 						.map(|tag_id| library_tag::ActiveModel {
 							library_id: Set(library_id.clone()),
 							tag_id: Set(tag_id),
 							..Default::default()
 						})
-						.collect::<Vec<library_tag::ActiveModel>>();
-
-					library_tag::Entity::insert_many(to_link)
-						.on_conflict_do_nothing()
-						.exec(&txn)
-						.await?;
-				}
-			},
-			_ => {
-				tracing::warn!("No tags provided, skipping tag update");
-			},
-		};
+						.collect::<Vec<library_tag::ActiveModel>>(),
+				)
+				.on_conflict_do_nothing()
+				.exec(&txn)
+				.await?;
+			}
+		}
 
 		txn.commit().await?;
 

--- a/crates/graphql/src/mutation/tag.rs
+++ b/crates/graphql/src/mutation/tag.rs
@@ -1,9 +1,16 @@
-use crate::{data::CoreContext, guard::PermissionGuard, object::tag::Tag};
-use async_graphql::{Context, Object, Result};
-use models::{entity::tag, shared::enums::UserPermission};
+use crate::{
+	data::{AuthContext, CoreContext},
+	guard::PermissionGuard,
+	object::{media::Media, tag::Tag},
+};
+use async_graphql::{Context, Object, Result, ID};
+use models::{
+	entity::{media, media_tag, tag},
+	shared::enums::UserPermission,
+};
 use sea_orm::{
-	prelude::*, ActiveValue::Set, DatabaseConnection, DatabaseTransaction,
-	IntoActiveModel, QuerySelect, TransactionTrait,
+	prelude::*, sea_query::Query, ActiveValue::Set, DatabaseConnection,
+	DatabaseTransaction, IntoActiveModel, QuerySelect, TransactionTrait,
 };
 use std::collections::HashSet;
 
@@ -33,6 +40,75 @@ impl TagMutation {
 	async fn rename_tag(&self, ctx: &Context<'_>, id: i32, name: String) -> Result<Tag> {
 		let conn = ctx.data::<CoreContext>()?.conn.as_ref();
 		rename_tag(conn, id, name).await
+	}
+
+	/// Set the tags for a media item. Creates any tags that don't exist yet, links new ones,
+	/// and unlinks removed ones. Returns the updated media item.
+	#[graphql(guard = "PermissionGuard::one(UserPermission::EditMetadata)")]
+	async fn set_media_tags(
+		&self,
+		ctx: &Context<'_>,
+		id: ID,
+		tags: Vec<String>,
+	) -> Result<Media> {
+		let AuthContext { user, .. } = ctx.data::<AuthContext>()?;
+		let conn = ctx.data::<CoreContext>()?.conn.as_ref();
+
+		let model = media::ModelWithMetadata::find_for_user(user)
+			.filter(media::Column::Id.eq(id.to_string()))
+			.into_model::<media::ModelWithMetadata>()
+			.one(conn)
+			.await?
+			.ok_or("Media not found")?;
+
+		let existing_tags = tag::Entity::find()
+			.filter(
+				tag::Column::Id.in_subquery(
+					Query::select()
+						.column(media_tag::Column::TagId)
+						.from(media_tag::Entity)
+						.and_where(media_tag::Column::MediaId.eq(model.media.id.clone()))
+						.to_owned(),
+				),
+			)
+			.all(conn)
+			.await?;
+
+		let txn = conn.begin().await?;
+
+		let (to_connect, to_disconnect) = sync_tags(&txn, &tags, &existing_tags).await?;
+
+		if !to_disconnect.is_empty() {
+			media_tag::Entity::delete_many()
+				.filter(
+					media_tag::Column::TagId
+						.is_in(to_disconnect)
+						.and(media_tag::Column::MediaId.eq(model.media.id.clone())),
+				)
+				.exec(&txn)
+				.await?;
+		}
+
+		if !to_connect.is_empty() {
+			let media_id = model.media.id.clone();
+			media_tag::Entity::insert_many(
+				to_connect
+					.into_iter()
+					.map(|tag_id| media_tag::ActiveModel {
+						media_id: Set(media_id.clone()),
+						tag_id: Set(tag_id),
+						..Default::default()
+					})
+					.collect::<Vec<_>>(),
+			)
+			.on_conflict_do_nothing()
+			.exec(&txn)
+			.await?;
+		}
+
+		txn.commit().await?;
+
+		Ok(model.into())
 	}
 
 	/// Delete tags. Returns a list containing the deleted tags, or an error if deletion failed.
@@ -113,6 +189,65 @@ async fn create_tags(conn: &DatabaseConnection, tags: Vec<String>) -> Result<Vec
 	txn.commit().await?;
 
 	Ok(inserted_tags.into_iter().map(Tag::from).collect())
+}
+
+/// Given desired tag names and the tags currently linked to an entity, resolves which tags
+/// need to be created, connected, and disconnected. Returns `(tag_ids_to_connect, tag_ids_to_disconnect)`.
+///
+/// Tags in `desired` that don't exist in the database are created. Tags currently linked but
+/// not in `desired` are marked for disconnection.
+pub(crate) async fn sync_tags(
+	txn: &DatabaseTransaction,
+	desired: &[String],
+	existing_linked: &[tag::Model],
+) -> Result<(Vec<i32>, Vec<i32>)> {
+	// Tags in desired that are NOT currently linked to this entity
+	let tags_not_linked = desired
+		.iter()
+		.filter(|name| !existing_linked.iter().any(|t| t.name == **name))
+		.collect::<Vec<_>>();
+
+	// Of those, which already exist in the tags table (but aren't linked to this entity)?
+	let tags_existing_but_not_linked = tag::Entity::find()
+		.filter(tag::Column::Name.is_in(tags_not_linked.clone()))
+		.all(txn)
+		.await?;
+
+	// The rest need to be created
+	let tags_to_create = tags_not_linked
+		.iter()
+		.filter(|name| {
+			!tags_existing_but_not_linked
+				.iter()
+				.any(|t| t.name == ***name)
+		})
+		.map(|name| tag::ActiveModel {
+			name: Set(name.to_string()),
+			..Default::default()
+		})
+		.collect::<Vec<_>>();
+
+	let created_tags = if !tags_to_create.is_empty() {
+		tag::Entity::insert_many(tags_to_create)
+			.exec_with_returning_many(txn)
+			.await?
+	} else {
+		vec![]
+	};
+
+	let to_connect = tags_existing_but_not_linked
+		.iter()
+		.chain(created_tags.iter())
+		.map(|tag| tag.id)
+		.collect::<Vec<_>>();
+
+	let to_disconnect = existing_linked
+		.iter()
+		.filter(|tag| !desired.iter().any(|name| name == &tag.name))
+		.map(|tag| tag.id)
+		.collect::<Vec<_>>();
+
+	Ok((to_connect, to_disconnect))
 }
 
 async fn rename_tag(conn: &DatabaseConnection, id: i32, name: String) -> Result<Tag> {
@@ -323,5 +458,124 @@ mod tests {
 
 		let result = rename_tag(&conn, 999, "new_name".to_string()).await;
 		assert!(result.is_err());
+	}
+
+	#[tokio::test]
+	async fn test_sync_tags_all_new() {
+		let created = vec![
+			tag::Model {
+				id: 1,
+				name: "a".to_string(),
+			},
+			tag::Model {
+				id: 2,
+				name: "b".to_string(),
+			},
+		];
+
+		// Query 1: find existing tags by name (not linked) -> none exist in DB
+		// Query 2: insert_many returns created tags
+		let mock_db = MockDatabase::new(sea_orm::DatabaseBackend::Sqlite)
+			.append_query_results::<tag::Model, Vec<_>, Vec<Vec<_>>>(vec![
+				vec![],
+				created.clone(),
+			])
+			.append_exec_results(vec![MockExecResult {
+				last_insert_id: 1,
+				rows_affected: 2,
+			}])
+			.into_connection();
+		let txn = mock_db.begin().await.unwrap();
+
+		let desired = vec!["a".to_string(), "b".to_string()];
+		let existing_linked: Vec<tag::Model> = vec![];
+
+		let (mut to_connect, to_disconnect) =
+			sync_tags(&txn, &desired, &existing_linked).await.unwrap();
+		to_connect.sort();
+		assert_eq!(to_connect, vec![1, 2]);
+		assert!(to_disconnect.is_empty());
+	}
+
+	#[tokio::test]
+	async fn test_sync_tags_add_and_keep() {
+		let existing_linked = vec![tag::Model {
+			id: 1,
+			name: "keep".to_string(),
+		}];
+		let existing_in_db = vec![tag::Model {
+			id: 2,
+			name: "add".to_string(),
+		}];
+
+		// Query 1: find tags by name not linked -> "add" exists in DB
+		let mock_db = MockDatabase::new(sea_orm::DatabaseBackend::Sqlite)
+			.append_query_results::<tag::Model, Vec<_>, Vec<Vec<_>>>(vec![
+				existing_in_db.clone()
+			])
+			.into_connection();
+		let txn = mock_db.begin().await.unwrap();
+
+		let desired = vec!["keep".to_string(), "add".to_string()];
+
+		let (to_connect, to_disconnect) =
+			sync_tags(&txn, &desired, &existing_linked).await.unwrap();
+		assert_eq!(to_connect, vec![2]);
+		assert!(to_disconnect.is_empty());
+	}
+
+	#[tokio::test]
+	async fn test_sync_tags_remove() {
+		let existing_linked = vec![
+			tag::Model {
+				id: 1,
+				name: "keep".to_string(),
+			},
+			tag::Model {
+				id: 2,
+				name: "remove".to_string(),
+			},
+		];
+
+		// Query 1: find tags by name not linked -> empty (no new tags to look up)
+		let mock_db = MockDatabase::new(sea_orm::DatabaseBackend::Sqlite)
+			.append_query_results::<tag::Model, Vec<_>, Vec<Vec<_>>>(vec![vec![]])
+			.into_connection();
+		let txn = mock_db.begin().await.unwrap();
+
+		let desired = vec!["keep".to_string()];
+
+		let (to_connect, to_disconnect) =
+			sync_tags(&txn, &desired, &existing_linked).await.unwrap();
+		assert!(to_connect.is_empty());
+		assert_eq!(to_disconnect, vec![2]);
+	}
+
+	#[tokio::test]
+	async fn test_sync_tags_empty_desired() {
+		let existing_linked = vec![
+			tag::Model {
+				id: 1,
+				name: "a".to_string(),
+			},
+			tag::Model {
+				id: 2,
+				name: "b".to_string(),
+			},
+		];
+
+		// Query 1: find tags by name not linked -> empty (nothing desired)
+		let mock_db = MockDatabase::new(sea_orm::DatabaseBackend::Sqlite)
+			.append_query_results::<tag::Model, Vec<_>, Vec<Vec<_>>>(vec![vec![]])
+			.into_connection();
+		let txn = mock_db.begin().await.unwrap();
+
+		let desired: Vec<String> = vec![];
+
+		let (to_connect, mut to_disconnect) =
+			sync_tags(&txn, &desired, &existing_linked).await.unwrap();
+		to_disconnect.sort();
+		assert!(to_connect.is_empty());
+		assert_eq!(to_disconnect, vec![1, 2]);
 	}
 }

--- a/crates/graphql/src/mutation/tag.rs
+++ b/crates/graphql/src/mutation/tag.rs
@@ -1,6 +1,6 @@
-use crate::{data::CoreContext, object::tag::Tag};
+use crate::{data::CoreContext, guard::PermissionGuard, object::tag::Tag};
 use async_graphql::{Context, Object, Result};
-use models::entity::tag;
+use models::{entity::tag, shared::enums::UserPermission};
 use sea_orm::{
 	prelude::*, ActiveValue::Set, DatabaseConnection, DatabaseTransaction,
 	IntoActiveModel, QuerySelect, TransactionTrait,
@@ -17,6 +17,7 @@ impl TagMutation {
 	/// If any of the tags already exist an error is returned.
 	///
 	/// * `tags` - A non-empty list of tags to create.
+	#[graphql(guard = "PermissionGuard::one(UserPermission::ManageLibrary)")]
 	async fn create_tags(
 		&self,
 		ctx: &Context<'_>,
@@ -28,6 +29,7 @@ impl TagMutation {
 
 	/// Rename a tag. Returns the updated tag, or an error if the tag was not found or the new
 	/// name already exists.
+	#[graphql(guard = "PermissionGuard::one(UserPermission::ManageLibrary)")]
 	async fn rename_tag(&self, ctx: &Context<'_>, id: i32, name: String) -> Result<Tag> {
 		let conn = ctx.data::<CoreContext>()?.conn.as_ref();
 		rename_tag(conn, id, name).await
@@ -35,7 +37,8 @@ impl TagMutation {
 
 	/// Delete tags. Returns a list containing the deleted tags, or an error if deletion failed.
 	///
-	/// * `tags` - A non-empty list of tags to create.
+	/// * `tags` - A non-empty list of tags to delete.
+	#[graphql(guard = "PermissionGuard::one(UserPermission::ManageLibrary)")]
 	async fn delete_tags(
 		&self,
 		ctx: &Context<'_>,

--- a/packages/browser/src/components/TagSelect.tsx
+++ b/packages/browser/src/components/TagSelect.tsx
@@ -74,7 +74,7 @@ export default function TagSelect({ label, description, selected = [], onChange 
 
 	return (
 		<ComboBox
-			label={label || 'Tags'}
+			label={label ?? 'Tags'}
 			description={description}
 			options={options}
 			value={[...selected].sort((a, b) => a.label.localeCompare(b.label)).map(({ value }) => value)}

--- a/packages/browser/src/components/tags/Tag.tsx
+++ b/packages/browser/src/components/tags/Tag.tsx
@@ -1,4 +1,4 @@
-import { Link, Text } from '@stump/components'
+import { Badge, Link } from '@stump/components'
 import { Tag } from '@stump/graphql'
 import { Fragment } from 'react'
 
@@ -7,16 +7,20 @@ type Props = {
 	href?: string
 }
 
-// TODO: more styling
 export default function TagComponent({ tag, href }: Props) {
 	const Container = href ? Link : Fragment
 	const containerProps = href ? { href, underline: false } : {}
 
 	return (
 		<Container {...containerProps}>
-			<Text variant="muted" size="xs">
-				#{tag.name}
-			</Text>
+			<Badge
+				variant="secondary"
+				size="xs"
+				rounded="full"
+				className={href ? 'cursor-pointer' : undefined}
+			>
+				{tag.name}
+			</Badge>
 		</Container>
 	)
 }

--- a/packages/browser/src/components/tags/TagList.tsx
+++ b/packages/browser/src/components/tags/TagList.tsx
@@ -1,25 +1,8 @@
 import { Tag } from '@stump/graphql'
 
-import TagComponent from './Tag'
+import BadgeList from '@/components/BadgeList'
 
-export const DEBUG_TAGS: Tag[] = [
-	{
-		id: 1,
-		name: 'Action',
-	},
-	{
-		id: 2,
-		name: 'Adventure',
-	},
-	{
-		id: 3,
-		name: 'Comedy',
-	},
-	{
-		id: 4,
-		name: 'Drama',
-	},
-]
+import TagComponent from './Tag'
 
 type Props = {
 	tags: Tag[] | null
@@ -27,13 +10,13 @@ type Props = {
 }
 
 export default function TagList({ tags, baseUrl }: Props) {
-	if (!tags && !import.meta.env.DEV) {
+	if (!tags?.length) {
 		return null
 	}
 
 	return (
-		<div className="space-x-2 flex flex-row">
-			{(tags ?? DEBUG_TAGS)
+		<BadgeList>
+			{tags
 				.filter((tag) => !!tag.name)
 				.map((tag) => (
 					<TagComponent
@@ -42,6 +25,6 @@ export default function TagList({ tags, baseUrl }: Props) {
 						{...(baseUrl ? { href: `${baseUrl}?tags[]=${tag.name}` } : {})}
 					/>
 				))}
-		</div>
+		</BadgeList>
 	)
 }

--- a/packages/browser/src/scenes/book/BookRouter.tsx
+++ b/packages/browser/src/scenes/book/BookRouter.tsx
@@ -21,7 +21,11 @@ export default function BookRouter() {
 					path=":id/manage"
 					element={
 						<UserPermissionRouteGuard
-							permissions={[UserPermission.ManageLibrary, UserPermission.EditThumbnails]}
+							permissions={[
+								UserPermission.ManageLibrary,
+								UserPermission.EditThumbnails,
+								UserPermission.EditMetadata,
+							]}
 							enforceAll={false}
 						/>
 					}

--- a/packages/browser/src/scenes/book/settings/BookManagementScene.tsx
+++ b/packages/browser/src/scenes/book/settings/BookManagementScene.tsx
@@ -2,13 +2,14 @@ import { useGraphQLMutation, useSDK, useSuspenseGraphQL } from '@stump/client'
 import { Alert, AlertDescription, Breadcrumbs, Button, Heading, Text } from '@stump/components'
 import { graphql, UserPermission } from '@stump/graphql'
 import { Construction } from 'lucide-react'
-import { useCallback, useEffect, useMemo } from 'react'
+import { Suspense, useCallback, useEffect, useMemo } from 'react'
 import { useNavigate, useParams } from 'react-router'
 
 import { SceneContainer } from '@/components/container'
 import { useAppContext } from '@/context'
 import paths from '@/paths'
 
+import BookTagEditor from './BookTagEditor'
 import BookThumbnailSelector from './BookThumbnailSelector'
 
 const query = graphql(`
@@ -23,6 +24,10 @@ const query = graphql(`
 			series {
 				id
 				resolvedName
+			}
+			tags {
+				id
+				name
 			}
 			...BookThumbnailSelector
 		}
@@ -107,21 +112,45 @@ export default function BookManagementScene() {
 				</Alert>
 
 				{checkPermission(UserPermission.ManageLibrary) && (
-					<div>
-						<Button
-							title={data ? 'Analysis already in progress' : 'Analyze this book'}
-							size="md"
-							variant="primary"
-							onClick={handleAnalyze}
-							disabled={!!data || isPending}
-						>
-							Analyze Media
-						</Button>
+					<div className="flex flex-col gap-y-2">
+						<div>
+							<Heading size="sm">Analysis</Heading>
+							<Text size="sm" variant="muted">
+								Re-analyze this book to update metadata from its file
+							</Text>
+						</div>
+
+						<div>
+							<Button
+								title={data ? 'Analysis already in progress' : 'Analyze this book'}
+								size="md"
+								variant="primary"
+								onClick={handleAnalyze}
+								disabled={!!data || isPending}
+							>
+								Analyze Media
+							</Button>
+						</div>
 					</div>
 				)}
 
+				{checkPermission(UserPermission.EditMetadata) && (
+					<Suspense>
+						<BookTagEditor mediaId={book.id} tags={book.tags} />
+					</Suspense>
+				)}
+
 				{checkPermission(UserPermission.EditThumbnails) && (
-					<BookThumbnailSelector fragment={book} />
+					<div className="flex flex-col gap-y-2">
+						<div>
+							<Heading size="sm">Thumbnail</Heading>
+							<Text size="sm" variant="muted">
+								Change the cover image for this book
+							</Text>
+						</div>
+
+						<BookThumbnailSelector fragment={book} />
+					</div>
 				)}
 			</div>
 		</SceneContainer>

--- a/packages/browser/src/scenes/book/settings/BookManagementScene.tsx
+++ b/packages/browser/src/scenes/book/settings/BookManagementScene.tsx
@@ -112,7 +112,7 @@ export default function BookManagementScene() {
 				</Alert>
 
 				{checkPermission(UserPermission.ManageLibrary) && (
-					<div className="flex flex-col gap-y-2">
+					<div className="gap-y-2 flex flex-col">
 						<div>
 							<Heading size="sm">Analysis</Heading>
 							<Text size="sm" variant="muted">
@@ -141,7 +141,7 @@ export default function BookManagementScene() {
 				)}
 
 				{checkPermission(UserPermission.EditThumbnails) && (
-					<div className="flex flex-col gap-y-2">
+					<div className="gap-y-2 flex flex-col">
 						<div>
 							<Heading size="sm">Thumbnail</Heading>
 							<Text size="sm" variant="muted">

--- a/packages/browser/src/scenes/book/settings/BookTagEditor.tsx
+++ b/packages/browser/src/scenes/book/settings/BookTagEditor.tsx
@@ -1,0 +1,76 @@
+import { useGraphQLMutation, useSDK } from '@stump/client'
+import { Heading, Text } from '@stump/components'
+import { graphql, Tag } from '@stump/graphql'
+import { useQueryClient } from '@tanstack/react-query'
+import { useCallback } from 'react'
+import { toast } from 'sonner'
+
+import TagSelect, { TagOption } from '@/components/TagSelect'
+
+const mutation = graphql(`
+	mutation BookTagEditorSetTags($id: ID!, $tags: [String!]!) {
+		setMediaTags(id: $id, tags: $tags) {
+			id
+			tags {
+				id
+				name
+			}
+		}
+	}
+`)
+
+type Props = {
+	mediaId: string
+	tags: Tag[]
+}
+
+export default function BookTagEditor({ mediaId, tags }: Props) {
+	const { sdk } = useSDK()
+	const client = useQueryClient()
+
+	const { mutate: setMediaTags } = useGraphQLMutation(mutation, {
+		onSuccess: () => {
+			client.refetchQueries({
+				exact: false,
+				predicate: ({ queryKey }) =>
+					queryKey.includes(sdk.cacheKeys.bookOverview) ||
+					queryKey.includes(sdk.cacheKeys.mediaById) ||
+					queryKey.includes(sdk.cacheKeys.tags),
+			})
+		},
+		onError: (error) => {
+			console.error('Failed to update tags', error)
+			toast.error(String(error))
+		},
+	})
+
+	const selected: TagOption[] = tags.map((tag) => ({
+		label: tag.name,
+		value: tag.name.toLowerCase(),
+	}))
+
+	const handleChange = useCallback(
+		(newSelected?: TagOption[]) => {
+			setMediaTags({
+				id: mediaId,
+				tags: (newSelected ?? []).map((t) => t.label),
+			})
+		},
+		[mediaId, setMediaTags],
+	)
+
+	return (
+		<div className="flex flex-col gap-y-2">
+			<div>
+				<Heading size="sm">Tags</Heading>
+				<Text size="sm" variant="muted">
+					Assign tags to this book
+				</Text>
+			</div>
+
+			<div className="max-w-sm">
+				<TagSelect label="" selected={selected} onChange={handleChange} />
+			</div>
+		</div>
+	)
+}

--- a/packages/browser/src/scenes/book/settings/BookTagEditor.tsx
+++ b/packages/browser/src/scenes/book/settings/BookTagEditor.tsx
@@ -60,7 +60,7 @@ export default function BookTagEditor({ mediaId, tags }: Props) {
 	)
 
 	return (
-		<div className="flex flex-col gap-y-2">
+		<div className="gap-y-2 flex flex-col">
 			<div>
 				<Heading size="sm">Tags</Heading>
 				<Text size="sm" variant="muted">

--- a/packages/graphql/src/client/gql.ts
+++ b/packages/graphql/src/client/gql.ts
@@ -164,8 +164,9 @@ type Documents = {
     "\n\tmutation SendEmailAttachment($id: ID!, $sendTo: [EmailerSendTo!]!) {\n\t\tsendAttachmentEmail(input: { mediaIds: [$id], sendTo: $sendTo }) {\n\t\t\tsentCount\n\t\t\terrors\n\t\t}\n\t}\n": typeof types.SendEmailAttachmentDocument,
     "\n\tquery BookReaderScene($id: ID!) {\n\t\tmediaById(id: $id) {\n\t\t\tid\n\t\t\tresolvedName\n\t\t\tpages\n\t\t\textension\n\t\t\treadProgress {\n\t\t\t\tpercentageCompleted\n\t\t\t\tepubcfi\n\t\t\t\tpage\n\t\t\t\telapsedSeconds\n\t\t\t}\n\t\t\tlibraryConfig {\n\t\t\t\tdefaultReadingImageScaleFit\n\t\t\t\tdefaultReadingMode\n\t\t\t\tdefaultReadingDir\n\t\t\t}\n\t\t\tanalysisData {\n\t\t\t\tdimensions {\n\t\t\t\t\theight\n\t\t\t\t\twidth\n\t\t\t\t}\n\t\t\t}\n\t\t\tnextInSeries(pagination: { cursor: { limit: 1 } }) {\n\t\t\t\tnodes {\n\t\t\t\t\tid\n\t\t\t\t\tname: resolvedName\n\t\t\t\t\tthumbnail {\n\t\t\t\t\t\turl\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n": typeof types.BookReaderSceneDocument,
     "\n\tmutation UpdateReadProgress($id: ID!, $input: MediaProgressInput!) {\n\t\tupdateMediaProgress(id: $id, input: $input) {\n\t\t\t__typename\n\t\t}\n\t}\n": typeof types.UpdateReadProgressDocument,
-    "\n\tquery BookManagementScene($id: ID!) {\n\t\tmediaById(id: $id) {\n\t\t\tid\n\t\t\tresolvedName\n\t\t\tlibrary {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t}\n\t\t\tseries {\n\t\t\t\tid\n\t\t\t\tresolvedName\n\t\t\t}\n\t\t\t...BookThumbnailSelector\n\t\t}\n\t}\n": typeof types.BookManagementSceneDocument,
+    "\n\tquery BookManagementScene($id: ID!) {\n\t\tmediaById(id: $id) {\n\t\t\tid\n\t\t\tresolvedName\n\t\t\tlibrary {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t}\n\t\t\tseries {\n\t\t\t\tid\n\t\t\t\tresolvedName\n\t\t\t}\n\t\t\ttags {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t}\n\t\t\t...BookThumbnailSelector\n\t\t}\n\t}\n": typeof types.BookManagementSceneDocument,
     "\n\tmutation BookManagementSceneAnalyze($id: ID!) {\n\t\tanalyzeMedia(id: $id)\n\t}\n": typeof types.BookManagementSceneAnalyzeDocument,
+    "\n\tmutation BookTagEditorSetTags($id: ID!, $tags: [String!]!) {\n\t\tsetMediaTags(id: $id, tags: $tags) {\n\t\t\tid\n\t\t\ttags {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t}\n\t\t}\n\t}\n": typeof types.BookTagEditorSetTagsDocument,
     "\n\tfragment BookThumbnailSelector on Media {\n\t\tid\n\t\tthumbnail {\n\t\t\turl\n\t\t}\n\t\tpages\n\t}\n": typeof types.BookThumbnailSelectorFragmentDoc,
     "\n\tmutation BookThumbnailSelectorUpdate($id: ID!, $input: PageBasedThumbnailInput!) {\n\t\tupdateMediaThumbnail(id: $id, input: $input) {\n\t\t\tid\n\t\t\tthumbnail {\n\t\t\t\turl\n\t\t\t}\n\t\t}\n\t}\n": typeof types.BookThumbnailSelectorUpdateDocument,
     "\n\tmutation BookThumbnailSelectorUpload($id: ID!, $file: Upload!) {\n\t\tuploadMediaThumbnail(id: $id, file: $file) {\n\t\t\tid\n\t\t\tthumbnail {\n\t\t\t\turl\n\t\t\t}\n\t\t}\n\t}\n": typeof types.BookThumbnailSelectorUploadDocument,
@@ -445,8 +446,9 @@ const documents: Documents = {
     "\n\tmutation SendEmailAttachment($id: ID!, $sendTo: [EmailerSendTo!]!) {\n\t\tsendAttachmentEmail(input: { mediaIds: [$id], sendTo: $sendTo }) {\n\t\t\tsentCount\n\t\t\terrors\n\t\t}\n\t}\n": types.SendEmailAttachmentDocument,
     "\n\tquery BookReaderScene($id: ID!) {\n\t\tmediaById(id: $id) {\n\t\t\tid\n\t\t\tresolvedName\n\t\t\tpages\n\t\t\textension\n\t\t\treadProgress {\n\t\t\t\tpercentageCompleted\n\t\t\t\tepubcfi\n\t\t\t\tpage\n\t\t\t\telapsedSeconds\n\t\t\t}\n\t\t\tlibraryConfig {\n\t\t\t\tdefaultReadingImageScaleFit\n\t\t\t\tdefaultReadingMode\n\t\t\t\tdefaultReadingDir\n\t\t\t}\n\t\t\tanalysisData {\n\t\t\t\tdimensions {\n\t\t\t\t\theight\n\t\t\t\t\twidth\n\t\t\t\t}\n\t\t\t}\n\t\t\tnextInSeries(pagination: { cursor: { limit: 1 } }) {\n\t\t\t\tnodes {\n\t\t\t\t\tid\n\t\t\t\t\tname: resolvedName\n\t\t\t\t\tthumbnail {\n\t\t\t\t\t\turl\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n": types.BookReaderSceneDocument,
     "\n\tmutation UpdateReadProgress($id: ID!, $input: MediaProgressInput!) {\n\t\tupdateMediaProgress(id: $id, input: $input) {\n\t\t\t__typename\n\t\t}\n\t}\n": types.UpdateReadProgressDocument,
-    "\n\tquery BookManagementScene($id: ID!) {\n\t\tmediaById(id: $id) {\n\t\t\tid\n\t\t\tresolvedName\n\t\t\tlibrary {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t}\n\t\t\tseries {\n\t\t\t\tid\n\t\t\t\tresolvedName\n\t\t\t}\n\t\t\t...BookThumbnailSelector\n\t\t}\n\t}\n": types.BookManagementSceneDocument,
+    "\n\tquery BookManagementScene($id: ID!) {\n\t\tmediaById(id: $id) {\n\t\t\tid\n\t\t\tresolvedName\n\t\t\tlibrary {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t}\n\t\t\tseries {\n\t\t\t\tid\n\t\t\t\tresolvedName\n\t\t\t}\n\t\t\ttags {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t}\n\t\t\t...BookThumbnailSelector\n\t\t}\n\t}\n": types.BookManagementSceneDocument,
     "\n\tmutation BookManagementSceneAnalyze($id: ID!) {\n\t\tanalyzeMedia(id: $id)\n\t}\n": types.BookManagementSceneAnalyzeDocument,
+    "\n\tmutation BookTagEditorSetTags($id: ID!, $tags: [String!]!) {\n\t\tsetMediaTags(id: $id, tags: $tags) {\n\t\t\tid\n\t\t\ttags {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t}\n\t\t}\n\t}\n": types.BookTagEditorSetTagsDocument,
     "\n\tfragment BookThumbnailSelector on Media {\n\t\tid\n\t\tthumbnail {\n\t\t\turl\n\t\t}\n\t\tpages\n\t}\n": types.BookThumbnailSelectorFragmentDoc,
     "\n\tmutation BookThumbnailSelectorUpdate($id: ID!, $input: PageBasedThumbnailInput!) {\n\t\tupdateMediaThumbnail(id: $id, input: $input) {\n\t\t\tid\n\t\t\tthumbnail {\n\t\t\t\turl\n\t\t\t}\n\t\t}\n\t}\n": types.BookThumbnailSelectorUpdateDocument,
     "\n\tmutation BookThumbnailSelectorUpload($id: ID!, $file: Upload!) {\n\t\tuploadMediaThumbnail(id: $id, file: $file) {\n\t\t\tid\n\t\t\tthumbnail {\n\t\t\t\turl\n\t\t\t}\n\t\t}\n\t}\n": types.BookThumbnailSelectorUploadDocument,
@@ -1176,11 +1178,15 @@ export function graphql(source: "\n\tmutation UpdateReadProgress($id: ID!, $inpu
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
-export function graphql(source: "\n\tquery BookManagementScene($id: ID!) {\n\t\tmediaById(id: $id) {\n\t\t\tid\n\t\t\tresolvedName\n\t\t\tlibrary {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t}\n\t\t\tseries {\n\t\t\t\tid\n\t\t\t\tresolvedName\n\t\t\t}\n\t\t\t...BookThumbnailSelector\n\t\t}\n\t}\n"): typeof import('./graphql').BookManagementSceneDocument;
+export function graphql(source: "\n\tquery BookManagementScene($id: ID!) {\n\t\tmediaById(id: $id) {\n\t\t\tid\n\t\t\tresolvedName\n\t\t\tlibrary {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t}\n\t\t\tseries {\n\t\t\t\tid\n\t\t\t\tresolvedName\n\t\t\t}\n\t\t\ttags {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t}\n\t\t\t...BookThumbnailSelector\n\t\t}\n\t}\n"): typeof import('./graphql').BookManagementSceneDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(source: "\n\tmutation BookManagementSceneAnalyze($id: ID!) {\n\t\tanalyzeMedia(id: $id)\n\t}\n"): typeof import('./graphql').BookManagementSceneAnalyzeDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n\tmutation BookTagEditorSetTags($id: ID!, $tags: [String!]!) {\n\t\tsetMediaTags(id: $id, tags: $tags) {\n\t\t\tid\n\t\t\ttags {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t}\n\t\t}\n\t}\n"): typeof import('./graphql').BookTagEditorSetTagsDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/graphql/src/client/graphql.ts
+++ b/packages/graphql/src/client/graphql.ts
@@ -1695,7 +1695,7 @@ export type Mutation = {
   /**
    * Delete tags. Returns a list containing the deleted tags, or an error if deletion failed.
    *
-   * * `tags` - A non-empty list of tags to create.
+   * * `tags` - A non-empty list of tags to delete.
    */
   deleteTags: Array<Tag>;
   deleteUser: User;

--- a/packages/graphql/src/client/graphql.ts
+++ b/packages/graphql/src/client/graphql.ts
@@ -1742,6 +1742,11 @@ export type Mutation = {
   sendAttachmentEmail: SendAttachmentEmailOutput;
   /** Send a message in a discussion */
   sendMessage: BookClubDiscussionMessage;
+  /**
+   * Set the tags for a media item. Creates any tags that don't exist yet, links new ones,
+   * and unlinks removed ones. Returns the updated media item.
+   */
+  setMediaTags: Media;
   /** Suggest a book for the book club */
   suggestBook: BookClubBookSuggestion;
   /** Send a test email to verify the SMTP configuration is working */
@@ -2260,6 +2265,12 @@ export type MutationSendAttachmentEmailArgs = {
 export type MutationSendMessageArgs = {
   discussionId: Scalars['ID']['input'];
   input: SendMessageInput;
+};
+
+
+export type MutationSetMediaTagsArgs = {
+  id: Scalars['ID']['input'];
+  tags: Array<Scalars['String']['input']>;
 };
 
 
@@ -5149,7 +5160,7 @@ export type BookManagementSceneQueryVariables = Exact<{
 
 
 export type BookManagementSceneQuery = { __typename?: 'Query', mediaById?: (
-    { __typename?: 'Media', id: string, resolvedName: string, library: { __typename?: 'Library', id: string, name: string }, series: { __typename?: 'Series', id: string, resolvedName: string } }
+    { __typename?: 'Media', id: string, resolvedName: string, library: { __typename?: 'Library', id: string, name: string }, series: { __typename?: 'Series', id: string, resolvedName: string }, tags: Array<{ __typename?: 'Tag', id: number, name: string }> }
     & { ' $fragmentRefs'?: { 'BookThumbnailSelectorFragment': BookThumbnailSelectorFragment } }
   ) | null };
 
@@ -5159,6 +5170,14 @@ export type BookManagementSceneAnalyzeMutationVariables = Exact<{
 
 
 export type BookManagementSceneAnalyzeMutation = { __typename?: 'Mutation', analyzeMedia: boolean };
+
+export type BookTagEditorSetTagsMutationVariables = Exact<{
+  id: Scalars['ID']['input'];
+  tags: Array<Scalars['String']['input']> | Scalars['String']['input'];
+}>;
+
+
+export type BookTagEditorSetTagsMutation = { __typename?: 'Mutation', setMediaTags: { __typename?: 'Media', id: string, tags: Array<{ __typename?: 'Tag', id: number, name: string }> } };
 
 export type BookThumbnailSelectorFragment = { __typename?: 'Media', id: string, pages: number, thumbnail: { __typename?: 'ImageRef', url: string } } & { ' $fragmentName'?: 'BookThumbnailSelectorFragment' };
 
@@ -9690,6 +9709,10 @@ export const BookManagementSceneDocument = new TypedDocumentString(`
       id
       resolvedName
     }
+    tags {
+      id
+      name
+    }
     ...BookThumbnailSelector
   }
 }
@@ -9705,6 +9728,17 @@ export const BookManagementSceneAnalyzeDocument = new TypedDocumentString(`
   analyzeMedia(id: $id)
 }
     `) as unknown as TypedDocumentString<BookManagementSceneAnalyzeMutation, BookManagementSceneAnalyzeMutationVariables>;
+export const BookTagEditorSetTagsDocument = new TypedDocumentString(`
+    mutation BookTagEditorSetTags($id: ID!, $tags: [String!]!) {
+  setMediaTags(id: $id, tags: $tags) {
+    id
+    tags {
+      id
+      name
+    }
+  }
+}
+    `) as unknown as TypedDocumentString<BookTagEditorSetTagsMutation, BookTagEditorSetTagsMutationVariables>;
 export const BookThumbnailSelectorUpdateDocument = new TypedDocumentString(`
     mutation BookThumbnailSelectorUpdate($id: ID!, $input: PageBasedThumbnailInput!) {
   updateMediaThumbnail(id: $id, input: $input) {


### PR DESCRIPTION
## Summary

 - Add a way to assign tags to a book through its management page
 - Redesign the way tags are displayed in the book details page, re-using the badge component
 - Refactor the library tag logic to use a more generic helper added for books

## Screenshots

<img width="1316" height="1252" alt="image" src="https://github.com/user-attachments/assets/377fe0ca-059f-44c6-856d-c4be44301a3a" />
<img width="1686" height="757" alt="image" src="https://github.com/user-attachments/assets/fdec077a-f5df-4d74-8165-217241604b0e" />

## What's next

Before calling #151 done, I'd like to add a way to create a tag inline from `TagSelect`, and handle tags on a series-level (most mutations/logic are already in place now, it's mostly the UI). Is there anything else I should consider on tags?