### PR TITLE
🐛 (expo): Fix various image reader bugs

### DIFF
--- a/apps/expo/app/offline/[fileId]/index.tsx
+++ b/apps/expo/app/offline/[fileId]/index.tsx
@@ -19,7 +19,6 @@ import { useDownloadsState } from '~/components/localLibrary/store'
 import { getThumbnailPath } from '~/components/localLibrary/utils'
 import { MetadataBadgeSection } from '~/components/overview'
 import { Button, Card, Heading, Text } from '~/components/ui'
-import { Icon } from '~/components/ui/icon'
 import {
 	db,
 	downloadedFiles,
@@ -161,7 +160,6 @@ export default function Screen() {
 								style={{ width: '100%', height: '100%' }}
 								resizeMode="cover"
 								fadeDuration={2000}
-								{...(Platform.OS === 'ios' && { indicator: { color: 'transparent' } })}
 								resize={60}
 								// android only supports up to blur={25} which doesn't look good,
 								// but if we heavily downscale first, the following looks near identical to using

--- a/apps/expo/app/opds/[id]/publication/index.tsx
+++ b/apps/expo/app/opds/[id]/publication/index.tsx
@@ -16,12 +16,7 @@ import {
 	useOverviewAnimations,
 } from '~/components/book/overview'
 import { ThumbnailImage } from '~/components/image'
-import {
-	CreditsSection,
-	PublicationMenu,
-	RelatedPublicationItem,
-	useRelatedPublications,
-} from '~/components/opds'
+import { CreditsSection, RelatedPublicationItem, useRelatedPublications } from '~/components/opds'
 import FeedSelfURL from '~/components/opds/FeedSelfURL'
 import { usePublicationMenu } from '~/components/opds/PublicationMenu'
 import {
@@ -242,7 +237,6 @@ export default function Screen() {
 							style={{ width: '100%', height: '100%' }}
 							resizeMode="cover"
 							fadeDuration={2000}
-							{...(Platform.OS === 'ios' && { indicator: { color: 'transparent' } })}
 							// android only supports up to blur={25} which doesn't look good,
 							// but if we heavily downscale first, the following looks near identical to using
 							// original res with blur={40} on ios, which is what I originally settled on

--- a/apps/expo/app/server/[id]/books/[id]/index.tsx
+++ b/apps/expo/app/server/[id]/books/[id]/index.tsx
@@ -30,7 +30,6 @@ import { ThumbnailImage } from '~/components/image'
 import { MetadataBadgeSection } from '~/components/overview'
 import RefreshControl from '~/components/RefreshControl'
 import { Button, Card, Heading, ListLabel, Text } from '~/components/ui'
-import { Icon } from '~/components/ui/icon'
 import { formatSeriesPosition } from '~/lib/bookUtils'
 import { formatBytes, parseGraphQLDecimal } from '~/lib/format'
 import { useDownload } from '~/lib/hooks'
@@ -365,7 +364,6 @@ export default function Screen() {
 							style={{ width: '100%', height: '100%' }}
 							resizeMode="cover"
 							fadeDuration={2000}
-							{...(Platform.OS === 'ios' && { indicator: { color: 'transparent' } })}
 							// android only supports up to blur={25} which doesn't look good,
 							// but if we heavily downscale first, the following looks near identical to using
 							// original res with blur={40} on ios, which is what I originally settled on

--- a/apps/expo/components/book/reader/image/Footer.tsx
+++ b/apps/expo/components/book/reader/image/Footer.tsx
@@ -10,6 +10,7 @@ import TImage from 'react-native-turbo-image'
 
 import { getThumbnailResizeProps, TurboImage } from '~/components/image'
 import { Progress, Text } from '~/components/ui'
+import { useColors } from '~/lib/constants'
 import { useDisplay, usePrevious } from '~/lib/hooks'
 import { cn } from '~/lib/utils'
 import { usePreferencesStore, useReaderStore } from '~/stores'
@@ -54,6 +55,7 @@ export default function Footer() {
 	const thumbnailRatio = usePreferencesStore((state) => state.thumbnailRatio)
 	const thumbnailResizeMode = usePreferencesStore((state) => state.thumbnailResizeMode)
 	const { secondaryStyle, translateFooterStyle } = useReaderAnimations()
+	const colors = useColors()
 
 	const [isSliderDragging, setIsSliderDragging] = useState(false)
 
@@ -317,6 +319,7 @@ export default function Footer() {
 										// @ts-expect-error bug in library (to be fixed soon). StyleProp<ImageStyle> should be StyleProp<ViewStyle>
 										borderCurve: 'continuous',
 										overflow: 'hidden',
+										backgroundColor: colors.thumbnail.placeholder,
 										...style,
 									}}
 									onSuccess={({ nativeEvent }) => onImageLoaded(pageIdx, nativeEvent)}
@@ -347,6 +350,7 @@ export default function Footer() {
 			thumbnailResizeMode,
 			imageSizes,
 			baseSize,
+			colors,
 		],
 	)
 
@@ -444,6 +448,7 @@ export default function Footer() {
 											style={{
 												width: item.length === 1 ? '100%' : '50%',
 												height: '100%',
+												backgroundColor: colors.thumbnail.placeholder,
 												...style,
 											}}
 											onSuccess={({ nativeEvent }) => onImageLoaded(pageIdx, nativeEvent)}
@@ -476,6 +481,7 @@ export default function Footer() {
 			baseSize,
 			thumbnailResizeMode,
 			imageSizes,
+			colors,
 		],
 	)
 

--- a/apps/expo/components/book/reader/image/ImageBasedReader.tsx
+++ b/apps/expo/components/book/reader/image/ImageBasedReader.tsx
@@ -198,8 +198,16 @@ const PageSet = React.memo(
 		onPastEndReached,
 		zoomResetCounter,
 	}: PageSetProps) => {
-		const { book, pageURL, flashListRef, pageSets, setImageSizes, requestHeaders, serverId } =
-			useImageBasedReader()
+		const {
+			book,
+			pageURL,
+			flashListRef,
+			pageSets,
+			imageSizes,
+			setImageSizes,
+			requestHeaders,
+			serverId,
+		} = useImageBasedReader()
 		const {
 			preferences: { tapSidesToNavigate, readingDirection, readingMode, allowDownscaling },
 		} = useBookPreferences({ book, serverId })
@@ -266,14 +274,13 @@ const PageSet = React.memo(
 			[showControls, setShowControls, onCheckForNavigationTaps, tapSidesToNavigate, readingMode],
 		)
 
-		const [imageRatio, setImageRatio] = useState<number | undefined>(undefined)
+		const imageRatio = imageSizes?.[index]?.ratio
 
 		const onImageLoaded = useCallback(
 			(event: NativeSyntheticEvent<Success>, idxIdx: number) => {
 				const { height, width } = event.nativeEvent
 				if (!height || !width) return
 				const ratio = width / height
-				setImageRatio(ratio)
 
 				const pageSize = sizes[idxIdx]
 				const isDifferent = pageSize?.height !== height || pageSize?.width !== width

--- a/apps/expo/components/book/reader/image/ImageBasedReader.tsx
+++ b/apps/expo/components/book/reader/image/ImageBasedReader.tsx
@@ -62,6 +62,8 @@ export default function ImageBasedReader({ initialPage, onPastEndReached }: Prop
 	const { height, width } = useWindowDimensions()
 	const insets = useSafeAreaInsets()
 
+	const [zoomResetCounter, setZoomResetCounter] = useState(0)
+
 	const deviceOrientation = useMemo(
 		() => (width > height ? 'landscape' : 'portrait'),
 		[width, height],
@@ -141,6 +143,7 @@ export default function ImageBasedReader({ initialPage, onPastEndReached }: Prop
 						maxHeight={height}
 						readingDirection="horizontal"
 						onPastEndReached={onPastEndReached}
+						zoomResetCounter={zoomResetCounter}
 					/>
 				)}
 				contentContainerStyle={
@@ -172,6 +175,7 @@ export default function ImageBasedReader({ initialPage, onPastEndReached }: Prop
 				initialScrollIndexParams={isVertical ? { viewOffset: -insets.top } : undefined}
 				showsHorizontalScrollIndicator={false}
 				onScroll={handleScroll}
+				onMomentumScrollEnd={() => setZoomResetCounter((c) => c + 1)}
 			/>
 		</View>
 	)
@@ -186,6 +190,7 @@ type PageSetProps = {
 	maxHeight: number
 	readingDirection: 'vertical' | 'horizontal'
 	onPastEndReached?: () => void
+	zoomResetCounter: number
 }
 
 const PageSet = React.memo(
@@ -198,6 +203,7 @@ const PageSet = React.memo(
 		maxHeight,
 		onPastEndReached,
 		// readingDirection,
+		zoomResetCounter,
 	}: PageSetProps) => {
 		const { book, pageURL, flashListRef, pageSets, setImageSizes, requestHeaders, serverId } =
 			useImageBasedReader()
@@ -214,6 +220,10 @@ const PageSet = React.memo(
 		const tapThresholdRatio = isTablet ? 4 : 5
 
 		const zoomableRef = useRef<ZoomableRef>(null)
+
+		useEffect(() => {
+			zoomableRef.current?.reset()
+		}, [zoomResetCounter])
 
 		const onCheckForNavigationTaps = useCallback(
 			(x: number) => {

--- a/apps/expo/components/book/reader/image/ImageBasedReader.tsx
+++ b/apps/expo/components/book/reader/image/ImageBasedReader.tsx
@@ -350,7 +350,6 @@ const PageSet = React.memo(
 										maxWidth: indexes.length > 1 ? '50%' : '100%',
 										aspectRatio: imageRatio,
 									}}
-									indicator={{ color: 'transparent' }}
 									resizeMode="contain"
 									resize={allowDownscaling ? roughPageRenderWidth * 1.2 : undefined}
 									onSuccess={(event) => onImageLoaded(event, i)}

--- a/apps/expo/components/book/reader/image/ImageBasedReader.tsx
+++ b/apps/expo/components/book/reader/image/ImageBasedReader.tsx
@@ -143,12 +143,6 @@ export default function ImageBasedReader({ initialPage, onPastEndReached }: Prop
 						onPastEndReached={onPastEndReached}
 					/>
 				)}
-				getItemType={(item) => {
-					const itemZero = item[0]
-					if (item.length === 2) return 'double'
-					else if (itemZero != null && (imageSizes?.[itemZero]?.ratio || 0) >= 1) return 'landscape'
-					else return 'single'
-				}}
 				contentContainerStyle={
 					isVertical && { paddingTop: insets.top, paddingBottom: insets.bottom }
 				}

--- a/apps/expo/components/book/reader/image/ImageBasedReader.tsx
+++ b/apps/expo/components/book/reader/image/ImageBasedReader.tsx
@@ -32,7 +32,6 @@ type ImageDimension = {
 // Not 100% sure, it is REALLY janky right now.
 // When Zoomable is on the list for continuous scrolling, panning is weird because there is the list scroll
 // and the Zoomable pan, but Zoomable pan vertically/horizontally won't scroll the vertical/horizontal list
-// TODO: Account for device orientation AND reading direction
 // TODO: Account for the image scaling settings
 
 type Props = {
@@ -129,19 +128,17 @@ export default function ImageBasedReader({ initialPage, onPastEndReached }: Prop
 	return (
 		<View style={[{ width, height }, isRtl && { transform: [{ scaleX: -1 }] }]}>
 			<FlashList
-				key={isVertical ? 'vertical' : 'horizontal'}
+				key={`${isVertical}-${deviceOrientation}`}
 				ref={flashListRef}
 				data={pageSets}
 				keyExtractor={(item) => item.toString()}
 				renderItem={({ item, index }) => (
 					<PageSet
-						deviceOrientation={deviceOrientation}
 						index={index}
 						indexes={item as [number, number]}
 						sizes={item.map((i: number) => imageSizes[i]).filter((i) => i != null)}
 						maxWidth={width}
 						maxHeight={height}
-						readingDirection="horizontal"
 						onPastEndReached={onPastEndReached}
 						zoomResetCounter={zoomResetCounter}
 					/>
@@ -182,27 +179,23 @@ export default function ImageBasedReader({ initialPage, onPastEndReached }: Prop
 }
 
 type PageSetProps = {
-	deviceOrientation: string
 	index: number
 	indexes: [number, number]
 	sizes: ImageDimension[]
 	maxWidth: number
 	maxHeight: number
-	readingDirection: 'vertical' | 'horizontal'
 	onPastEndReached?: () => void
 	zoomResetCounter: number
 }
 
 const PageSet = React.memo(
 	({
-		// deviceOrientation,
 		index,
 		indexes,
 		sizes,
 		maxWidth,
 		maxHeight,
 		onPastEndReached,
-		// readingDirection,
 		zoomResetCounter,
 	}: PageSetProps) => {
 		const { book, pageURL, flashListRef, pageSets, setImageSizes, requestHeaders, serverId } =
@@ -227,8 +220,6 @@ const PageSet = React.memo(
 
 		const onCheckForNavigationTaps = useCallback(
 			(x: number) => {
-				if (readingMode === ReadingMode.ContinuousVertical) return
-
 				const isLeft = x < maxWidth / tapThresholdRatio
 				const isRight = x > maxWidth - maxWidth / tapThresholdRatio
 
@@ -253,7 +244,6 @@ const PageSet = React.memo(
 				readingDirection,
 				pageSets,
 				onPastEndReached,
-				readingMode,
 			],
 		)
 
@@ -261,7 +251,7 @@ const PageSet = React.memo(
 			(event: GestureStateChangeEvent<TapGestureHandlerEventPayload>) => {
 				if (event.state !== State.ACTIVE) return
 
-				if (!tapSidesToNavigate) {
+				if (!tapSidesToNavigate || readingMode !== ReadingMode.Paged) {
 					setShowControls(!showControls)
 					return
 				}
@@ -273,7 +263,7 @@ const PageSet = React.memo(
 					setShowControls(!showControls)
 				}
 			},
-			[showControls, setShowControls, onCheckForNavigationTaps, tapSidesToNavigate],
+			[showControls, setShowControls, onCheckForNavigationTaps, tapSidesToNavigate, readingMode],
 		)
 
 		const [imageRatio, setImageRatio] = useState<number | undefined>(undefined)

--- a/apps/expo/components/bookClub/CurrentBookSheet.tsx
+++ b/apps/expo/components/bookClub/CurrentBookSheet.tsx
@@ -107,7 +107,6 @@ export const CurrentBookSheet = forwardRef<CurrentBookSheetRef, Props>(({ book }
 								style={{ width: '100%', height: '100%' }}
 								resizeMode="cover"
 								fadeDuration={2000}
-								{...(Platform.OS === 'ios' && { indicator: { color: 'transparent' } })}
 								// android only supports up to blur={25} which doesn't look good,
 								// but if we heavily downscale first, the following looks near identical to using
 								// original res with blur={40} on ios, which is what I originally settled on

--- a/apps/expo/components/bookClub/PreviewBookSheet.tsx
+++ b/apps/expo/components/bookClub/PreviewBookSheet.tsx
@@ -138,7 +138,6 @@ function BookContent({ book, onConfirmAddBook }: BookContentProps) {
 						style={{ width: '100%', height: '100%' }}
 						resizeMode="cover"
 						fadeDuration={2000}
-						{...(Platform.OS === 'ios' && { indicator: { color: 'transparent' } })}
 						// android only supports up to blur={25} which doesn't look good,
 						// but if we heavily downscale first, the following looks near identical to using
 						// original res with blur={40} on ios, which is what I originally settled on

--- a/apps/expo/components/image/ThumbnailImage.tsx
+++ b/apps/expo/components/image/ThumbnailImage.tsx
@@ -110,11 +110,6 @@ export const ThumbnailImage = ({
 						resize={size.width * 1.5}
 						fadeDuration={800}
 						resizeMode={effectiveResizeMode}
-						// This is a weird workaround:
-						// Using the indicator prop hides the built in grey placeholder on ios (what we want)
-						// but will force show a circular loading indicator on all platforms, so we make it transparent.
-						// Android doesn't support transparent (and doesn't have built in placeholders) so we do nothing.
-						{...(Platform.OS === 'ios' && { indicator: { color: 'transparent' } })}
 						{...props}
 					/>
 				</View>

--- a/apps/expo/components/opdsLegacy/OPDSLegacyEntryItemSheet.tsx
+++ b/apps/expo/components/opdsLegacy/OPDSLegacyEntryItemSheet.tsx
@@ -92,7 +92,6 @@ export const OPDSLegacyEntryItemSheet = forwardRef<TrueSheet, Props>(
 										style={{ width: '100%', height: '100%' }}
 										resizeMode="cover"
 										fadeDuration={2000}
-										{...(Platform.OS === 'ios' && { indicator: { color: 'transparent' } })}
 										resize={60}
 										blur={Platform.OS === 'ios' ? 7 : 16}
 									/>

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -107,7 +107,7 @@
 		"react-native-screens": "~4.24.0",
 		"react-native-super-grid": "^6.0.1",
 		"react-native-svg": "15.15.3",
-		"react-native-turbo-image": "^1.23.1",
+		"react-native-turbo-image": "^1.24.1",
 		"react-native-web": "^0.21.0",
 		"react-native-webview": "13.16.0",
 		"react-native-worklets": "0.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21259,10 +21259,10 @@ react-native-svg@15.15.3:
     css-tree "^1.1.3"
     warn-once "0.1.1"
 
-react-native-turbo-image@^1.23.1:
-  version "1.23.1"
-  resolved "https://registry.yarnpkg.com/react-native-turbo-image/-/react-native-turbo-image-1.23.1.tgz#ef56b4aa6efe169793795dfbd01a0b57f70762c1"
-  integrity sha512-PXJO5x2mzrtfcyWaYrSFSMluYjYKKK+u6kPiw9Qk47JTOT/evNyBlMsTjbIWHlHYnb5eGTPhvoFy91csplyUkw==
+react-native-turbo-image@^1.24.1:
+  version "1.24.1"
+  resolved "https://registry.yarnpkg.com/react-native-turbo-image/-/react-native-turbo-image-1.24.1.tgz#45db8b8e5958835bf985591b333c78c2f8e49f0e"
+  integrity sha512-Sj41a3WfZJvg/J+oC9KEjjLr/EFlLQqCDzyw2HU+mrA342drIfpS9oe7AZr+arzGS8hJpaey2xL2OmEGypZ54g==
 
 react-native-web@^0.21.0:
   version "0.21.2"
@@ -23106,16 +23106,7 @@ string-trim-spaces-only@^5.1.0:
   resolved "https://registry.yarnpkg.com/string-trim-spaces-only/-/string-trim-spaces-only-5.1.0.tgz#d68e328f4f11cbb96642334ae1582bf3c02582f5"
   integrity sha512-632znq4SGCNM7Vw7QITbx05oej+Xly2s7OtDxN9jvNbOoWcQuA5fq14CAS5TlpiiB04LDETzJj9fk851PnWLgg==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -23241,7 +23232,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -23261,13 +23252,6 @@ strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.2"
@@ -25349,7 +25333,7 @@ workbox-window@7.4.0, workbox-window@^7.4.0:
     "@types/trusted-types" "^2.0.2"
     workbox-core "7.4.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -25362,15 +25346,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
The issues with the image reader that have been fixed are:
- image paging, where the sides of the screen and the sides of the page did not properly align when different types of pages existed (it stopped like half way through each page after a landscape page). I don't think `getItemType` does anything for performance anyways
- on tapping to change page, if zoomed in and recently panned and the panning momentum hasn't yet stopped, the page resets to the wrong place
- and updated the image library which has since fixed the placeholder weirdness