### PR TITLE
👷 Add OCI image labels for changelog/metadata discovery

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -102,6 +102,8 @@ runs:
         build-args: |
           GIT_REV=${{ env.GIT_REV }}
           BUILD_CHANNEL=${{ inputs.build-channel }}
+        labels: |
+          org.opencontainers.image.revision=${{ env.GIT_REV }}
         containerfiles: |
           ./docker/Dockerfile
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -96,6 +96,14 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,id=${TARGETARCH} \
 
 FROM gcr.io/distroless/cc-debian12:debug
 
+LABEL org.opencontainers.image.title="Stump" \
+      org.opencontainers.image.description="A free and open source comics, manga and digital book server with OPDS support" \
+      org.opencontainers.image.source="https://github.com/stumpapp/stump" \
+      org.opencontainers.image.url="https://stumpapp.dev" \
+      org.opencontainers.image.documentation="https://stumpapp.dev/guides" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.vendor="stumpapp"
+
 RUN [ "/busybox/ln", "-s", "/busybox/sh", "/bin/sh" ]
 RUN ln -s /busybox/env /usr/bin/env
 


### PR DESCRIPTION
This allows tools like Renovate to pick up changelogs automatically, for example.