### PR TITLE
:sparkles: Intake tags from ComicInfo.xml during scans

### DIFF
--- a/core/src/filesystem/media/builder.rs
+++ b/core/src/filesystem/media/builder.rs
@@ -31,6 +31,10 @@ pub struct MediaBuilder {
 pub struct BuiltMedia {
 	pub media: media::ActiveModel,
 	pub metadata: Option<media_metadata::ActiveModel>,
+	/// Tag names extracted from the file's metadata (e.g. ComicInfo.xml `<Tags>`).
+	/// Applied additively to `media_tags` during create/update so user-assigned tags
+	/// are never removed by a rescan.
+	pub tags: Vec<String>,
 }
 
 impl BuiltMedia {
@@ -72,6 +76,7 @@ impl MediaBuilder {
 				media_id: Set(Some(media.media.id.clone())),
 				..meta
 			}),
+			tags: generated.tags,
 		})
 	}
 
@@ -104,25 +109,29 @@ impl MediaBuilder {
 
 		let id = Uuid::new_v4().to_string();
 		let pages = processed_entry.pages;
-		let mut resolved_metadata = None;
+		let (resolved_metadata, resolved_tags) = processed_entry
+			.metadata
+			.map(|mut metadata| {
+				let conflicting_page_counts =
+					metadata.page_count.is_some_and(|count| count != pages);
+				if conflicting_page_counts {
+					tracing::warn!(
+						?pages,
+						?metadata.page_count,
+						"Page count in metadata does not match actual page count!"
+					);
+					metadata.page_count = Some(pages);
+				}
 
-		if let Some(mut metadata) = processed_entry.metadata {
-			let conflicting_page_counts =
-				metadata.page_count.is_some_and(|count| count != pages);
-			if conflicting_page_counts {
-				tracing::warn!(
-					?pages,
-					?metadata.page_count,
-					"Page count in metadata does not match actual page count!"
-				);
-				metadata.page_count = Some(pages);
-			}
+				let tags = metadata.tags.take().unwrap_or_default();
 
-			resolved_metadata = Some(media_metadata::ActiveModel {
-				media_id: Set(Some(id.clone())),
-				..metadata.into_active_model()
-			});
-		}
+				let active = media_metadata::ActiveModel {
+					media_id: Set(Some(id.clone())),
+					..metadata.into_active_model()
+				};
+				(Some(active), tags)
+			})
+			.unwrap_or_default();
 
 		let media = media::ActiveModel {
 			id: Set(id),
@@ -141,6 +150,7 @@ impl MediaBuilder {
 		Ok(BuiltMedia {
 			media,
 			metadata: resolved_metadata,
+			tags: resolved_tags,
 		})
 	}
 

--- a/core/src/filesystem/media/metadata.rs
+++ b/core/src/filesystem/media/metadata.rs
@@ -20,8 +20,6 @@ const NAIVE_DATE_FORMATS: [&str; 2] = ["%Y-%m-%d", "%m-%d-%Y"];
 // NOTE: alias is used primarily to support ComicInfo.xml files, as that metadata
 // is formatted in PascalCase
 
-// TODO: Intake tags
-
 /// Struct representing the metadata for a processed file.
 #[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize, Default, Merge)]
@@ -92,6 +90,14 @@ pub struct ProcessedMediaMetadata {
 		default = "Option::default"
 	)]
 	pub genres: Option<Vec<String>>,
+	/// The tag(s) the media belongs to. Unlike genres, these are stored as first-class
+	/// `Tag` entities and linked to the media via the `media_tags` junction table.
+	#[serde(
+		alias = "Tags",
+		deserialize_with = "string_list_deserializer",
+		default = "Option::default"
+	)]
+	pub tags: Option<Vec<String>>,
 	/// The language of the media
 	#[serde(alias = "Language")]
 	pub language: Option<String>,
