### PR TITLE
🐛 Mark EPUB as 100% complete when reaching the final page

### DIFF
--- a/packages/browser/src/components/readers/epub/EpubJsReader.tsx
+++ b/packages/browser/src/components/readers/epub/EpubJsReader.tsx
@@ -328,6 +328,13 @@ export default function EpubJsReader({ id, isIncognito }: EpubJsReaderProps) {
 				percentageCompleted = computeNaiveProgress(location)
 			}
 
+			// epubjs's percentageFromCfi uses start.cfi; on the final page this still
+			// returns <1.0 (e.g. ~0.98) even when the reader has seen everything. Clamp
+			// to 1.0 when epubjs signals atEnd so completion is persisted correctly.
+			if (location.atEnd) {
+				percentageCompleted = 1.0
+			}
+
 			if (percentageCompleted == null) {
 				console.warn('Failed to compute any percentage-based progress')
 				return


### PR DESCRIPTION
## Summary

Fixes #795.

EPUBs would stop at ~99% when the user reached the final page, so the book was never marked as finished. The root cause is that `computeProgress` passes `location.start.cfi` to epubjs's `percentageFromCfi`, and on the final page the start CFI maps to a location strictly before the last indexed location — returning something like `0.9958` rather than `1.0`. The existing completion gate (`isComplete: percentageCompleted >= 1.0`) never fires.

This PR clamps `percentageCompleted` to `1.0` when epubjs signals `location.atEnd`. epubjs sets `atEnd` only when the user is on the last displayed page of the last spine item (see `rendition.js` in epubjs — the condition is `end.index === spine.last().index && end.displayed.page >= end.displayed.total`), so it's safe to treat as an authoritative "final page of the book" signal.

## Verification

Reproduced the bug and confirmed the fix against a real EPUB (Project Gutenberg's _Aesop's Fables_, 122 pages) in a local dev stack.

**Before the patch** — active `reading_sessions` row stuck at:

```
percentage_completed = 0.9958071278826
finished_reading_sessions: (none)
```

**After the patch** — the active session is cleared and a `finished_reading_sessions` row is inserted with `completed_at` set, which matches the expected flow in `update_media_progress` (`crates/graphql/src/mutation/media.rs`).

## Notes for reviewers

- Placement is intentionally before the final null-guard so that `atEnd` still forces completion even if all CFI-based paths returned null.
- Scope is deliberately limited to the web EPUB reader (epubjs). The mobile reader uses Readium, which has a different completion model and isn't affected.
- No tests added — `EpubJsReader.tsx` doesn't have a colocated test file and spinning up jsdom + epubjs for one conditional felt out of proportion. Happy to add one if preferred.