### PR TITLE
:bug: Fix HTML parsing for some ebook metadata fields

### DIFF
--- a/core/integration-tests/data/calibre-html-descriptions.opf
+++ b/core/integration-tests/data/calibre-html-descriptions.opf
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='utf-8'?>
+<package xmlns="http://www.idpf.org/2007/opf" unique-identifier="uuid_id" version="2.0">
+    <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+        <dc:identifier opf:scheme="calibre" id="calibre_id">17</dc:identifier>
+        <dc:identifier opf:scheme="uuid" id="uuid_id">c29b5d04-4046-4508-a722-f1dc9b2158ad</dc:identifier>
+        <dc:title>Heated Rivalry</dc:title>
+        <dc:creator opf:file-as="Reid, Rachel" opf:role="aut">Rachel Reid</dc:creator>
+        <dc:contributor opf:file-as="calibre" opf:role="bkp">calibre (8.7.0) [https://calibre-ebook.com]</dc:contributor>
+        <dc:date>2026-03-06T17:33:05+00:00</dc:date>
+        <dc:description>&lt;div&gt;
+&lt;p&gt;Pro hockey star Shane Hollander isn't just crazy talented, he's got a spotless reputation. Hockey is his life. Now that he's captain of the Montreal Voyageurs, he won't let anything jeopardize that, especially the sexy Russian whose hard body keeps him awake at night.&lt;br&gt;&lt;br&gt;Boston Bears captain Ilya Rozanov is everything Shane's not. The self-proclaimed king of the ice, he's as cocky as he is talented. No one can beat him - except Shane. They've made a career on their legendary rivalry, but when the skates come off, the heat between them is undeniable. When Ilya realizes he wants more than a few secret hookups, he knows he must walk away. The risk is too great.&lt;br&gt;&lt;br&gt;As their attraction intensifies, they struggle to keep their relationship out of the public eye. If the truth comes out, it could ruin them both. But when their need for each other rivals their ambition on the ice, secrecy is no longer an option...&lt;/p&gt;&lt;/div&gt;</dc:description>
+        <dc:publisher>Carina Press</dc:publisher>
+        <dc:identifier opf:scheme="GOOGLE">4re5EQAAQBAJ</dc:identifier>
+        <dc:identifier opf:scheme="ISBN">9789062229352</dc:identifier>
+        <dc:language>eng</dc:language>
+        <dc:subject>New Adult</dc:subject>
+        <dc:subject>Romance</dc:subject>
+        <dc:subject>Fiction</dc:subject>
+        <dc:subject>Gay</dc:subject>
+        <dc:subject>Lgbtq+</dc:subject>
+        <meta name="calibre:series" content="Game Changers"/>
+        <meta name="calibre:series_index" content="2"/>
+        <meta name="calibre:title_sort" content="Heated Rivalry"/>
+    </metadata>
+    <guide>
+        <reference type="cover" title="Cover" href="cover.jpg"/>
+    </guide>
+</package>

--- a/core/src/filesystem/media/format/epub.rs
+++ b/core/src/filesystem/media/format/epub.rs
@@ -1,5 +1,5 @@
 use merge::Merge;
-use quick_xml::{events::Event, Reader};
+use quick_xml::{escape::unescape, events::Event, Reader};
 use std::{collections::HashMap, fs::File, io::BufReader, path::PathBuf};
 
 const ACCEPTED_EPUB_COVER_MIMES: [&str; 2] = ["image/jpeg", "image/png"];
@@ -514,7 +514,12 @@ fn parse_opf_xml(opf_content: &str) -> Result<HashMap<String, Vec<String>>, File
 	let mut buf = Vec::new();
 	let mut opf_metadata: HashMap<String, Vec<String>> = HashMap::new();
 
+	// tags which _might_ contain html, will be handled differently if encountered
+	const HTML_CONTENT_TAGS: [&str; 3] = ["description", "summary", "synopsis"];
+
 	loop {
+		let mut html_tag_to_read: Option<(String, String)> = None;
+
 		match reader.read_event_into(&mut buf) {
 			Ok(Event::Start(ref e)) => {
 				let tag_name = String::from_utf8_lossy(e.name().as_ref()).to_string();
@@ -523,29 +528,33 @@ fn parse_opf_xml(opf_content: &str) -> Result<HashMap<String, Vec<String>>, File
 					.unwrap_or(tag_name.as_str())
 					.to_string();
 
-				current_tag = base_tag.clone();
+				if HTML_CONTENT_TAGS.contains(&base_tag.as_str()) {
+					html_tag_to_read = Some((tag_name, base_tag));
+				} else {
+					current_tag = base_tag.clone();
 
-				// Check for attributes that modify the tag name
-				for attr in e.attributes().flatten() {
-					match attr.key.as_ref() {
-						b"opf:scheme" if base_tag == "identifier" => {
-							let scheme =
-								String::from_utf8_lossy(&attr.value).to_lowercase();
-							current_tag = format!("identifier_{}", scheme);
-						},
-						b"name" if tag_name == "meta" => {
-							let name = String::from_utf8_lossy(&attr.value);
-							current_tag = name.trim_start_matches("calibre:").to_string();
-						},
-						b"property" if tag_name == "meta" => {
-							let property = String::from_utf8_lossy(&attr.value);
-							current_tag = property.to_string();
-						},
-						b"property" if tag_name == "opf:meta" => {
-							let property = String::from_utf8_lossy(&attr.value);
-							current_tag = property.to_string();
-						},
-						_ => {},
+					for attr in e.attributes().flatten() {
+						match attr.key.as_ref() {
+							b"opf:scheme" if base_tag == "identifier" => {
+								let scheme =
+									String::from_utf8_lossy(&attr.value).to_lowercase();
+								current_tag = format!("identifier_{}", scheme);
+							},
+							b"name" if tag_name == "meta" => {
+								let name = String::from_utf8_lossy(&attr.value);
+								current_tag =
+									name.trim_start_matches("calibre:").to_string();
+							},
+							b"property" if tag_name == "meta" => {
+								let property = String::from_utf8_lossy(&attr.value);
+								current_tag = property.to_string();
+							},
+							b"property" if tag_name == "opf:meta" => {
+								let property = String::from_utf8_lossy(&attr.value);
+								current_tag = property.to_string();
+							},
+							_ => {},
+						}
 					}
 				}
 			},
@@ -672,6 +681,26 @@ fn parse_opf_xml(opf_content: &str) -> Result<HashMap<String, Vec<String>>, File
 			},
 			_ => {},
 		}
+
+		if let Some((full_tag, base_tag)) = html_tag_to_read.take() {
+			let end = quick_xml::events::BytesEnd::new(&full_tag);
+			match reader.read_text(end.name()) {
+				Ok(raw_text) => {
+					let text = unescape(&raw_text)
+						.map(|c| c.into_owned())
+						.unwrap_or_else(|_| raw_text.into_owned());
+					let trimmed = text.trim().to_string();
+
+					if !trimmed.is_empty() {
+						opf_metadata.entry(base_tag).or_default().push(trimmed);
+					}
+				},
+				Err(e) => {
+					tracing::warn!("Error reading {} content: {}", base_tag, e);
+				},
+			}
+		}
+
 		buf.clear();
 	}
 
@@ -956,14 +985,6 @@ mod tests {
 		assert_eq!(contributors.len(), 1);
 		assert!(contributors[0].contains("calibre"));
 
-		let _descriptions = metadata
-			.get("description")
-			.expect("Should have description");
-		// FIXME: The XML parser is not correctly handling HTML tags within the description.
-		// For the time being, I've uncommented this test but I definitely want to fix it...
-		// assert_eq!(descriptions.len(), 1);
-		// assert!(descriptions[0].contains("Victorian mansion"));
-
 		assert_eq!(
 			metadata.get("identifier_calibre"),
 			Some(&vec!["106".to_string()])
@@ -1028,6 +1049,54 @@ mod tests {
 		for key in expected_keys.iter() {
 			assert!(metadata.contains_key(*key), "Missing expected key: {}", key);
 		}
+	}
+
+	#[test]
+	fn test_parse_calibre_html_description_opf() {
+		let opf_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+			.join("integration-tests")
+			.join("data")
+			.join("calibre-html-descriptions.opf");
+
+		let opf_content = std::fs::read_to_string(&opf_path)
+			.expect("Failed to read calibre-html-descriptions.opf test file");
+
+		let metadata = parse_opf_xml(&opf_content)
+			.expect("Failed to parse calibre-html-descriptions.opf");
+
+		assert_eq!(
+			metadata.get("title"),
+			Some(&vec!["Heated Rivalry".to_string()])
+		);
+		assert_eq!(
+			metadata.get("creator"),
+			Some(&vec!["Rachel Reid".to_string()])
+		);
+
+		let descriptions = metadata
+			.get("description")
+			.expect("Should have description");
+		assert_eq!(
+			descriptions.len(),
+			1,
+			"Description should be a single entry"
+		);
+		let description = &descriptions[0];
+
+		assert!(description.contains("Pro hockey star Shane Hollander"));
+		assert!(description.contains("Boston Bears captain Ilya Rozanov"));
+		assert!(description.contains("<div>"));
+		assert!(description.contains("<p>"));
+		assert!(description.contains("<br>"));
+		assert!(description.contains("</p>"));
+		assert!(description.contains("</div>"));
+
+		assert_eq!(
+			metadata.get("series"),
+			Some(&vec!["Game Changers".to_string()])
+		);
+		assert_eq!(metadata.get("series_index"), Some(&vec!["2".to_string()]));
+		assert_eq!(metadata.get("language"), Some(&vec!["eng".to_string()]));
 	}
 
 	#[test]


### PR DESCRIPTION
This fixes an issue I documented months ago wrt HTML entities inside description-like tags for ebook opf parsing