@@ -284,6 +290,19 @@ impl From<HashMap<String, Vec<String>>> for ProcessedMediaMetadata {
 				"genre" | "genres" | "subject" | "subjects" => {
 					metadata.genres = Some(value)
 				},
+				"tag" | "tags" => {
+					metadata.tags = Some(
+						value
+							.into_iter()
+							.flat_map(|v| {
+								v.split(',')
+									.map(|s| s.trim().to_owned())
+									.collect::<Vec<_>>()
+							})
+							.filter(|s| !s.is_empty())
+							.collect(),
+					)
+				},
 				"year" => {
 					metadata.year = value.into_iter().next().and_then(|n| n.parse().ok());
 				},
@@ -448,6 +467,10 @@ mod tests {
 			"Summary".to_string(),
 			vec![String::from("A book, you know?")],
 		);
+		map.insert(
+			"tags".to_string(),
+			vec![String::from("epic"), String::from("high-fantasy")],
+		);
 
 		let metadata = ProcessedMediaMetadata::from(map);
 
@@ -460,7 +483,35 @@ mod tests {
 		assert_eq!(metadata.month, Some(8));
 		assert_eq!(metadata.day, Some(31));
 		assert_eq!(metadata.genres, Some(vec!["Fantasy".to_string()]));
+		assert_eq!(
+			metadata.tags,
+			Some(vec!["epic".to_string(), "high-fantasy".to_string()])
+		);
 		assert_eq!(metadata.summary, Some("A book, you know?".to_string()));
+	}
+
+	#[test]
+	fn test_from_hashmap_splits_comma_separated_tags() {
+		let mut map = HashMap::new();
+		map.insert(
+			"tags".to_string(),
+			vec![
+				String::from("epic, high-fantasy"),
+				String::from("  standalone "),
+				String::from(""),
+			],
+		);
+
+		let metadata = ProcessedMediaMetadata::from(map);
+
+		assert_eq!(
+			metadata.tags,
+			Some(vec![
+				"epic".to_string(),
+				"high-fantasy".to_string(),
+				"standalone".to_string(),
+			])
+		);
 	}
 
 	#[test]

--- a/core/src/filesystem/media/utils.rs
+++ b/core/src/filesystem/media/utils.rs
@@ -136,4 +136,33 @@ mod tests {
 		assert_eq!(metadata.number, None);
 		assert_eq!(metadata.volume, None);
 	}
+
+	#[test]
+	fn test_should_parse_comic_info_tags() {
+		let contents = r#"<?xml version="1.0"?>
+<ComicInfo>
+  <Title>Test Comic</Title>
+  <Tags>superhero, origin story, dark</Tags>
+</ComicInfo>"#;
+		let metadata = metadata_from_buf(contents).expect("should parse");
+		assert_eq!(
+			metadata.tags,
+			Some(vec![
+				"superhero".to_string(),
+				"origin story".to_string(),
+				"dark".to_string(),
+			])
+		);
+	}
+
+	#[test]
+	fn test_should_parse_comic_info_with_empty_tags_element() {
+		let contents = r#"<?xml version="1.0"?>
+<ComicInfo>
+  <Title>Test Comic</Title>
+  <Tags></Tags>
+</ComicInfo>"#;
+		let metadata = metadata_from_buf(contents).expect("should parse");
+		assert_eq!(metadata.tags, None);
+	}
 }

--- a/core/src/filesystem/scanner/options.rs
+++ b/core/src/filesystem/scanner/options.rs
@@ -161,6 +161,7 @@ mod tests {
 				..Default::default()
 			},
 			metadata: None,
+			tags: Vec::new(),
 		};
 
 		let result = BookVisitResult::Built(Box::new(book.clone()));

