### PR TITLE
:wrench: Add optional env var to configure directory for Stump.log

### DIFF
--- a/core/src/config/logging.rs
+++ b/core/src/config/logging.rs
@@ -11,8 +11,8 @@ pub const STUMP_SHADOW_TEXT: &str = include_str!("stump_shadow_text.txt");
 /// both the console and a file in the config directory. The file is called `Stump.log`
 /// by default.
 pub fn init_tracing(config: &StumpConfig) {
-	let config_dir = config.get_config_dir();
-	let file_appender = tracing_appender::rolling::never(config_dir, "Stump.log");
+	let log_dir = config.get_log_dir();
+	let file_appender = tracing_appender::rolling::never(log_dir, "Stump.log");
 
 	let max_level = match config.verbosity {
 		0 => LevelFilter::OFF,

--- a/core/src/config/stump_config.rs
+++ b/core/src/config/stump_config.rs
@@ -23,6 +23,7 @@ pub mod env_keys {
 	pub const PORT_KEY: &str = "STUMP_PORT";
 	pub const VERBOSITY_KEY: &str = "STUMP_VERBOSITY";
 	pub const PRETTY_LOGS_KEY: &str = "STUMP_PRETTY_LOGS";
+	pub const LOG_DIR_KEY: &str = "STUMP_LOG_DIR";
 	pub const COLORFUL_LOGS_KEY: &str = "STUMP_COLORFUL_LOGS";
 	pub const DB_PATH_KEY: &str = "STUMP_DB_PATH";
 	pub const CLIENT_KEY: &str = "STUMP_CLIENT_DIR";
@@ -132,6 +133,11 @@ pub struct StumpConfig {
 	#[default_value(true)]
 	#[env_key(PRETTY_LOGS_KEY)]
 	pub pretty_logs: bool,
+
+	/// The directory where the applicaiton logs will be stored
+	#[default_value(None)]
+	#[env_key(LOG_DIR_KEY)]
+	pub log_dir: Option<String>,
 
 	/// Whether or not to include ANSI color codes in log files.
 	#[default_value(false)]
@@ -354,6 +360,13 @@ impl StumpConfig {
 		PathBuf::from(&self.config_dir)
 	}
 
+	pub fn get_log_dir(&self) -> PathBuf {
+		match &self.log_dir {
+			Some(value) => PathBuf::from(value),
+			None => self.get_config_dir(),
+		}
+	}
+
 	/// Returns a `PathBuf` to the Stump cache directory.
 	pub fn get_cache_dir(&self) -> PathBuf {
 		PathBuf::from(&self.config_dir).join("cache")
@@ -435,6 +448,7 @@ mod tests {
 			port: Some(1337),
 			verbosity: Some(3),
 			pretty_logs: Some(true),
+			log_dir: None,
 			colorful_logs: None,
 			db_path: Some("not_a_real_path".to_string()),
 			client_dir: Some("not_a_real_dir".to_string()),
@@ -483,6 +497,7 @@ mod tests {
 				port: Some(1337),
 				verbosity: Some(3),
 				pretty_logs: Some(true),
+				log_dir: None,
 				colorful_logs: Some(false),
 				db_path: Some("not_a_real_path".to_string()),
 				client_dir: Some("not_a_real_dir".to_string()),
@@ -551,6 +566,7 @@ mod tests {
 						port: 1337,
 						verbosity: 2,
 						pretty_logs: true,
+						log_dir: None,
 						colorful_logs: false,
 						db_path: None,
 						client_dir: "./client".to_string(),

--- a/crates/graphql/schema.graphql
+++ b/crates/graphql/schema.graphql
@@ -2669,6 +2669,8 @@ type StumpConfig {
 	verbosity: Int!
 	"Whether or not to pretty print logs."
 	prettyLogs: Boolean!
+	"The directory where the applicaiton logs will be stored"
+	logDir: String
 	"Whether or not to include ANSI color codes in log files."
 	colorfulLogs: Boolean!
 	"An optional custom path for the database."

--- a/packages/graphql/src/client/graphql.ts
+++ b/packages/graphql/src/client/graphql.ts
@@ -3750,6 +3750,8 @@ export type StumpConfig = {
   enableUpload: Scalars['Boolean']['output'];
   /** The interval at which automatic deleted session cleanup is performed. */
   expiredSessionCleanupInterval: Scalars['Int']['output'];
+  /** The directory where the applicaiton logs will be stored */
+  logDir?: Maybe<Scalars['String']['output']>;
   /** The maximum size, in bytes, of files that can be uploaded to be included in libraries. */
   maxFileUploadSize: Scalars['Int']['output'];
   /**


### PR DESCRIPTION
Adds a new env var `STUMP_LOG_DIR` which updates the directory that the `Stump.log` file is stored in. If not set, it defaults to the current behaviour/config dir