### PR TITLE
✨ Add tag assignment to series and inline tag creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9142,7 +9142,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "models",

--- a/crates/graphql/schema.graphql
+++ b/crates/graphql/schema.graphql
@@ -2008,6 +2008,11 @@ type Mutation {
 	"""
 	setMediaTags(id: ID!, tags: [String!]!): Media!
 	"""
+	Set the tags for a series. Creates any tags that don't exist yet, links new ones,
+	and unlinks removed ones. Returns the updated series.
+	"""
+	setSeriesTags(id: ID!, tags: [String!]!): Series!
+	"""
 	Delete tags. Returns a list containing the deleted tags, or an error if deletion failed.
 	
 	* `tags` - A non-empty list of tags to delete.

--- a/crates/graphql/src/mutation/tag.rs
+++ b/crates/graphql/src/mutation/tag.rs
@@ -1,11 +1,11 @@
 use crate::{
 	data::{AuthContext, CoreContext},
 	guard::PermissionGuard,
-	object::{media::Media, tag::Tag},
+	object::{media::Media, series::Series, tag::Tag},
 };
 use async_graphql::{Context, Object, Result, ID};
 use models::{
-	entity::{media, media_tag, tag},
+	entity::{media, media_tag, series, series_tag, tag},
 	shared::enums::UserPermission,
 };
 use sea_orm::{
@@ -96,6 +96,77 @@ impl TagMutation {
 					.into_iter()
 					.map(|tag_id| media_tag::ActiveModel {
 						media_id: Set(media_id.clone()),
+						tag_id: Set(tag_id),
+						..Default::default()
+					})
+					.collect::<Vec<_>>(),
+			)
+			.on_conflict_do_nothing()
+			.exec(&txn)
+			.await?;
+		}
+
+		txn.commit().await?;
+
+		Ok(model.into())
+	}
+
+	/// Set the tags for a series. Creates any tags that don't exist yet, links new ones,
+	/// and unlinks removed ones. Returns the updated series.
+	#[graphql(guard = "PermissionGuard::one(UserPermission::EditMetadata)")]
+	async fn set_series_tags(
+		&self,
+		ctx: &Context<'_>,
+		id: ID,
+		tags: Vec<String>,
+	) -> Result<Series> {
+		let AuthContext { user, .. } = ctx.data::<AuthContext>()?;
+		let conn = ctx.data::<CoreContext>()?.conn.as_ref();
+
+		let model = series::ModelWithMetadata::find_for_user(user)
+			.filter(series::Column::Id.eq(id.to_string()))
+			.into_model::<series::ModelWithMetadata>()
+			.one(conn)
+			.await?
+			.ok_or("Series not found")?;
+
+		let existing_tags = tag::Entity::find()
+			.filter(
+				tag::Column::Id.in_subquery(
+					Query::select()
+						.column(series_tag::Column::TagId)
+						.from(series_tag::Entity)
+						.and_where(
+							series_tag::Column::SeriesId.eq(model.series.id.clone()),
+						)
+						.to_owned(),
+				),
+			)
+			.all(conn)
+			.await?;
+
+		let txn = conn.begin().await?;
+
+		let (to_connect, to_disconnect) = sync_tags(&txn, &tags, &existing_tags).await?;
+
+		if !to_disconnect.is_empty() {
+			series_tag::Entity::delete_many()
+				.filter(
+					series_tag::Column::TagId
+						.is_in(to_disconnect)
+						.and(series_tag::Column::SeriesId.eq(model.series.id.clone())),
+				)
+				.exec(&txn)
+				.await?;
+		}
+
+		if !to_connect.is_empty() {
+			let series_id = model.series.id.clone();
+			series_tag::Entity::insert_many(
+				to_connect
+					.into_iter()
+					.map(|tag_id| series_tag::ActiveModel {
+						series_id: Set(series_id.clone()),
 						tag_id: Set(tag_id),
 						..Default::default()
 					})

--- a/packages/browser/src/scenes/series/tabs/settings/SeriesSettingsScene.tsx
+++ b/packages/browser/src/scenes/series/tabs/settings/SeriesSettingsScene.tsx
@@ -2,7 +2,7 @@ import { useGraphQLMutation, useSDK, useSuspenseGraphQL } from '@stump/client'
 import { Alert, AlertDescription, Button, Heading, Text } from '@stump/components'
 import { graphql, MetadataResetImpact, UserPermission } from '@stump/graphql'
 import { Construction } from 'lucide-react'
-import { useCallback, useEffect } from 'react'
+import { Suspense, useCallback, useEffect } from 'react'
 import { useNavigate } from 'react-router'
 
 import { SceneContainer } from '@/components/container'
@@ -12,6 +12,7 @@ import { useAppContext } from '@/context'
 import paths from '@/paths'
 
 import { useSeriesContext } from '../../context'
+import SeriesTagEditor from './SeriesTagEditor'
 import SeriesThumbnailSelector from './SeriesThumbnailSelector'
 
 const query = graphql(`
@@ -19,6 +20,10 @@ const query = graphql(`
 		seriesById(id: $id) {
 			id
 			...SeriesThumbnailSelector
+			tags {
+				id
+				name
+			}
 			metadata {
 				...SeriesMetadataEditor
 			}
@@ -82,17 +87,43 @@ export default function SeriesSettingsScene() {
 					</AlertDescription>
 				</Alert>
 
-				<Button
-					title={data ? 'Analysis already in progress' : 'Analyze this series'}
-					size="md"
-					variant="primary"
-					onClick={handleAnalyze}
-					disabled={!!data || isPending}
-				>
-					Analyze series
-				</Button>
+				<div className="gap-y-2 flex flex-col">
+					<div>
+						<Heading size="sm">Analysis</Heading>
+						<Text size="sm" variant="muted">
+							Re-analyze this series to update metadata from its files
+						</Text>
+					</div>
 
-				<SeriesThumbnailSelector fragment={seriesById} />
+					<div>
+						<Button
+							title={data ? 'Analysis already in progress' : 'Analyze this series'}
+							size="md"
+							variant="primary"
+							onClick={handleAnalyze}
+							disabled={!!data || isPending}
+						>
+							Analyze series
+						</Button>
+					</div>
+				</div>
+
+				{checkPermission(UserPermission.EditMetadata) && (
+					<Suspense>
+						<SeriesTagEditor seriesId={seriesById.id} tags={seriesById.tags} />
+					</Suspense>
+				)}
+
+				<div className="gap-y-2 flex flex-col">
+					<div>
+						<Heading size="sm">Thumbnail</Heading>
+						<Text size="sm" variant="muted">
+							Change the cover image for this series
+						</Text>
+					</div>
+
+					<SeriesThumbnailSelector fragment={seriesById} />
+				</div>
 
 				<div className="gap-y-2 flex w-full flex-col">
 					<div className="flex items-end justify-between">

--- a/packages/browser/src/scenes/series/tabs/settings/SeriesTagEditor.tsx
+++ b/packages/browser/src/scenes/series/tabs/settings/SeriesTagEditor.tsx
@@ -1,0 +1,74 @@
+import { useGraphQLMutation, useSDK } from '@stump/client'
+import { Heading, Text } from '@stump/components'
+import { graphql, Tag } from '@stump/graphql'
+import { useQueryClient } from '@tanstack/react-query'
+import { useCallback } from 'react'
+import { toast } from 'sonner'
+
+import TagSelect, { TagOption } from '@/components/TagSelect'
+
+const mutation = graphql(`
+	mutation SeriesTagEditorSetTags($id: ID!, $tags: [String!]!) {
+		setSeriesTags(id: $id, tags: $tags) {
+			id
+			tags {
+				id
+				name
+			}
+		}
+	}
+`)
+
+type Props = {
+	seriesId: string
+	tags: Tag[]
+}
+
+export default function SeriesTagEditor({ seriesId, tags }: Props) {
+	const { sdk } = useSDK()
+	const client = useQueryClient()
+
+	const { mutate: setSeriesTags } = useGraphQLMutation(mutation, {
+		onSuccess: () => {
+			client.refetchQueries({
+				exact: false,
+				predicate: ({ queryKey }) =>
+					queryKey.includes(sdk.cacheKeys.seriesById) || queryKey.includes(sdk.cacheKeys.tags),
+			})
+		},
+		onError: (error) => {
+			console.error('Failed to update tags', error)
+			toast.error(String(error))
+		},
+	})
+
+	const selected: TagOption[] = tags.map((tag) => ({
+		label: tag.name,
+		value: tag.name.toLowerCase(),
+	}))
+
+	const handleChange = useCallback(
+		(newSelected?: TagOption[]) => {
+			setSeriesTags({
+				id: seriesId,
+				tags: (newSelected ?? []).map((t) => t.label),
+			})
+		},
+		[seriesId, setSeriesTags],
+	)
+
+	return (
+		<div className="gap-y-2 flex flex-col">
+			<div>
+				<Heading size="sm">Tags</Heading>
+				<Text size="sm" variant="muted">
+					Assign tags to this series
+				</Text>
+			</div>
+
+			<div className="max-w-sm">
+				<TagSelect label="" selected={selected} onChange={handleChange} />
+			</div>
+		</div>
+	)
+}

--- a/packages/graphql/src/client/gql.ts
+++ b/packages/graphql/src/client/gql.ts
@@ -232,9 +232,10 @@ type Documents = {
     "\n\tquery SeriesLibrayLink($id: ID!) {\n\t\tlibraryById(id: $id) {\n\t\t\tid\n\t\t\tname\n\t\t}\n\t}\n": typeof types.SeriesLibrayLinkDocument,
     "\n\tquery SeriesBooksScene(\n\t\t$filter: MediaFilterInput!\n\t\t$orderBy: [MediaOrderBy!]!\n\t\t$pagination: Pagination!\n\t) {\n\t\tmedia(filter: $filter, orderBy: $orderBy, pagination: $pagination) {\n\t\t\tnodes {\n\t\t\t\tid\n\t\t\t\t...BookCard\n\t\t\t\t...BookMetadata\n\t\t\t}\n\t\t\tpageInfo {\n\t\t\t\t__typename\n\t\t\t\t... on OffsetPaginationInfo {\n\t\t\t\t\tcurrentPage\n\t\t\t\t\ttotalPages\n\t\t\t\t\tpageSize\n\t\t\t\t\tpageOffset\n\t\t\t\t\tzeroBased\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n": typeof types.SeriesBooksSceneDocument,
     "\n\tquery SeriesBookGrid($id: String!, $pagination: Pagination) {\n\t\tmedia(filter: { seriesId: { eq: $id } }, pagination: $pagination) {\n\t\t\tnodes {\n\t\t\t\tid\n\t\t\t\tthumbnail {\n\t\t\t\t\turl\n\t\t\t\t}\n\t\t\t\tpages\n\t\t\t}\n\t\t\tpageInfo {\n\t\t\t\t__typename\n\t\t\t\t... on CursorPaginationInfo {\n\t\t\t\t\tcurrentCursor\n\t\t\t\t\tnextCursor\n\t\t\t\t\tlimit\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n": typeof types.SeriesBookGridDocument,
-    "\n\tquery SeriesSettingsScene($id: ID!) {\n\t\tseriesById(id: $id) {\n\t\t\tid\n\t\t\t...SeriesThumbnailSelector\n\t\t\tmetadata {\n\t\t\t\t...SeriesMetadataEditor\n\t\t\t}\n\t\t}\n\t}\n": typeof types.SeriesSettingsSceneDocument,
+    "\n\tquery SeriesSettingsScene($id: ID!) {\n\t\tseriesById(id: $id) {\n\t\t\tid\n\t\t\t...SeriesThumbnailSelector\n\t\t\ttags {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t}\n\t\t\tmetadata {\n\t\t\t\t...SeriesMetadataEditor\n\t\t\t}\n\t\t}\n\t}\n": typeof types.SeriesSettingsSceneDocument,
     "\n\tmutation SeriesSettingsSceneAnalyze($id: ID!) {\n\t\tanalyzeSeries(id: $id)\n\t}\n": typeof types.SeriesSettingsSceneAnalyzeDocument,
     "\n\tmutation SeriesSettingsSceneResetMetadata($id: ID!, $impact: MetadataResetImpact!) {\n\t\tresetSeriesMetadata(id: $id, impact: $impact) {\n\t\t\tid\n\t\t}\n\t}\n": typeof types.SeriesSettingsSceneResetMetadataDocument,
+    "\n\tmutation SeriesTagEditorSetTags($id: ID!, $tags: [String!]!) {\n\t\tsetSeriesTags(id: $id, tags: $tags) {\n\t\t\tid\n\t\t\ttags {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t}\n\t\t}\n\t}\n": typeof types.SeriesTagEditorSetTagsDocument,
     "\n\tfragment SeriesThumbnailSelector on Series {\n\t\tid\n\t\tthumbnail {\n\t\t\turl\n\t\t}\n\t}\n": typeof types.SeriesThumbnailSelectorFragmentDoc,
     "\n\tmutation SeriesThumbnailSelectorUpdate($id: ID!, $input: UpdateThumbnailInput!) {\n\t\tupdateSeriesThumbnail(id: $id, input: $input) {\n\t\t\tid\n\t\t\tthumbnail {\n\t\t\t\turl\n\t\t\t}\n\t\t}\n\t}\n": typeof types.SeriesThumbnailSelectorUpdateDocument,
     "\n\tmutation SeriesThumbnailSelectorUpload($id: ID!, $file: Upload!) {\n\t\tuploadSeriesThumbnail(id: $id, file: $file) {\n\t\t\tid\n\t\t\tthumbnail {\n\t\t\t\turl\n\t\t\t}\n\t\t}\n\t}\n": typeof types.SeriesThumbnailSelectorUploadDocument,
@@ -534,9 +535,10 @@ const documents: Documents = {
     "\n\tquery SeriesLibrayLink($id: ID!) {\n\t\tlibraryById(id: $id) {\n\t\t\tid\n\t\t\tname\n\t\t}\n\t}\n": types.SeriesLibrayLinkDocument,
     "\n\tquery SeriesBooksScene(\n\t\t$filter: MediaFilterInput!\n\t\t$orderBy: [MediaOrderBy!]!\n\t\t$pagination: Pagination!\n\t) {\n\t\tmedia(filter: $filter, orderBy: $orderBy, pagination: $pagination) {\n\t\t\tnodes {\n\t\t\t\tid\n\t\t\t\t...BookCard\n\t\t\t\t...BookMetadata\n\t\t\t}\n\t\t\tpageInfo {\n\t\t\t\t__typename\n\t\t\t\t... on OffsetPaginationInfo {\n\t\t\t\t\tcurrentPage\n\t\t\t\t\ttotalPages\n\t\t\t\t\tpageSize\n\t\t\t\t\tpageOffset\n\t\t\t\t\tzeroBased\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n": types.SeriesBooksSceneDocument,
     "\n\tquery SeriesBookGrid($id: String!, $pagination: Pagination) {\n\t\tmedia(filter: { seriesId: { eq: $id } }, pagination: $pagination) {\n\t\t\tnodes {\n\t\t\t\tid\n\t\t\t\tthumbnail {\n\t\t\t\t\turl\n\t\t\t\t}\n\t\t\t\tpages\n\t\t\t}\n\t\t\tpageInfo {\n\t\t\t\t__typename\n\t\t\t\t... on CursorPaginationInfo {\n\t\t\t\t\tcurrentCursor\n\t\t\t\t\tnextCursor\n\t\t\t\t\tlimit\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n": types.SeriesBookGridDocument,
-    "\n\tquery SeriesSettingsScene($id: ID!) {\n\t\tseriesById(id: $id) {\n\t\t\tid\n\t\t\t...SeriesThumbnailSelector\n\t\t\tmetadata {\n\t\t\t\t...SeriesMetadataEditor\n\t\t\t}\n\t\t}\n\t}\n": types.SeriesSettingsSceneDocument,
+    "\n\tquery SeriesSettingsScene($id: ID!) {\n\t\tseriesById(id: $id) {\n\t\t\tid\n\t\t\t...SeriesThumbnailSelector\n\t\t\ttags {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t}\n\t\t\tmetadata {\n\t\t\t\t...SeriesMetadataEditor\n\t\t\t}\n\t\t}\n\t}\n": types.SeriesSettingsSceneDocument,
     "\n\tmutation SeriesSettingsSceneAnalyze($id: ID!) {\n\t\tanalyzeSeries(id: $id)\n\t}\n": types.SeriesSettingsSceneAnalyzeDocument,
     "\n\tmutation SeriesSettingsSceneResetMetadata($id: ID!, $impact: MetadataResetImpact!) {\n\t\tresetSeriesMetadata(id: $id, impact: $impact) {\n\t\t\tid\n\t\t}\n\t}\n": types.SeriesSettingsSceneResetMetadataDocument,
+    "\n\tmutation SeriesTagEditorSetTags($id: ID!, $tags: [String!]!) {\n\t\tsetSeriesTags(id: $id, tags: $tags) {\n\t\t\tid\n\t\t\ttags {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t}\n\t\t}\n\t}\n": types.SeriesTagEditorSetTagsDocument,
     "\n\tfragment SeriesThumbnailSelector on Series {\n\t\tid\n\t\tthumbnail {\n\t\t\turl\n\t\t}\n\t}\n": types.SeriesThumbnailSelectorFragmentDoc,
     "\n\tmutation SeriesThumbnailSelectorUpdate($id: ID!, $input: UpdateThumbnailInput!) {\n\t\tupdateSeriesThumbnail(id: $id, input: $input) {\n\t\t\tid\n\t\t\tthumbnail {\n\t\t\t\turl\n\t\t\t}\n\t\t}\n\t}\n": types.SeriesThumbnailSelectorUpdateDocument,
     "\n\tmutation SeriesThumbnailSelectorUpload($id: ID!, $file: Upload!) {\n\t\tuploadSeriesThumbnail(id: $id, file: $file) {\n\t\t\tid\n\t\t\tthumbnail {\n\t\t\t\turl\n\t\t\t}\n\t\t}\n\t}\n": types.SeriesThumbnailSelectorUploadDocument,
@@ -1490,7 +1492,7 @@ export function graphql(source: "\n\tquery SeriesBookGrid($id: String!, $paginat
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
-export function graphql(source: "\n\tquery SeriesSettingsScene($id: ID!) {\n\t\tseriesById(id: $id) {\n\t\t\tid\n\t\t\t...SeriesThumbnailSelector\n\t\t\tmetadata {\n\t\t\t\t...SeriesMetadataEditor\n\t\t\t}\n\t\t}\n\t}\n"): typeof import('./graphql').SeriesSettingsSceneDocument;
+export function graphql(source: "\n\tquery SeriesSettingsScene($id: ID!) {\n\t\tseriesById(id: $id) {\n\t\t\tid\n\t\t\t...SeriesThumbnailSelector\n\t\t\ttags {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t}\n\t\t\tmetadata {\n\t\t\t\t...SeriesMetadataEditor\n\t\t\t}\n\t\t}\n\t}\n"): typeof import('./graphql').SeriesSettingsSceneDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
@@ -1499,6 +1501,10 @@ export function graphql(source: "\n\tmutation SeriesSettingsSceneAnalyze($id: ID
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(source: "\n\tmutation SeriesSettingsSceneResetMetadata($id: ID!, $impact: MetadataResetImpact!) {\n\t\tresetSeriesMetadata(id: $id, impact: $impact) {\n\t\t\tid\n\t\t}\n\t}\n"): typeof import('./graphql').SeriesSettingsSceneResetMetadataDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n\tmutation SeriesTagEditorSetTags($id: ID!, $tags: [String!]!) {\n\t\tsetSeriesTags(id: $id, tags: $tags) {\n\t\t\tid\n\t\t\ttags {\n\t\t\t\tid\n\t\t\t\tname\n\t\t\t}\n\t\t}\n\t}\n"): typeof import('./graphql').SeriesTagEditorSetTagsDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/graphql/src/client/graphql.ts
+++ b/packages/graphql/src/client/graphql.ts
@@ -2114,6 +2114,11 @@ export type Mutation = {
   setMediaTags: Media;
   /** Set the locked metadata fields for a series */
   setSeriesLockedFields: Series;
+  /**
+   * Set the tags for a series. Creates any tags that don't exist yet, links new ones,
+   * and unlinks removed ones. Returns the updated series.
+   */
+  setSeriesTags: Series;
   /** Suggest a book for the book club */
   suggestBook: BookClubBookSuggestion;
   /** Send a test email to verify the SMTP configuration is working */
@@ -2725,6 +2730,12 @@ export type MutationSetMediaTagsArgs = {
 export type MutationSetSeriesLockedFieldsArgs = {
   lockedFields: Array<MetadataField>;
   seriesId: Scalars['ID']['input'];
+};
+
+
+export type MutationSetSeriesTagsArgs = {
+  id: Scalars['ID']['input'];
+  tags: Array<Scalars['String']['input']>;
 };
 
 

--- a/packages/graphql/src/client/graphql.ts
+++ b/packages/graphql/src/client/graphql.ts
@@ -6271,7 +6271,7 @@ export type SeriesSettingsSceneQueryVariables = Exact<{
 
 
 export type SeriesSettingsSceneQuery = { __typename?: 'Query', seriesById?: (
-    { __typename?: 'Series', id: string, metadata?: (
+    { __typename?: 'Series', id: string, tags: Array<{ __typename?: 'Tag', id: number, name: string }>, metadata?: (
       { __typename?: 'SeriesMetadata' }
       & { ' $fragmentRefs'?: { 'SeriesMetadataEditorFragment': SeriesMetadataEditorFragment } }
     ) | null }
@@ -6292,6 +6292,14 @@ export type SeriesSettingsSceneResetMetadataMutationVariables = Exact<{
 
 
 export type SeriesSettingsSceneResetMetadataMutation = { __typename?: 'Mutation', resetSeriesMetadata: { __typename?: 'Series', id: string } };
+
+export type SeriesTagEditorSetTagsMutationVariables = Exact<{
+  id: Scalars['ID']['input'];
+  tags: Array<Scalars['String']['input']> | Scalars['String']['input'];
+}>;
+
+
+export type SeriesTagEditorSetTagsMutation = { __typename?: 'Mutation', setSeriesTags: { __typename?: 'Series', id: string, tags: Array<{ __typename?: 'Tag', id: number, name: string }> } };
 
 export type SeriesThumbnailSelectorFragment = { __typename?: 'Series', id: string, thumbnail: { __typename?: 'ImageRef', url: string } } & { ' $fragmentName'?: 'SeriesThumbnailSelectorFragment' };
 
@@ -12179,6 +12187,10 @@ export const SeriesSettingsSceneDocument = new TypedDocumentString(`
   seriesById(id: $id) {
     id
     ...SeriesThumbnailSelector
+    tags {
+      id
+      name
+    }
     metadata {
       ...SeriesMetadataEditor
     }
@@ -12230,6 +12242,17 @@ export const SeriesSettingsSceneResetMetadataDocument = new TypedDocumentString(
   }
 }
     `) as unknown as TypedDocumentString<SeriesSettingsSceneResetMetadataMutation, SeriesSettingsSceneResetMetadataMutationVariables>;
+export const SeriesTagEditorSetTagsDocument = new TypedDocumentString(`
+    mutation SeriesTagEditorSetTags($id: ID!, $tags: [String!]!) {
+  setSeriesTags(id: $id, tags: $tags) {
+    id
+    tags {
+      id
+      name
+    }
+  }
+}
+    `) as unknown as TypedDocumentString<SeriesTagEditorSetTagsMutation, SeriesTagEditorSetTagsMutationVariables>;
 export const SeriesThumbnailSelectorUpdateDocument = new TypedDocumentString(`
     mutation SeriesThumbnailSelectorUpdate($id: ID!, $input: UpdateThumbnailInput!) {
   updateSeriesThumbnail(id: $id, input: $input) {


### PR DESCRIPTION
## Summary

 - Add `setSeriesTags` mutation to assign tags to series (guarded behind `EditMetadata`)
 - Add tag editor to the series settings page

## Screenshots

<img width="2580" height="1590" alt="image" src="https://github.com/user-attachments/assets/f9586432-3a59-403c-ab7c-5e7f4a7fffa3" />

## Context

Series equivalent to #1077 