--- a/core/src/filesystem/scanner/utils.rs
+++ b/core/src/filesystem/scanner/utils.rs
@@ -1022,3 +1022,192 @@ pub(crate) async fn visit_and_update_media(
 
 	Ok(output)
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use ::tests::db::test_database;
+	use ::tests::fake_data;
+	use sea_orm::{ActiveModelTrait, EntityTrait, QueryOrder};
+
+	fn built_media(id: &str, series_id: &str, tags: Vec<String>) -> BuiltMedia {
+		BuiltMedia {
+			media: media::ActiveModel {
+				id: Set(id.to_string()),
+				name: Set(format!("{id}.cbz")),
+				size: Set(100),
+				extension: Set("cbz".to_string()),
+				pages: Set(1),
+				path: Set(format!("/tmp/{id}.cbz")),
+				series_id: Set(Some(series_id.to_string())),
+				..Default::default()
+			},
+			metadata: None,
+			tags,
+		}
+	}
+
+	async fn fetch_tag_names_for(db: &DatabaseConnection, media_id: &str) -> Vec<String> {
+		let mut names: Vec<String> = tag::Entity::find_for_media_id(media_id)
+			.all(db)
+			.await
+			.expect("tag query failed")
+			.into_iter()
+			.map(|t| t.name)
+			.collect();
+		names.sort();
+		names
+	}
+
+	async fn count_media_tag_rows(db: &DatabaseConnection, media_id: &str) -> usize {
+		media_tag::Entity::find()
+			.filter(media_tag::Column::MediaId.eq(media_id))
+			.all(db)
+			.await
+			.expect("media_tag query failed")
+			.len()
+	}
+
+	// Scenario 1: a fresh scan of a CBZ with ComicInfo `<Tags>action, drama</Tags>` lands
+	// both tags on the book as first-class `tag` rows linked via `media_tags`.
+	#[tokio::test]
+	async fn test_scan_intakes_comicinfo_tags() {
+		let db = test_database().await;
+		let series = fake_data::Series::default().insert(&db).await;
+
+		create_media(
+			&db,
+			built_media(
+				"book-1",
+				&series.id,
+				vec!["action".to_string(), "drama".to_string()],
+			),
+		)
+		.await
+		.expect("create_media failed");
+
+		assert_eq!(
+			fetch_tag_names_for(&db, "book-1").await,
+			vec!["action".to_string(), "drama".to_string()],
+		);
+		assert_eq!(count_media_tag_rows(&db, "book-1").await, 2);
+	}
+
+	// Scenario 2: a tag added through the UI must survive a rescan. We simulate the UI
+	// path by inserting a tag + link directly, then running update_media with scan-derived
+	// tags that don't include the user's tag.
+	#[tokio::test]
+	async fn test_rescan_preserves_user_assigned_tags() {
+		let db = test_database().await;
+		let series = fake_data::Series::default().insert(&db).await;
+
+		// Initial scan pulls in "action".
+		create_media(
+			&db,
+			built_media("book-2", &series.id, vec!["action".to_string()]),
+		)
+		.await
+		.expect("create_media failed");
+
+		// User adds "my-favorite" through the UI.
+		let user_tag = tag::ActiveModel {
+			name: Set("my-favorite".to_string()),
+			..Default::default()
+		}
+		.insert(&db)
+		.await
+		.expect("tag insert failed");
+		media_tag::ActiveModel {
+			media_id: Set("book-2".to_string()),
+			tag_id: Set(user_tag.id),
+			..Default::default()
+		}
+		.insert(&db)
+		.await
+		.expect("media_tag insert failed");
+
+		// Rescan delivers "action" again plus a newly-added "drama" from updated metadata.
+		update_media(
+			&db,
+			built_media(
+				"book-2",
+				&series.id,
+				vec!["action".to_string(), "drama".to_string()],
+			),
+		)
+		.await
+		.expect("update_media failed");
+
+		assert_eq!(
+			fetch_tag_names_for(&db, "book-2").await,
+			vec![
+				"action".to_string(),
+				"drama".to_string(),
+				"my-favorite".to_string(),
+			],
+			"user-assigned tag must survive rescan",
+		);
+		assert_eq!(count_media_tag_rows(&db, "book-2").await, 3);
+	}
+
+	// Scenario 3: rescanning a file whose ComicInfo tags haven't changed is idempotent —
+	// no duplicate `tag` rows, no duplicate `media_tags` rows.
+	#[tokio::test]
+	async fn test_rescan_is_idempotent_for_unchanged_tags() {
+		let db = test_database().await;
+		let series = fake_data::Series::default().insert(&db).await;
+
+		let initial = vec!["action".to_string(), "drama".to_string()];
+		create_media(&db, built_media("book-3", &series.id, initial.clone()))
+			.await
+			.expect("create_media failed");
+
+		update_media(&db, built_media("book-3", &series.id, initial))
+			.await
+			.expect("update_media failed");
+
+		assert_eq!(count_media_tag_rows(&db, "book-3").await, 2);
+
+		let all_tags = tag::Entity::find()
+			.order_by_asc(tag::Column::Name)
+			.all(&db)
+			.await
+			.expect("tag query failed");
+		assert_eq!(
+			all_tags.into_iter().map(|t| t.name).collect::<Vec<_>>(),
+			vec!["action".to_string(), "drama".to_string()],
+			"no duplicate tag rows should be created",
+		);
+	}
+
+	// A tag that already exists (from another book) should be reused rather than duplicated.
+	#[tokio::test]
+	async fn test_existing_tag_is_reused_across_books() {
+		let db = test_database().await;
+		let series = fake_data::Series::default().insert(&db).await;
+
+		create_media(
+			&db,
+			built_media("book-a", &series.id, vec!["shared".to_string()]),
+		)
+		.await
+		.expect("create_media failed");
+
+		create_media(
+			&db,
+			built_media("book-b", &series.id, vec!["shared".to_string()]),
+		)
+		.await
+		.expect("create_media failed");
+
+		let tag_count = tag::Entity::find()
+			.filter(tag::Column::Name.eq("shared"))
+			.all(&db)
+			.await
+			.expect("tag query failed")
+			.len();
+		assert_eq!(tag_count, 1, "shared tag should not be duplicated");
+		assert_eq!(count_media_tag_rows(&db, "book-a").await, 1);
+		assert_eq!(count_media_tag_rows(&db, "book-b").await, 1);
+	}
+}

