### PR TITLE
✨ Add type-to-confirm dialog for library deletion

### DIFF
--- a/packages/browser/src/components/library/DeleteLibraryConfirmation.tsx
+++ b/packages/browser/src/components/library/DeleteLibraryConfirmation.tsx
@@ -78,13 +78,11 @@ export default function DeleteLibraryConfirmation({
 		}
 	}, [error])
 
-	const i18nValues = { type: 'library' }
-
 	return (
 		<TypeToConfirmModal
-			title={t(getKey('title'), i18nValues)}
-			description={t(getKey('description'), i18nValues)}
-			confirmText={t(getKey('confirm'), i18nValues)}
+			title={t(getKey('title'))}
+			description={t(getKey('description'))}
+			confirmText={t(getKey('confirm'))}
 			confirmVariant="danger"
 			isOpen={isOpen}
 			onClose={onClose}

--- a/packages/browser/src/components/library/DeleteLibraryConfirmation.tsx
+++ b/packages/browser/src/components/library/DeleteLibraryConfirmation.tsx
@@ -90,7 +90,7 @@ export default function DeleteLibraryConfirmation({
 			confirmIsLoading={isPending}
 			trigger={trigger}
 			confirmationValue={libraryName}
-			instructionText={t(getKey('typeToConfirm'), { name: libraryName })}
+			instructionText={t(getKey('typeToConfirm'))}
 		/>
 	)
 }

--- a/packages/browser/src/components/library/DeleteLibraryConfirmation.tsx
+++ b/packages/browser/src/components/library/DeleteLibraryConfirmation.tsx
@@ -1,6 +1,7 @@
 import { useGraphQLMutation } from '@stump/client'
-import { ConfirmationModal } from '@stump/components'
+import { TypeToConfirmModal } from '@stump/components'
 import { graphql, UserPermission } from '@stump/graphql'
+import { useLocaleContext } from '@stump/i18n'
 import { isAxiosError } from '@stump/sdk'
 import { useQueryClient } from '@tanstack/react-query'
 import { useCallback, useEffect, useMemo } from 'react'
@@ -18,16 +19,27 @@ const mutation = graphql(`
 	}
 `)
 
+const LOCALE_KEY = 'common.deleteConfirmation'
+const getKey = (key: string) => `${LOCALE_KEY}.${key}`
+
 type Props = {
 	libraryId: string
+	libraryName: string
 	onClose: () => void
 	isOpen: boolean
 	trigger?: React.ReactNode
 }
 
-export default function DeleteLibraryConfirmation({ isOpen, libraryId, onClose, trigger }: Props) {
+export default function DeleteLibraryConfirmation({
+	isOpen,
+	libraryId,
+	libraryName,
+	onClose,
+	trigger,
+}: Props) {
 	const navigate = useNavigate()
 	const client = useQueryClient()
+	const { t } = useLocaleContext()
 
 	const {
 		mutate: deleteLibrary,
@@ -66,17 +78,21 @@ export default function DeleteLibraryConfirmation({ isOpen, libraryId, onClose, 
 		}
 	}, [error])
 
+	const i18nValues = { type: 'library' }
+
 	return (
-		<ConfirmationModal
-			title="Delete Library"
-			description="Are you sure you want to delete this library? This action cannot be undone."
-			confirmText="Delete Library"
+		<TypeToConfirmModal
+			title={t(getKey('title'), i18nValues)}
+			description={t(getKey('description'), i18nValues)}
+			confirmText={t(getKey('confirm'), i18nValues)}
 			confirmVariant="danger"
 			isOpen={isOpen}
 			onClose={onClose}
 			onConfirm={handleDelete}
 			confirmIsLoading={isPending}
 			trigger={trigger}
+			confirmationValue={libraryName}
+			instructionText={t(getKey('typeToConfirm'), { name: libraryName })}
 		/>
 	)
 }

--- a/packages/browser/src/components/navigation/sidebar/sections/library/LibraryOptionsMenu.tsx
+++ b/packages/browser/src/components/navigation/sidebar/sections/library/LibraryOptionsMenu.tsx
@@ -74,6 +74,7 @@ export default function LibraryOptionsMenu({ library }: Props) {
 				isOpen={isDeleting}
 				onClose={() => setIsDeleting(false)}
 				libraryId={library.id}
+				libraryName={library.name}
 			/>
 
 			<DropdownMenu

--- a/packages/browser/src/scenes/library/tabs/settings/danger/deletion/DeleteLibrary.tsx
+++ b/packages/browser/src/scenes/library/tabs/settings/danger/deletion/DeleteLibrary.tsx
@@ -8,7 +8,7 @@ import { useLibraryManagement } from '../../context'
 
 export default function DeleteLibrary() {
 	const {
-		library: { id },
+		library: { id, name },
 	} = useLibraryManagement()
 	const { t } = useLocaleContext()
 
@@ -26,6 +26,7 @@ export default function DeleteLibrary() {
 			<DeleteLibraryConfirmation
 				isOpen={showConfirmation}
 				libraryId={id}
+				libraryName={name}
 				onClose={() => setShowConfirmation(false)}
 				trigger={
 					<div>

--- a/packages/components/src/dialog/ConfirmationModal.tsx
+++ b/packages/components/src/dialog/ConfirmationModal.tsx
@@ -13,6 +13,7 @@ export type ConfirmationModalProps = {
 	children?: React.ReactNode
 	confirmText?: string
 	confirmIsLoading?: boolean
+	confirmDisabled?: boolean
 	cancelText?: string
 	closeIcon?: boolean
 	triggerVariant?: ButtonVariant
@@ -32,6 +33,7 @@ export function ConfirmationModal({
 	confirmText,
 	cancelText,
 	confirmIsLoading,
+	confirmDisabled,
 	closeIcon = true,
 	triggerVariant,
 	confirmVariant = 'primary',
@@ -77,6 +79,7 @@ export function ConfirmationModal({
 						form={formId}
 						variant={confirmVariant}
 						onClick={onConfirm}
+						disabled={confirmDisabled}
 						isLoading={confirmIsLoading}
 					>
 						{confirmText || 'Confirm'}

--- a/packages/components/src/dialog/TypeToConfirmModal.tsx
+++ b/packages/components/src/dialog/TypeToConfirmModal.tsx
@@ -1,0 +1,60 @@
+import { useCallback, useEffect, useId, useState } from 'react'
+
+import { Input } from '../input'
+import { Text } from '../text'
+import { ConfirmationModal, ConfirmationModalProps } from './ConfirmationModal'
+
+export type TypeToConfirmModalProps = Omit<
+	ConfirmationModalProps,
+	'children' | 'confirmDisabled' | 'formId' | 'onConfirm'
+> & {
+	/** The exact string the user must type to enable the confirm button */
+	confirmationValue: string
+	/** Instruction text displayed above the input */
+	instructionText: React.ReactNode
+	/** Called when the user confirms after typing the correct value */
+	onConfirm: () => void
+}
+
+export function TypeToConfirmModal({
+	confirmationValue,
+	instructionText,
+	onConfirm,
+	isOpen,
+	...rest
+}: TypeToConfirmModalProps) {
+	const formId = useId()
+	const [inputValue, setInputValue] = useState('')
+
+	useEffect(() => {
+		setInputValue('')
+	}, [isOpen])
+
+	const isMatch = confirmationValue.length > 0 && inputValue === confirmationValue
+
+	const handleSubmit = useCallback(
+		(e: React.FormEvent) => {
+			e.preventDefault()
+			if (isMatch) {
+				onConfirm()
+			}
+		},
+		[isMatch, onConfirm],
+	)
+
+	return (
+		<ConfirmationModal {...rest} isOpen={isOpen} formId={formId} confirmDisabled={!isMatch}>
+			<form id={formId} onSubmit={handleSubmit} className="gap-2 py-2 flex flex-col">
+				<Text size="sm">{instructionText}</Text>
+				<Input
+					value={inputValue}
+					onChange={(e) => setInputValue(e.target.value)}
+					placeholder={confirmationValue}
+					autoComplete="off"
+					autoFocus
+					fullWidth
+				/>
+			</form>
+		</ConfirmationModal>
+	)
+}

--- a/packages/components/src/dialog/index.ts
+++ b/packages/components/src/dialog/index.ts
@@ -1,4 +1,5 @@
 export { ConfirmationModal, type ConfirmationModalProps } from './ConfirmationModal'
+export { TypeToConfirmModal, type TypeToConfirmModalProps } from './TypeToConfirmModal'
 export {
 	Dialog,
 	DialogContent,

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -22,7 +22,13 @@ export { Card, CardGrid, type CardProps, HoverCard, type HoverCardProps } from '
 export { Command, type CommandProps } from './command'
 export { Divider, Spacer, type SpacerProps, SplitContainer } from './container'
 export { ContextMenu, type ContextMenuProps } from './context-menu'
-export { ConfirmationModal, type ConfirmationModalProps, Dialog } from './dialog'
+export {
+	ConfirmationModal,
+	type ConfirmationModalProps,
+	Dialog,
+	TypeToConfirmModal,
+	type TypeToConfirmModalProps,
+} from './dialog'
 export { Drawer } from './drawer'
 export { Dropdown, DropdownMenu, type DropdownMenuProps } from './dropdown'
 export { EmojiPicker } from './emoji'

--- a/packages/i18n/src/config.ts
+++ b/packages/i18n/src/config.ts
@@ -154,6 +154,7 @@ function parseMissingKeyHandler(missingKey: string) {
 
 i18n.use(initReactI18next).init({
 	fallbackLng: 'en-US',
+	fallbackNS: 'en-US',
 	interpolation: {
 		escapeValue: false, // not needed for react as it escapes by default
 	},

--- a/packages/i18n/src/locales/en-US.json
+++ b/packages/i18n/src/locales/en-US.json
@@ -2320,6 +2320,12 @@
 		"clear": "Clear",
 		"confirm": "Confirm",
 		"delete": "Delete",
+		"deleteConfirmation": {
+			"title": "Delete {{type}}",
+			"description": "Are you sure you want to delete this {{type}}? This action cannot be undone.",
+			"confirm": "Delete {{type}}",
+			"typeToConfirm": "Type {{name}} to confirm:"
+		},
 		"enter": "Enter",
 		"save": "Save",
 		"send": "Send",


### PR DESCRIPTION
## Summary

This adds a reusable TypeToConfirmModal component, requiring to type the name of an entity before the confirm button gets enabled, and then uses it for library deletion. This fixes #1074 but also establishes a pattern that can be reused if we eventually add series/book removal.

## Screenshots

<img width="857" height="638" alt="image" src="https://github.com/user-attachments/assets/69b24dcf-7e16-4e14-8538-7ade31aa3db3" />