### PR TITLE
🔨 Expand t() to take an optional record for interpolation

### DIFF
--- a/packages/browser/src/components/library/DeleteLibraryConfirmation.tsx
+++ b/packages/browser/src/components/library/DeleteLibraryConfirmation.tsx
@@ -78,11 +78,13 @@ export default function DeleteLibraryConfirmation({
 		}
 	}, [error])
 
+	const entityI18nValues = { name: libraryName, type: 'library' }
+
 	return (
 		<TypeToConfirmModal
-			title={t(getKey('title'))}
-			description={t(getKey('description'))}
-			confirmText={t(getKey('confirm'))}
+			title={t(getKey('title'), entityI18nValues)}
+			description={t(getKey('description'), entityI18nValues)}
+			confirmText={t(getKey('confirm'), entityI18nValues)}
 			confirmVariant="danger"
 			isOpen={isOpen}
 			onClose={onClose}
@@ -90,7 +92,7 @@ export default function DeleteLibraryConfirmation({
 			confirmIsLoading={isPending}
 			trigger={trigger}
 			confirmationValue={libraryName}
-			instructionText={t(getKey('typeToConfirm'))}
+			instructionText={t(getKey('typeToConfirm'), entityI18nValues)}
 		/>
 	)
 }

--- a/packages/i18n/src/context.ts
+++ b/packages/i18n/src/context.ts
@@ -4,7 +4,7 @@ import { AllowedLocale } from './config'
 
 export type LocaleContextProps = {
 	locale: AllowedLocale
-	t: (key: string) => string
+	t: (key: string, options?: Record<string, string>) => string
 }
 
 export const getDefaultLocale = (defaultValue: AllowedLocale = 'en-US') => {

--- a/packages/i18n/src/context.ts
+++ b/packages/i18n/src/context.ts
@@ -4,7 +4,7 @@ import { AllowedLocale } from './config'
 
 export type LocaleContextProps = {
 	locale: AllowedLocale
-	t: (key: string, options?: Record<string, string>) => string
+	t: (key: string, options?: Record<string, unknown>) => string
 }
 
 export const getDefaultLocale = (defaultValue: AllowedLocale = 'en-US') => {


### PR DESCRIPTION
This allows keys to contain variables replaced automatically by i18next, rather than doing manual replacing or composition.