### PR TITLE
:globe_with_meridians: Localize remaining keys for app appearance settings

### DIFF
--- a/packages/browser/src/scenes/settings/app/preferences/MaxWidthPreference.tsx
+++ b/packages/browser/src/scenes/settings/app/preferences/MaxWidthPreference.tsx
@@ -3,36 +3,21 @@ import { useLocaleContext } from '@stump/i18n'
 
 import { usePreferences } from '@/hooks'
 
-const OPTIONS = [
-	{ label: 'No limit', value: 0 },
-	{
-		label: '1152px',
-		value: 1152,
-	},
-	{
-		label: '1280px',
-		value: 1280,
-	},
-	{
-		label: '1440px',
-		value: 1440,
-	},
-	{
-		label: '1600px',
-		value: 1600,
-	},
-	{
-		label: '1920px',
-		value: 1920,
-	},
-]
-
 export default function MaxWidthPreference() {
 	const { t } = useLocaleContext()
 	const {
 		preferences: { layoutMaxWidthPx, primaryNavigationMode },
 		update,
 	} = usePreferences()
+
+	const options = [
+		{ label: t(getKey('options.noLimit')), value: 0 },
+		{ label: '1152px', value: 1152 },
+		{ label: '1280px', value: 1280 },
+		{ label: '1440px', value: 1440 },
+		{ label: '1600px', value: 1600 },
+		{ label: '1920px', value: 1920 },
+	]
 
 	const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
 		const value = e.target.value
@@ -43,7 +28,7 @@ export default function MaxWidthPreference() {
 
 		// TODO: support custom
 		const parsed = parseInt(value)
-		if (!isNaN(parsed) && OPTIONS.some((opt) => opt.value === parsed)) {
+		if (!isNaN(parsed) && options.some((opt) => opt.value === parsed)) {
 			return update({ layoutMaxWidthPx: parsed })
 		}
 
@@ -65,7 +50,7 @@ export default function MaxWidthPreference() {
 			</Label>
 			<NativeSelect
 				value={layoutMaxWidthPx || undefined}
-				options={OPTIONS}
+				options={options}
 				onChange={handleChange}
 				disabled={primaryNavigationMode === 'SIDEBAR'}
 			/>

--- a/packages/browser/src/scenes/settings/app/preferences/ThumbnailRatioSelect.tsx
+++ b/packages/browser/src/scenes/settings/app/preferences/ThumbnailRatioSelect.tsx
@@ -3,12 +3,6 @@ import { useLocaleContext } from '@stump/i18n'
 
 import { usePreferences } from '@/hooks'
 
-const OPTIONS = [
-	{ label: '1 : 1.6', value: 1 / 1.6 },
-	{ label: '1 : 1.5 (Default)', value: 1 / 1.5 },
-	{ label: '1 : √2', value: 1 / 1.414 },
-]
-
 export default function ThumbnailRatioSelect() {
 	const { t } = useLocaleContext()
 	const {
@@ -16,20 +10,26 @@ export default function ThumbnailRatioSelect() {
 		update,
 	} = usePreferences()
 
+	const options = [
+		{ label: '1 : 1.6', value: 1 / 1.6 },
+		{ label: `1 : 1.5 (${t(getKey('defaultSuffix'))})`, value: 1 / 1.5 },
+		{ label: '1 : √2', value: 1 / 1.414 },
+	]
+
 	const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
 		const value = e.target.value
 		return update({ thumbnailRatio: Number(value) })
 	}
 
 	// Sidestep any precision issues with the stored thumbnailRatio value
-	const closestOption = OPTIONS.reduce((prev, curr) =>
+	const closestOption = options.reduce((prev, curr) =>
 		Math.abs(curr.value - thumbnailRatio) < Math.abs(prev.value - thumbnailRatio) ? curr : prev,
 	)
 
 	return (
 		<div className="gap-y-1.5 md:max-w-md flex flex-col">
 			<Label>{t(getKey('label'))}</Label>
-			<NativeSelect value={closestOption.value} options={OPTIONS} onChange={handleChange} />
+			<NativeSelect value={closestOption.value} options={options} onChange={handleChange} />
 			<Text size="xs" variant="muted">
 				{t(getKey('description'))}
 			</Text>

--- a/packages/browser/src/scenes/settings/app/preferences/navigation-arrangement/NavigationArrangement.tsx
+++ b/packages/browser/src/scenes/settings/app/preferences/navigation-arrangement/NavigationArrangement.tsx
@@ -198,7 +198,7 @@ export default function NavigationArrangement() {
 
 	const renderLockedButton = () => {
 		const Icon = locked ? Lock : Unlock
-		const help = locked ? 'Unlock arrangement' : 'Lock arrangement'
+		const help = locked ? t(getKey('unlock')) : t(getKey('lock'))
 
 		return (
 			<ToolTip content={help} align="end" size="sm">

--- a/packages/i18n/src/locales/en-US.json
+++ b/packages/i18n/src/locales/en-US.json
@@ -1437,7 +1437,8 @@
 				},
 				"thumbnailRatioSelect": {
 					"label": "Thumbnail Ratio",
-					"description": "The aspect ratio to use for thumbnails"
+					"description": "The aspect ratio to use for thumbnails",
+					"defaultSuffix": "Default"
 				},
 				"thumbnailPlaceholder": {
 					"label": "Thumbnail placeholder",
@@ -1513,7 +1514,10 @@
 				"maxWidthPreference": {
 					"label": "Adjusted width",
 					"description": "Stump applies a max-width to the viewport. This setting allows you to adjust or remove this limit",
-					"tooltip": "This setting is not currently supported when the primary navigation is set to sidebar"
+					"tooltip": "This setting is not currently supported when the primary navigation is set to sidebar",
+					"options": {
+						"noLimit": "No limit"
+					}
 				},
 				"additionalPreferences": {
 					"label": "Additional preferences",


### PR DESCRIPTION
Closes #541

## Summary

Replaces hardcoded English strings in the app preferences scene with translation keys so Crowdin can surface them to translators.

- `NavigationArrangement.tsx` — wires the lock tooltip to the existing `navigationArrangement.lock` / `navigationArrangement.unlock` keys (no new keys needed; they were already in `en-US.json` but the component wasn't using them). Several non-English locales like `fr-FR` already have translations for these keys — they were just sitting unused until now.
- `MaxWidthPreference.tsx` — translates `"No limit"`; numeric pixel labels (`1152px`, etc.) intentionally left as-is since they're universal
- `ThumbnailRatioSelect.tsx` — translates the `"(Default)"` suffix; numeric ratio labels (`1 : 1.6`, etc.) intentionally left as-is

## New keys added to `en-US.json`

- `settingsScene.app/preferences.sections.thumbnailRatioSelect.defaultSuffix` → `"Default"`
- `settingsScene.app/preferences.sections.maxWidthPreference.options.noLimit` → `"No limit"`

Other locale files are not touched — they fall back to the English source via `parseMissingKeyHandler` in `packages/i18n/src/config.ts` until Crowdin translators fill them in.

## Test plan

Verified locally against a fresh dev instance (`yarn web dev` + `cargo run -p stump_server`):

- [x] Preferences page renders with English strings as before
- [x] NavigationArrangement lock button renders `"Unlock arrangement"` in English; `"Déverrouiller la disposition"` in French (`fr-FR`) — confirming the existing translation is now being surfaced
- [x] MaxWidthPreference dropdown first option reads `"No limit"` in English; falls back cleanly to `"No limit"` in `fr-FR` (no raw key path rendered)
- [x] ThumbnailRatioSelect shows `"1 : 1.5 (Default)"` in English; falls back cleanly in `fr-FR`
- [x] Non-English locale does not leak any raw key paths (`settingsScene.*` strings) — snapshot grep returned 0 matches