--- a/core/src/filesystem/scanner/utils.rs
+++ b/core/src/filesystem/scanner/utils.rs
@@ -1,5 +1,5 @@
 use std::{
-	collections::{HashMap, VecDeque},
+	collections::{HashMap, HashSet, VecDeque},
 	path::{Path, PathBuf},
 	sync::{
 		atomic::{AtomicUsize, Ordering},
@@ -11,13 +11,14 @@ use std::{
 use chrono::{DateTime, Utc};
 use futures::{stream::FuturesUnordered, StreamExt};
 use models::{
-	entity::{library_config, media, media_metadata, series},
+	entity::{library_config, media, media_metadata, media_tag, series, tag},
 	shared::enums::FileStatus,
 };
 use sea_orm::{
 	prelude::*,
 	sea_query::{OnConflict, Query},
-	Condition, DatabaseConnection, IntoActiveModel, Iterable, Set, TransactionTrait,
+	Condition, DatabaseConnection, DatabaseTransaction, IntoActiveModel, Iterable, Set,
+	TransactionTrait,
 };
 use tokio::{sync::oneshot, task::spawn_blocking};
 use walkdir::DirEntry;
@@ -73,7 +74,11 @@ pub(crate) fn file_updated_since_scan(
 
 pub(crate) async fn create_media(
 	db: &DatabaseConnection,
-	BuiltMedia { media, metadata }: BuiltMedia,
+	BuiltMedia {
+		media,
+		metadata,
+		tags,
+	}: BuiltMedia,
 ) -> CoreResult<media::Model> {
 	let txn = db.begin().await?;
 
@@ -83,6 +88,8 @@ pub(crate) async fn create_media(
 		meta.insert(&txn).await?;
 	}
 
+	ensure_tags_linked(&txn, &created_media.id, &tags).await?;
+
 	txn.commit().await?;
 
 	Ok(created_media)
@@ -90,7 +97,11 @@ pub(crate) async fn create_media(
 
 pub(crate) async fn update_media(
 	db: &DatabaseConnection,
-	BuiltMedia { media, metadata }: BuiltMedia,
+	BuiltMedia {
+		media,
+		metadata,
+		tags,
+	}: BuiltMedia,
 ) -> CoreResult<media::Model> {
 	let txn = db.begin().await?;
 
@@ -106,9 +117,89 @@ pub(crate) async fn update_media(
 			.await?;
 	}
 
+	ensure_tags_linked(&txn, &updated_media.id, &tags).await?;
+
 	txn.commit().await?;
 
 	Ok(updated_media)
+}
+
+/// Ensure each tag name in `tag_names` exists in the `tags` table and is linked to
+/// `media_id` via `media_tags`. Creates tags that don't yet exist and adds missing
+/// links; never removes existing links.
+///
+/// This is used during scans to intake tags from file metadata (e.g. ComicInfo.xml
+/// `<Tags>`) without clobbering tags the user has manually assigned through the UI.
+pub(crate) async fn ensure_tags_linked(
+	txn: &DatabaseTransaction,
+	media_id: &str,
+	tag_names: &[String],
+) -> CoreResult<()> {
+	let desired: HashSet<String> = tag_names
+		.iter()
+		.filter(|n| !n.is_empty())
+		.cloned()
+		.collect();
+	if desired.is_empty() {
+		return Ok(());
+	}
+
+	let already_linked: Vec<tag::Model> =
+		tag::Entity::find_for_media_id(media_id).all(txn).await?;
+	let already_linked_names: HashSet<&str> =
+		already_linked.iter().map(|t| t.name.as_str()).collect();
+
+	let to_link: Vec<String> = desired
+		.into_iter()
+		.filter(|n| !already_linked_names.contains(n.as_str()))
+		.collect();
+	if to_link.is_empty() {
+		return Ok(());
+	}
+
+	let existing_unlinked: Vec<tag::Model> = tag::Entity::find()
+		.filter(tag::Column::Name.is_in(to_link.clone()))
+		.all(txn)
+		.await?;
+	let existing_unlinked_names: HashSet<&str> =
+		existing_unlinked.iter().map(|t| t.name.as_str()).collect();
+
+	let to_create: Vec<tag::ActiveModel> = to_link
+		.iter()
+		.filter(|n| !existing_unlinked_names.contains(n.as_str()))
+		.map(|name| tag::ActiveModel {
+			name: Set(name.clone()),
+			..Default::default()
+		})
+		.collect();
+
+	let created = if to_create.is_empty() {
+		Vec::new()
+	} else {
+		tag::Entity::insert_many(to_create)
+			.exec_with_returning_many(txn)
+			.await?
+	};
+
+	let new_link_ids: Vec<i32> = existing_unlinked
+		.iter()
+		.map(|t| t.id)
+		.chain(created.iter().map(|t| t.id))
+		.collect();
+
+	if !new_link_ids.is_empty() {
+		media_tag::Entity::insert_many(new_link_ids.into_iter().map(|tag_id| {
+			media_tag::ActiveModel {
+				media_id: Set(media_id.to_string()),
+				tag_id: Set(tag_id),
+				..Default::default()
+			}
+		}))
+		.exec(txn)
+		.await?;
+	}
+
+	Ok(())
 }
 
 pub(crate) async fn handle_book_visit_operation(
@@ -117,12 +208,17 @@ pub(crate) async fn handle_book_visit_operation(
 ) -> CoreResult<()> {
 	match result {
 		BookVisitResult::Custom(custom) => {
-			if let Some(meta) = custom.meta {
+			if let Some(mut meta) = custom.meta {
+				let tags = meta.tags.take().unwrap_or_default();
+
+				let txn = db.begin().await?;
 				let active_model = media_metadata::ActiveModel {
 					media_id: Set(Some(custom.id.clone())),
 					..meta.into_active_model()
 				};
-				let updated_meta = active_model.update(db).await?;
+				let updated_meta = active_model.update(&txn).await?;
+				ensure_tags_linked(&txn, &custom.id, &tags).await?;
+				txn.commit().await?;
 
 				tracing::trace!(?updated_meta, "Metadata upserted");
 			}

--- a/crates/tests/src/db.rs
+++ b/crates/tests/src/db.rs
@@ -1,7 +1,7 @@
 use models::entity::{
 	finished_reading_session, kobo_sync_session, library, library_exclusion, media,
-	media_metadata, reading_session, registered_reading_device, series, series_metadata,
-	user, user_preferences,
+	media_metadata, media_tag, reading_session, registered_reading_device, series,
+	series_metadata, tag, user, user_preferences,
 };
 use sea_orm::{ConnectionTrait, Database, DbBackend, DbConn, DbErr, Schema};
 pub async fn test_database() -> DbConn {
@@ -32,6 +32,8 @@ pub async fn create_database_tables(db: &DbConn) -> Result<(), DbErr> {
 		schema.create_table_from_entity(reading_session::Entity),
 		schema.create_table_from_entity(finished_reading_session::Entity),
 		schema.create_table_from_entity(registered_reading_device::Entity),
+		schema.create_table_from_entity(tag::Entity),
+		schema.create_table_from_entity(media_tag::Entity),
 	];
 
 	for stmt in tables {


### PR DESCRIPTION
## Summary

Closes #651.

Library scans now pick up the `<Tags>` element from ComicInfo.xml (and the equivalent `tag` / `tags` entries from Calibre OPF metadata) and link them to the media as first-class `Tag` entities via the `media_tags` junction table, so they appear in the UI alongside manually-assigned tags and can be used for filtering the same way.

### Behavior

- **Additive**: linking only *adds* missing tags — a rescan will never remove a tag the user assigned manually through the UI.
- **Idempotent**: re-scanning an unchanged file is a no-op; existing links are detected and skipped.
- **Comma-split**: a value like `"epic, high-fantasy"` becomes two tags, matching how the UI already stores them.
- **Reuses existing tags**: if a tag with the same name already exists, we link to it instead of creating a duplicate.

### Where it plugs in

- `ProcessedMediaMetadata` gains an `Option<Vec<String>>` `tags` field. The XML deserializer uses the existing `string_list_deserializer`; the HashMap (OPF) path splits comma-separated values on the way in.
- `BuiltMedia` carries the extracted tag names alongside the `media` / `media_metadata` active models. They're intentionally kept out of `media_metadata` since tags are their own entity.
- The scanner's `create_media` / `update_media` paths, plus the `Custom { regen_meta: true }` visit branch, call a new `ensure_tags_linked` helper inside the same DB transaction as the media/metadata write.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p stump_core --all-targets -- -D warnings`
- [x] `cargo test -p stump_core --lib` (187 passed, including new tests)
- [x] Unit tests: ComicInfo `<Tags>` parsing (populated + empty element), HashMap→metadata comma-split path
- [x] Integration tests (in-memory SQLite, exercising `create_media` / `update_media` end-to-end):
  - [x] Scan of a book with ComicInfo tags lands them as first-class `tag` rows linked via `media_tags`
  - [x] A tag assigned through the UI survives a rescan (additive semantics verified)
  - [x] Rescanning an unchanged book is idempotent — no duplicate `tag` rows, no duplicate `media_tags` rows
  - [x] A tag shared across books is reused, not duplicated