### PR TITLE
:sparkles: Add validation for metadata provider token

### DIFF
--- a/packages/browser/src/scenes/settings/server/metadataIntegrations/providers/CreateProviderDialog.tsx
+++ b/packages/browser/src/scenes/settings/server/metadataIntegrations/providers/CreateProviderDialog.tsx
@@ -96,7 +96,7 @@ export function CreateProviderDialog() {
 			</Button>
 
 			<Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
-				<Dialog.Content size="md">
+				<Dialog.Content size="md" className="max-h-full overflow-y-auto">
 					<Dialog.Header>
 						<Dialog.Title>{dialogTitle}</Dialog.Title>
 						<Dialog.Close onClick={handleClose} />

--- a/packages/browser/src/scenes/settings/server/metadataIntegrations/providers/EditProviderDialog.tsx
+++ b/packages/browser/src/scenes/settings/server/metadataIntegrations/providers/EditProviderDialog.tsx
@@ -4,6 +4,7 @@ import { Button, ConfirmationModal, Dialog, Form, ToolTip } from '@stump/compone
 import { ExistingProviderCardFragment, graphql } from '@stump/graphql'
 import { useLocaleContext } from '@stump/i18n'
 import { useQueryClient } from '@tanstack/react-query'
+import omit from 'lodash/omit'
 import { Cog } from 'lucide-react'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
@@ -73,7 +74,7 @@ export function EditProviderDialog({ provider }: Props) {
 	const handleSubmit = (data: PatchProviderConfigSchema) => {
 		editProvider({
 			id: provider.id,
-			input: data,
+			input: omit(data, 'providerType'),
 		})
 	}
 

--- a/packages/browser/src/scenes/settings/server/metadataIntegrations/providers/ProviderApiKeyInput.tsx
+++ b/packages/browser/src/scenes/settings/server/metadataIntegrations/providers/ProviderApiKeyInput.tsx
@@ -1,0 +1,126 @@
+import { Alert, AlertDescription, AlertTitle, PasswordInput } from '@stump/components'
+import { MetadataProvider } from '@stump/graphql'
+import { useLocaleContext } from '@stump/i18n'
+import { useMutation } from '@tanstack/react-query'
+import getProperty from 'lodash/get'
+import { AlertTriangleIcon } from 'lucide-react'
+import { useCallback, useEffect } from 'react'
+import { useFormContext, useFormState, useWatch } from 'react-hook-form'
+import { useDebouncedValue } from 'rooks'
+
+import { CreateProviderConfigSchema } from './schema'
+
+export function ProviderApiKeyInput() {
+	const form = useFormContext<CreateProviderConfigSchema>()
+	const { t } = useLocaleContext()
+	const { errors } = useFormState({ control: form.control })
+
+	const [provider, value] = useWatch({
+		control: form.control,
+		name: ['providerType', 'apiToken'],
+	})
+
+	const [debouncedValue] = useDebouncedValue(value, 500)
+
+	const {
+		mutate,
+		isPending,
+		error: fetchError,
+	} = useMutation({
+		mutationKey: ['validateApiKey', provider, debouncedValue],
+		mutationFn: async ({ apiKey, validator }: { apiKey: string; validator: Validator }) => {
+			const isValid = await validator(apiKey)
+			if (!isValid) {
+				form.setError('apiToken', {
+					type: 'validate',
+					message: t(getKey('apiToken.validationError')),
+				})
+			} else {
+				form.clearErrors('apiToken')
+			}
+		},
+	})
+
+	const validateKey = useCallback(
+		async (apiKey: string) => {
+			if (isPending || !apiKey) return
+			const validator = PROVIDER_VALIDATORS[provider]
+			if (!validator) return
+			mutate({ apiKey, validator })
+		},
+		[provider, mutate, isPending],
+	)
+
+	useEffect(
+		() => {
+			if (debouncedValue) {
+				validateKey(debouncedValue)
+			}
+		},
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[debouncedValue],
+	)
+
+	return (
+		<>
+			<PasswordInput
+				label={t(getKey('apiToken.label'))}
+				description={t(getKey('apiToken.description'))}
+				variant="primary"
+				type="password"
+				{...form.register('apiToken')}
+				errorMessage={errors.apiToken?.message}
+				fullWidth
+			/>
+
+			{fetchError && (
+				<Alert variant="destructive">
+					<AlertTriangleIcon />
+					<AlertTitle>{t(getKey('apiToken.validationRequestError'))}</AlertTitle>
+					<AlertDescription>
+						{fetchError instanceof Error
+							? fetchError.message
+							: t(getKey('apiToken.validationRequestErrorUnknown'))}
+					</AlertDescription>
+				</Alert>
+			)}
+		</>
+	)
+}
+
+const LOCALE_KEY = 'settingsScene.server/metadataIntegrations.providerForm'
+const getKey = (key: string) => `${LOCALE_KEY}.${key}`
+
+type Validator = (apiKey: string) => Promise<boolean>
+
+const validateHardcoverApiKey: Validator = async (apiKey) => {
+	const response = await fetch('https://api.hardcover.app/v1/graphql', {
+		method: 'POST',
+		body: JSON.stringify({
+			query: `
+          query {
+            me {
+              id
+              username
+            }
+          }
+        `,
+		}),
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${apiKey}`,
+		},
+	})
+
+	// TODO(localization): localize this error message
+	if (!response.ok) {
+		throw new Error(`Hardcover API responded with status ${response.status}`)
+	}
+
+	const data = await response.json()
+	return getProperty(data, 'data.me.id') != null
+}
+
+const PROVIDER_VALIDATORS: Record<MetadataProvider, Validator | null> = {
+	HARDCOVER: validateHardcoverApiKey,
+}

--- a/packages/browser/src/scenes/settings/server/metadataIntegrations/providers/ProviderApiKeyInput.tsx
+++ b/packages/browser/src/scenes/settings/server/metadataIntegrations/providers/ProviderApiKeyInput.tsx
@@ -29,7 +29,7 @@ export function ProviderApiKeyInput() {
 	} = useMutation({
 		mutationKey: ['validateApiKey', provider, debouncedValue],
 		mutationFn: async ({ apiKey, validator }: { apiKey: string; validator: Validator }) => {
-			const isValid = await validator(apiKey)
+			const isValid = await validator(apiKey, t)
 			if (!isValid) {
 				form.setError('apiToken', {
 					type: 'validate',
@@ -55,8 +55,11 @@ export function ProviderApiKeyInput() {
 		() => {
 			if (debouncedValue) {
 				validateKey(debouncedValue)
+			} else {
+				form.clearErrors('apiToken')
 			}
 		},
+		// eslint-disable-next-line react-compiler/react-compiler
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[debouncedValue],
 	)
@@ -91,9 +94,16 @@ export function ProviderApiKeyInput() {
 const LOCALE_KEY = 'settingsScene.server/metadataIntegrations.providerForm'
 const getKey = (key: string) => `${LOCALE_KEY}.${key}`
 
-type Validator = (apiKey: string) => Promise<boolean>
+type Validator = (
+	apiKey: string,
+	t: (key: string, args?: Record<string, unknown>) => string,
+) => Promise<boolean>
 
-const validateHardcoverApiKey: Validator = async (apiKey) => {
+const validateHardcoverApiKey: Validator = async (apiKey, t) => {
+	if (apiKey.startsWith('Bearer ')) {
+		throw new Error(t(getKey('apiToken.noBearerPrefixRequired')))
+	}
+
 	const response = await fetch('https://api.hardcover.app/v1/graphql', {
 		method: 'POST',
 		body: JSON.stringify({
@@ -112,13 +122,17 @@ const validateHardcoverApiKey: Validator = async (apiKey) => {
 		},
 	})
 
-	// TODO(localization): localize this error message
 	if (!response.ok) {
-		throw new Error(`Hardcover API responded with status ${response.status}`)
+		throw new Error(t(getKey('apiToken.hardcoverStatusError'), { status: response.status }))
 	}
 
 	const data = await response.json()
-	return getProperty(data, 'data.me.id') != null
+	const firstError = getProperty(data, 'errors[0].message')
+	if (firstError && typeof firstError === 'string') {
+		throw new Error(t(getKey('apiToken.hardcoverValidationError'), { message: firstError }))
+	}
+	// hardcover `me` is an array for whatever reason
+	return getProperty(data, 'data.me[0].id') != null
 }
 
 const PROVIDER_VALIDATORS: Record<MetadataProvider, Validator | null> = {

--- a/packages/browser/src/scenes/settings/server/metadataIntegrations/providers/ProviderForm.tsx
+++ b/packages/browser/src/scenes/settings/server/metadataIntegrations/providers/ProviderForm.tsx
@@ -15,6 +15,7 @@ import { useLocaleContext } from '@stump/i18n'
 import { startOfDay } from 'date-fns'
 import { useFormContext, useFormState, useWatch } from 'react-hook-form'
 
+import { ProviderApiKeyInput } from './ProviderApiKeyInput'
 import { PatchProviderConfigSchema } from './schema'
 
 export default function ProviderForm() {
@@ -44,7 +45,7 @@ export default function ProviderForm() {
 
 	return (
 		<>
-			<PasswordInput
+			{/*<PasswordInput
 				label={t(getKey('apiToken.label'))}
 				description={t(getKey('apiToken.description'))}
 				variant="primary"
@@ -52,7 +53,8 @@ export default function ProviderForm() {
 				{...form.register('apiToken')}
 				errorMessage={errors.apiToken?.message}
 				fullWidth
-			/>
+			/>*/}
+			<ProviderApiKeyInput />
 
 			<div className="gap-2 flex flex-col">
 				<Label>{t(getKey('apiTokenExpiresAt.label'))}</Label>

--- a/packages/browser/src/scenes/settings/server/metadataIntegrations/providers/ProviderForm.tsx
+++ b/packages/browser/src/scenes/settings/server/metadataIntegrations/providers/ProviderForm.tsx
@@ -6,7 +6,6 @@ import {
 	Input,
 	Label,
 	NativeSelect,
-	PasswordInput,
 	RawSwitch,
 	Text,
 } from '@stump/components'
@@ -45,15 +44,6 @@ export default function ProviderForm() {
 
 	return (
 		<>
-			{/*<PasswordInput
-				label={t(getKey('apiToken.label'))}
-				description={t(getKey('apiToken.description'))}
-				variant="primary"
-				type="password"
-				{...form.register('apiToken')}
-				errorMessage={errors.apiToken?.message}
-				fullWidth
-			/>*/}
 			<ProviderApiKeyInput />
 
 			<div className="gap-2 flex flex-col">

--- a/packages/browser/src/scenes/settings/server/metadataIntegrations/providers/schema.ts
+++ b/packages/browser/src/scenes/settings/server/metadataIntegrations/providers/schema.ts
@@ -57,7 +57,7 @@ export const getCommonDefaults = () => ({
 
 export const getPatchDefaults = (
 	provider: ExistingProviderCardFragment,
-): PatchProviderConfigSchema => ({
+): PatchProviderConfigSchema & { providerType: MetadataProvider } => ({
 	enabled: provider.enabled,
 	apiToken: null,
 	apiTokenExpiresAt: provider.apiTokenExpiresAt,
@@ -67,4 +67,6 @@ export const getPatchDefaults = (
 		strategy: provider.autoApplyConfig?.strategy ?? MergeStrategy.FillGaps,
 		excludeFields: provider.autoApplyConfig?.excludeFields ?? [],
 	},
+	// Note: A bit lazy but adding here to inform the form the provider type and skip context etc
+	providerType: provider.providerType,
 })

--- a/packages/i18n/src/locales/en-US.json
+++ b/packages/i18n/src/locales/en-US.json
@@ -2313,7 +2313,10 @@
 					"description": "The API token for authenticating with this provider",
 					"validationError": "The auto-validation failed for this token",
 					"validationRequestError": "The validation request failed",
-					"validationRequestErrorUnknown": "An unknown error occurred during validation"
+					"validationRequestErrorUnknown": "An unknown error occurred during validation",
+					"hardcoverStatusError": "Hardcover API responded with status {{status}}",
+					"hardcoverValidationError": "Hardcover API responded with an error: {{message}}",
+					"noBearerPrefixRequired": "Remove the 'Bearer ' prefix from the API token"
 				},
 				"apiTokenExpiresAt": {
 					"label": "API token expiration",

--- a/packages/i18n/src/locales/en-US.json
+++ b/packages/i18n/src/locales/en-US.json
@@ -2310,7 +2310,10 @@
 			"providerForm": {
 				"apiToken": {
 					"label": "API token",
-					"description": "The API token for authenticating with this provider"
+					"description": "The API token for authenticating with this provider",
+					"validationError": "The auto-validation failed for this token",
+					"validationRequestError": "The validation request failed",
+					"validationRequestErrorUnknown": "An unknown error occurred during validation"
 				},
 				"apiTokenExpiresAt": {
 					"label": "API token expiration",


### PR DESCRIPTION
This change does primarily two things:

1. Sets up a reusable pattern by which the provider form can issue test requests to validate the token entered is valid
2. Implements the above for Hardcover

It will also detect when you enter `Bearer ` and inform you to remove it. Kinda relates to #1062, in conversations with the author of that issue.