### PR TITLE
💄 (expo): Add blur to progress bars and smart list stats

### DIFF
--- a/apps/expo/components/activeServer/home/ReadingNow.tsx
+++ b/apps/expo/components/activeServer/home/ReadingNow.tsx
@@ -7,6 +7,7 @@ import {
 	useFragment,
 } from '@stump/graphql'
 import { formatDistanceToNow } from 'date-fns'
+import { BlurTargetView } from 'expo-blur'
 import { useRouter } from 'expo-router'
 import { useRef } from 'react'
 import { Easing, Pressable, View } from 'react-native'
@@ -20,7 +21,7 @@ import { stripHtml } from 'string-strip-html'
 import { ThumbnailImage } from '~/components/image'
 import { Badge, Heading, Progress, Text } from '~/components/ui'
 import { COLORS, useColors } from '~/lib/constants'
-import { parseGraphQLDecimal } from '~/lib/format'
+import { parseGraphQLPercentageDecimal } from '~/lib/format'
 import { useDisplay } from '~/lib/hooks'
 import { cn } from '~/lib/utils'
 import { usePreferencesStore } from '~/stores'
@@ -198,7 +199,7 @@ function ReadingNowItem({ book }: ReadingNowItemProps) {
 	const router = useRouter()
 	const colors = useColors()
 
-	const percentageCompleted = parseGraphQLDecimal(data.readProgress?.percentageCompleted)
+	const percentageCompleted = parseGraphQLPercentageDecimal(data.readProgress?.percentageCompleted)
 	const currentPage =
 		data.readProgress?.page ?? data.readProgress?.locator?.locations?.position ?? '??'
 
@@ -336,22 +337,26 @@ function ReadingNowItem({ book }: ReadingNowItemProps) {
 
 	const { url: uri, metadata: placeholderData } = data.thumbnail
 
+	const blurTargetRef = useRef<View>(null)
+
 	return (
 		<View className="gap-4 flex flex-row">
 			<Pressable onPress={() => router.navigate(`/server/${serverID}/books/${data.id}`)}>
-				<ThumbnailImage
-					source={{
-						uri,
-						headers: {
-							...sdk.customHeaders,
-							Authorization: sdk.authorizationHeader || '',
-						},
-					}}
-					size={{ height: imageHeight, width: IMAGE_WIDTH }}
-					gradient={{ colors: gradientColors, locations: gradientLocations }}
-					placeholderData={placeholderData}
-					originalDimensions={originalDimensions}
-				/>
+				<BlurTargetView ref={blurTargetRef}>
+					<ThumbnailImage
+						source={{
+							uri,
+							headers: {
+								...sdk.customHeaders,
+								Authorization: sdk.authorizationHeader || '',
+							},
+						}}
+						size={{ height: imageHeight, width: IMAGE_WIDTH }}
+						gradient={{ colors: gradientColors, locations: gradientLocations }}
+						placeholderData={placeholderData}
+						originalDimensions={originalDimensions}
+					/>
+				</BlurTargetView>
 
 				<View className="bottom-0 gap-2 p-3 absolute z-20 w-full">
 					{!isTablet && (
@@ -396,9 +401,15 @@ function ReadingNowItem({ book }: ReadingNowItemProps) {
 
 						{percentageCompleted != null && (
 							<Progress
-								className="h-1 bg-white/40"
+								className="h-1"
 								indicatorClassName="bg-[#f5f3ef]"
-								value={percentageCompleted * 100}
+								trackClassName="bg-white/30"
+								value={percentageCompleted}
+								blurProps={{
+									intensity: 4,
+									blurTarget: blurTargetRef,
+									blurMethod: 'dimezisBlurView',
+								}}
 							/>
 						)}
 					</View>

--- a/apps/expo/components/appSettings/preferences/ImageCacheActions.tsx
+++ b/apps/expo/components/appSettings/preferences/ImageCacheActions.tsx
@@ -8,7 +8,7 @@ import { useTranslate } from '~/lib/hooks'
 
 import AppSettingsRow from '../AppSettingsRow'
 
-export default function CachePolicySelect() {
+export default function ImageCacheActions() {
 	const { t } = useTranslate()
 
 	const onClearCache = async (message: string) => {

--- a/apps/expo/components/book/reader/image/Footer.tsx
+++ b/apps/expo/components/book/reader/image/Footer.tsx
@@ -487,7 +487,7 @@ export default function Footer() {
 
 	return (
 		<Animated.View
-			className="insets-x-safe bottom-safe gap-4 absolute z-20 shrink"
+			className="insets-x-safe bottom-safe gap-4 absolute z-20 w-full shrink"
 			style={[secondaryStyle, translateFooterStyle]}
 		>
 			{footerControls === 'images' && readingMode !== ReadingMode.ContinuousVertical && (

--- a/apps/expo/components/book/reader/image/Footer.tsx
+++ b/apps/expo/components/book/reader/image/Footer.tsx
@@ -514,14 +514,17 @@ export default function Footer() {
 			<View className={cn('gap-2 px-3', { 'pb-1': Platform.OS === 'android' })}>
 				{(footerControls === 'images' || readingMode === ReadingMode.ContinuousVertical) && (
 					<Progress
-						className="h-1 bg-white/40"
+						className="h-1"
 						indicatorClassName="bg-[#f5f3ef]"
+						trackClassName="bg-white/30"
 						value={percentage}
 						inverted={
 							readingDirection === ReadingDirection.Rtl &&
 							readingMode !== ReadingMode.ContinuousVertical
 						}
 						max={100}
+						// TODO: Figure out android (blurTarget)
+						blurProps={{ intensity: 4 }}
 					/>
 				)}
 

--- a/apps/expo/components/book/reader/image/ImageBasedReader.tsx
+++ b/apps/expo/components/book/reader/image/ImageBasedReader.tsx
@@ -1,6 +1,7 @@
 import { Zoomable, ZoomableRef } from '@likashefqet/react-native-image-zoom'
 import { FlashList, useMappingHelper } from '@shopify/flash-list'
 import { ReadingDirection, ReadingMode } from '@stump/graphql'
+import { ImageBasedBookPageRef, PageSetIndexes } from '@stump/sdk'
 import { STUMP_SAVE_BASIC_SESSION_HEADER } from '@stump/sdk/constants'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { NativeScrollEvent, NativeSyntheticEvent, useWindowDimensions, View } from 'react-native'
@@ -18,13 +19,7 @@ import { useDisplay, usePrevious } from '~/lib/hooks'
 import { useReaderStore } from '~/stores'
 import { useBookPreferences } from '~/stores/reader'
 
-import { PageIndexes, useImageBasedReader } from './context'
-
-type ImageDimension = {
-	height: number
-	width: number
-	ratio: number
-}
+import { useImageBasedReader } from './context'
 
 // TODO: The reading directions don't play well with the pinch and zoom, particularly the continuous
 // scroll modes. I think when it is set to continuous, the zoom might have to be on the list?
@@ -179,8 +174,8 @@ export default function ImageBasedReader({ initialPage, onPastEndReached }: Prop
 
 type PageSetProps = {
 	flashListIndex: number
-	pageIndexes: PageIndexes
-	dimensions: ImageDimension[]
+	pageIndexes: PageSetIndexes
+	dimensions: ImageBasedBookPageRef[]
 	maxWidth: number
 	maxHeight: number
 	onPastEndReached?: () => void

--- a/apps/expo/components/book/reader/image/ImageBasedReaderContainer.tsx
+++ b/apps/expo/components/book/reader/image/ImageBasedReaderContainer.tsx
@@ -1,6 +1,6 @@
 import { FlashListRef } from '@shopify/flash-list'
 import { ReadingMode } from '@stump/graphql'
-import { generatePageSets, ImageBasedBookPageRef } from '@stump/sdk'
+import { generatePageSets, ImageBasedBookPageRef, PageSetIndexes } from '@stump/sdk'
 import { ComponentProps, useCallback, useMemo, useRef, useState } from 'react'
 import { View } from 'react-native'
 
@@ -64,7 +64,7 @@ export default function ImageBasedReaderContainer({
 		const autoButOff = doublePageBehavior === 'auto' && deviceOrientation === 'portrait'
 		const modeForceOff = readingMode === ReadingMode.ContinuousVertical
 
-		let sets: number[][] = []
+		let sets: PageSetIndexes[] = []
 		if (doublePageBehavior === 'off' || autoButOff || modeForceOff) {
 			sets = Array.from({ length: pages }, (_, i) => [i])
 		} else {
@@ -90,7 +90,7 @@ export default function ImageBasedReaderContainer({
 		[incognito, onPageChanged],
 	)
 
-	const flashListRef = useRef<FlashListRef<number[]>>(null)
+	const flashListRef = useRef<FlashListRef<PageSetIndexes>>(null)
 
 	return (
 		<ImageBasedReaderContext.Provider

--- a/apps/expo/components/book/reader/image/context.ts
+++ b/apps/expo/components/book/reader/image/context.ts
@@ -1,5 +1,6 @@
 import { FlashListRef } from '@shopify/flash-list'
 import { BookReadScreenQuery, ReadiumLocation, ReadiumLocator } from '@stump/graphql'
+import { ImageBasedBookPageRef, PageSetIndexes } from '@stump/sdk'
 import { createContext, useContext } from 'react'
 
 import { OfflineCompatibleReader } from '../types'
@@ -29,12 +30,6 @@ export type EbookReaderBookRef = {
 		readProgress?: QueryData['readProgress']
 	}
 
-export type ImageBasedBookPageRef = {
-	height: number
-	width: number
-	ratio: number
-}
-
 export type NextInSeriesBookRef = {
 	id: string
 	name: string
@@ -47,14 +42,12 @@ export type BookmarkRef = NonNullable<EbookReaderBookRef['ebook']>['bookmarks'][
 		createdAt?: Date
 	}
 
-export type PageIndexes = [number, number] | [number]
-
 export type IImageBasedReaderContext = {
-	flashListRef: React.RefObject<FlashListRef<PageIndexes> | null>
+	flashListRef: React.RefObject<FlashListRef<PageSetIndexes> | null>
 	book: ImageReaderBookRef
 	imageSizes?: Record<number, ImageBasedBookPageRef>
 	setImageSizes: React.Dispatch<React.SetStateAction<Record<number, ImageBasedBookPageRef>>>
-	pageSets: PageIndexes[]
+	pageSets: PageSetIndexes[]
 	pageURL: (page: number) => string
 	pageThumbnailURL?: (page: number) => string
 	currentPage?: number

--- a/apps/expo/components/book/reader/image/index.ts
+++ b/apps/expo/components/book/reader/image/index.ts
@@ -1,2 +1,2 @@
-export { ImageBasedBookPageRef, ImageBasedReaderContext } from './context'
+export { ImageBasedReaderContext } from './context'
 export { default as ImageBasedReader } from './ImageBasedReaderContainer'

--- a/apps/expo/components/book/reader/image/useDimensions.ts
+++ b/apps/expo/components/book/reader/image/useDimensions.ts
@@ -1,8 +1,7 @@
+import { ImageBasedBookPageRef } from '@stump/sdk'
 import { useEffect, useState } from 'react'
 
 import { useReaderStore } from '~/stores'
-
-import { ImageBasedBookPageRef } from './context'
 
 type Params = {
 	bookID: string

--- a/apps/expo/components/downloadQueue/DownloadQueueItem.tsx
+++ b/apps/expo/components/downloadQueue/DownloadQueueItem.tsx
@@ -19,7 +19,11 @@ export default function DownloadQueueItem({ item, onCancel }: Props) {
 		if (item.status === 'downloading' && item.progress) {
 			return (
 				<>
-					<Progress value={item.progress.percentage} className="h-2 flex-1" />
+					<Progress
+						value={item.progress.percentage}
+						trackClassName="bg-background-surface"
+						className="h-2 flex-1"
+					/>
 					<Text className="text-xs text-foreground-muted">{item.progress.percentage}%</Text>
 				</>
 			)

--- a/apps/expo/components/listLayout/grid/GridImageItem.tsx
+++ b/apps/expo/components/listLayout/grid/GridImageItem.tsx
@@ -77,9 +77,15 @@ export default function GridImageItem({
 						{isReading && (
 							<View className="bottom-2 left-2 right-2 absolute z-30">
 								<Progress
-									className="h-1 bg-white/40"
+									className="h-1"
 									indicatorClassName="bg-[#f5f3ef]"
+									trackClassName=" bg-white/30"
 									value={percentageCompleted}
+									blurProps={{
+										intensity: 4,
+										blurTarget: blurTargetRef,
+										blurMethod: 'dimezisBlurView',
+									}}
 								/>
 							</View>
 						)}

--- a/apps/expo/components/listLayout/list/ListRowItem.tsx
+++ b/apps/expo/components/listLayout/list/ListRowItem.tsx
@@ -69,7 +69,7 @@ export function ListRowItem({
 						{percentageCompleted != null && percentageCompleted < 100 && (
 							<View className="gap-3 flex-row items-center">
 								<Progress
-									className="h-1 shrink bg-background-surface-secondary"
+									className="shrink"
 									value={percentageCompleted}
 									style={{ height: 6, borderRadius: 3 }}
 								/>

--- a/apps/expo/components/localLibrary/DownloadRowItem.tsx
+++ b/apps/expo/components/localLibrary/DownloadRowItem.tsx
@@ -216,7 +216,7 @@ export default function DownloadRowItem({ downloadedFile }: Props) {
 						{readProgress && (
 							<View className="gap-3 flex-row items-center">
 								<Progress
-									className="h-1 shrink bg-background-surface-secondary"
+									className="shrink"
 									value={getProgress()}
 									style={{ height: 6, borderRadius: 3 }}
 								/>

--- a/apps/expo/components/localLibrary/ReadingNow.tsx
+++ b/apps/expo/components/localLibrary/ReadingNow.tsx
@@ -1,5 +1,6 @@
 import { MediaMetadata } from '@stump/graphql'
 import { formatDistanceToNow } from 'date-fns'
+import { BlurTargetView } from 'expo-blur'
 import { useRouter } from 'expo-router'
 import { useCallback, useMemo, useRef } from 'react'
 import { Easing, Pressable, View } from 'react-native'
@@ -14,11 +15,10 @@ import { ThumbnailImage } from '~/components/image'
 import { Badge, Heading, Progress, Text } from '~/components/ui'
 import { epubProgress, imageMeta, syncStatus } from '~/db'
 import { COLORS, useColors } from '~/lib/constants'
-import { parseGraphQLDecimal } from '~/lib/format'
+import { parseGraphQLPercentageDecimal } from '~/lib/format'
 import { useDisplay } from '~/lib/hooks'
 import { usePreferencesStore } from '~/stores'
 
-import { BookMetaLink } from '../book'
 import { SyncIcon } from './sync-icon/SyncIcon'
 import { DownloadedFile } from './types'
 import { getThumbnailPath } from './utils'
@@ -144,7 +144,7 @@ function ReadingNowItem({ book }: ReadingNowItemProps) {
 
 	const colors = useColors()
 
-	const percentageCompleted = parseGraphQLDecimal(book.readProgress?.percentage)
+	const percentageCompleted = parseGraphQLPercentageDecimal(book.readProgress?.percentage)
 	const epubProgression = epubProgress.safeParse(book.readProgress?.epubProgress).data
 	const currentPage = book.readProgress?.page ?? epubProgression?.locations?.position ?? '??'
 
@@ -256,19 +256,23 @@ function ReadingNowItem({ book }: ReadingNowItemProps) {
 		easing: Easing.bezier(0.42, 0, 1, 1), // https://cubic-bezier.com/#.42,0,1,1
 	})
 
+	const blurTargetRef = useRef<View>(null)
+
 	return (
 		<View className="gap-4 flex flex-row">
 			<Pressable onPress={() => router.push(`/offline/${book.id}`)}>
-				<ThumbnailImage
-					source={{
-						// @ts-expect-error: URI doesn't like undefined but it shows a placeholder when
-						// undefined so it's fine
-						uri: thumbnailPath,
-					}}
-					size={{ height: imageHeight, width: IMAGE_WIDTH }}
-					gradient={{ colors: gradientColors, locations: gradientLocations }}
-					placeholderData={thumbnailData}
-				/>
+				<BlurTargetView ref={blurTargetRef}>
+					<ThumbnailImage
+						source={{
+							// @ts-expect-error: URI doesn't like undefined but it shows a placeholder when
+							// undefined so it's fine
+							uri: thumbnailPath,
+						}}
+						size={{ height: imageHeight, width: IMAGE_WIDTH }}
+						gradient={{ colors: gradientColors, locations: gradientLocations }}
+						placeholderData={thumbnailData}
+					/>
+				</BlurTargetView>
 
 				{status && (
 					<View className="right-0 p-3 shadow absolute z-20 w-full items-end">
@@ -325,9 +329,15 @@ function ReadingNowItem({ book }: ReadingNowItemProps) {
 
 						{percentageCompleted != null && (
 							<Progress
-								className="h-1 bg-white/40"
+								className="h-1"
 								indicatorClassName="bg-[#f5f3ef]"
-								value={percentageCompleted * 100}
+								trackClassName="bg-white/30"
+								value={percentageCompleted}
+								blurProps={{
+									intensity: 4,
+									blurTarget: blurTargetRef,
+									blurMethod: 'dimezisBlurView',
+								}}
 							/>
 						)}
 					</View>

--- a/apps/expo/components/smartList/SmartListBookItem.tsx
+++ b/apps/expo/components/smartList/SmartListBookItem.tsx
@@ -173,7 +173,7 @@ export default function SmartListBookItem({ book }: Props) {
 							</Text>
 
 							<Progress
-								className="h-1 bg-white/40"
+								className="bg-white/40"
 								indicatorClassName="bg-[#f5f3ef]"
 								value={getProgress()}
 								style={{ height: 6, borderRadius: 3 }}
@@ -205,7 +205,7 @@ export default function SmartListBookItem({ book }: Props) {
 					{data.readProgress && layout === 'list' && (
 						<View className="gap-4 pt-4 flex-row items-center">
 							<Progress
-								className="h-1 shrink bg-background-surface-secondary"
+								className="shrink"
 								value={getProgress()}
 								style={{ height: 6, borderRadius: 3 }}
 							/>

--- a/apps/expo/components/smartList/SmartListGridItem.tsx
+++ b/apps/expo/components/smartList/SmartListGridItem.tsx
@@ -1,7 +1,9 @@
 import { Host, Image } from '@expo/ui/swift-ui'
 import { FragmentType, graphql, useFragment } from '@stump/graphql'
+import { BlurTargetView, BlurView, BlurViewProps } from 'expo-blur'
 import { Href, useRouter } from 'expo-router'
 import { Book, Library, LucideIcon, Rows3 } from 'lucide-react-native'
+import { useRef } from 'react'
 import { Platform, Pressable, View } from 'react-native'
 
 import { COLORS } from '~/lib/constants'
@@ -48,33 +50,38 @@ type StatItemProps = {
 	iosIcon: React.ComponentProps<typeof Image>['systemName']
 	androidIcon: LucideIcon
 	count: number
+	blurTarget: BlurViewProps['blurTarget']
 }
 
-function StatItem({ iosIcon, androidIcon, count }: StatItemProps) {
+function StatItem({ iosIcon, androidIcon, count, blurTarget }: StatItemProps) {
 	const iconSize = 14
 	const color = COLORS.dark.foreground.DEFAULT
 
 	return (
-		<View className="squircle flex-row items-center gap-1 rounded-full bg-black/70 px-2.5 py-1.5 shadow-lg">
-			{Platform.OS === 'ios' ? (
-				<Host matchContents>
-					<Image systemName={iosIcon} size={iconSize} color={color} />
-				</Host>
-			) : (
-				<Icon as={androidIcon} size={iconSize} color={color} />
-			)}
-			<Text
-				className="font-medium"
-				style={{
-					color,
-					textShadowOffset: { width: 1, height: 1 },
-					textShadowRadius: 1,
-					textShadowColor: 'rgba(0, 0, 0, 0.5)',
-				}}
-			>
-				{count}
-			</Text>
-		</View>
+		<BlurView
+			className="squircle rounded-full"
+			intensity={4}
+			blurTarget={blurTarget}
+			blurMethod="dimezisBlurView"
+		>
+			<View className="bg-black/40 gap-1 px-2.5 py-1.5 shadow-lg flex-row items-center">
+				{Platform.OS === 'ios' ? (
+					<Host matchContents>
+						<Image systemName={iosIcon} size={iconSize} color={color} />
+					</Host>
+				) : (
+					<Icon as={androidIcon} size={iconSize} color={color} />
+				)}
+				<Text
+					className="font-medium shadow"
+					style={{
+						color,
+					}}
+				>
+					{count}
+				</Text>
+			</View>
+		</BlurView>
 	)
 }
 
@@ -94,25 +101,44 @@ export default function SmartListGridItem({ smartList, getLayoutNumber }: Props)
 
 	const { matchedLibraries, matchedSeries, matchedBooks } = data.meta
 
+	const blurTargetRef = useRef<View>(null)
+
 	return (
 		<View className="w-full items-center">
 			{/* TODO: Worth starting prefetch before navigate? */}
 			<Pressable onPress={() => router.navigate(href)}>
 				{({ pressed }) => (
 					<View className={cn('relative', { 'opacity-80': pressed })}>
-						<CollectionStackedThumbnails
-							thumbnailData={thumbnailData}
-							layoutNumber={layoutNumber}
-						/>
+						<BlurTargetView ref={blurTargetRef}>
+							<CollectionStackedThumbnails
+								thumbnailData={thumbnailData}
+								layoutNumber={layoutNumber}
+							/>
+						</BlurTargetView>
 
 						{/* Note: I've tried a few variations of placement and didn't love many but this was most OK */}
-						<View className="absolute left-0 top-0 z-20 flex-row gap-2 px-4 py-2">
-							<StatItem iosIcon="books.vertical" androidIcon={Library} count={matchedLibraries} />
-							<StatItem iosIcon="square.stack" androidIcon={Rows3} count={matchedSeries} />
-							<StatItem iosIcon="book.closed" androidIcon={Book} count={matchedBooks} />
+						<View className="left-0 top-0 gap-2 px-4 py-2 absolute z-20 flex-row">
+							<StatItem
+								iosIcon="books.vertical"
+								androidIcon={Library}
+								count={matchedLibraries}
+								blurTarget={blurTargetRef}
+							/>
+							<StatItem
+								iosIcon="square.stack"
+								androidIcon={Rows3}
+								count={matchedSeries}
+								blurTarget={blurTargetRef}
+							/>
+							<StatItem
+								iosIcon="book.closed"
+								androidIcon={Book}
+								count={matchedBooks}
+								blurTarget={blurTargetRef}
+							/>
 						</View>
 
-						<View className="absolute bottom-0 left-0 z-20 w-full px-4 py-2">
+						<View className="bottom-0 left-0 px-4 py-2 absolute z-20 w-full">
 							<Text
 								size="2xl"
 								className="font-bold leading-8 tracking-wide"

--- a/apps/expo/components/ui/progress.tsx
+++ b/apps/expo/components/ui/progress.tsx
@@ -1,5 +1,7 @@
 import * as ProgressPrimitive from '@rn-primitives/progress'
+import { BlurView, BlurViewProps } from 'expo-blur'
 import * as React from 'react'
+import { View } from 'react-native'
 import Animated, {
 	Extrapolation,
 	interpolate,
@@ -12,22 +14,37 @@ import { cn } from '~/lib/utils'
 
 type Props = {
 	indicatorClassName?: string
+	trackClassName?: string
 	inverted?: boolean
+	blurProps?: BlurViewProps
 } & ProgressPrimitive.RootProps
 
 const Progress = React.forwardRef<ProgressPrimitive.RootRef, Props>(
-	({ className, value, indicatorClassName, inverted, ...props }, ref) => {
+	(
+		{ className, value, indicatorClassName, trackClassName, inverted, blurProps, ...props },
+		ref,
+	) => {
 		return (
 			<ProgressPrimitive.Root
 				ref={ref}
 				className={cn(
-					'squircle relative h-4 w-full overflow-hidden rounded-full bg-background-surface',
+					'squircle h-4 relative w-full overflow-hidden rounded-full',
 					{ 'rotate-180 transform': inverted },
 					className,
 				)}
 				{...props}
 			>
-				<Indicator value={value} className={indicatorClassName} />
+				{blurProps ? (
+					<BlurView {...blurProps}>
+						<View className={cn('bg-background-surface-secondary', trackClassName)}>
+							<Indicator value={value} className={indicatorClassName} />
+						</View>
+					</BlurView>
+				) : (
+					<View className={cn('bg-background-surface-secondary', trackClassName)}>
+						<Indicator value={value} className={indicatorClassName} />
+					</View>
+				)}
 			</ProgressPrimitive.Root>
 		)
 	},

--- a/apps/expo/stores/reader.ts
+++ b/apps/expo/stores/reader.ts
@@ -15,16 +15,11 @@ export type DoublePageBehavior = 'auto' | 'always' | 'off'
 
 export type FooterControls = 'images' | 'slider'
 
-export type CachePolicy = 'none' | 'disk' | 'memory' | 'memory-disk'
-export const isCachePolicy = (value: string): value is CachePolicy =>
-	['none', 'disk', 'memory', 'memory-disk'].includes(value)
-
 export type BookPreferences = IBookPreferences & {
 	serverID?: string
 	incognito?: boolean
 	preferSmallImages?: boolean
 	allowDownscaling: boolean
-	cachePolicy: CachePolicy
 	doublePageBehavior: DoublePageBehavior
 	tapSidesToNavigate: boolean
 	footerControls: FooterControls
@@ -97,7 +92,6 @@ export const DEFAULT_BOOK_PREFERENCES = {
 	trackElapsedTime: true,
 	tapSidesToNavigate: true,
 	allowDownscaling: false,
-	cachePolicy: 'memory-disk',
 	footerControls: 'images',
 	allowPublisherStyles: true,
 	pageMargins: 1.0,

--- a/apps/expo/stores/reader.ts
+++ b/apps/expo/stores/reader.ts
@@ -92,7 +92,7 @@ export const DEFAULT_BOOK_PREFERENCES = {
 	imageScaling: {
 		scaleToFit: ReadingImageScaleFit.Auto,
 	},
-	doublePageBehavior: 'off',
+	doublePageBehavior: 'auto',
 	secondPageSeparate: false,
 	trackElapsedTime: true,
 	tapSidesToNavigate: true,

--- a/apps/expo/stores/user.ts
+++ b/apps/expo/stores/user.ts
@@ -8,7 +8,6 @@ import {
 	ThumbnailResizeMode,
 } from '~/components/image/ThumbnailPlaceholder'
 
-import { CachePolicy } from './reader'
 import { ZustandMMKVStorage } from './store'
 
 export const useUserStore = createUserStore(ZustandMMKVStorage)
@@ -23,7 +22,6 @@ type MobilePreferencesStore = {
 	setMaskURLs: (mask: boolean) => void
 	storeLastRead: boolean
 	reduceAnimations: boolean
-	cachePolicy: CachePolicy
 	allowDownscaling: boolean
 	thumbnailRatio: number
 	thumbnailResizeMode: ThumbnailResizeMode
@@ -61,7 +59,6 @@ export const usePreferencesStore = create<MobilePreferencesStore>()(
 			setMaskURLs: (mask) => set({ maskURLs: mask }),
 			storeLastRead: false,
 			reduceAnimations: false,
-			cachePolicy: 'memory-disk',
 			allowDownscaling: true,
 			thumbnailRatio: 2 / 3,
 			thumbnailPlaceholder: 'grayscale',

--- a/packages/sdk/src/utils/reader.ts
+++ b/packages/sdk/src/utils/reader.ts
@@ -4,6 +4,8 @@ export type ImageBasedBookPageRef = {
 	ratio: number
 }
 
+export type PageSetIndexes = [number, number] | [number]
+
 export type GeneratePageSetsParams = {
 	imageSizes: Record<number, ImageBasedBookPageRef>
 	pages: number
@@ -14,20 +16,17 @@ export const generatePageSets = ({
 	imageSizes,
 	pages,
 	secondPageSeparate = false,
-}: GeneratePageSetsParams): number[][] => {
-	const sets: number[][] = []
-
+}: GeneratePageSetsParams): PageSetIndexes[] => {
 	if (Object.keys(imageSizes).length === 0) {
 		return Array.from({ length: pages }, (_, i) => [i])
 	}
 
-	const landscapePages = Object.keys(imageSizes).reduce(
-		(acc, key) => {
+	const landscapePages = Object.entries(imageSizes).reduce(
+		(acc, [key, dimensions]) => {
 			const idx = parseInt(key)
 			if (isNaN(idx)) return acc
-			if (!imageSizes[idx]) return acc
 
-			const { width, height, ratio } = imageSizes[idx]
+			const { width, height, ratio } = dimensions
 
 			const computedRatio = width / height
 			if (computedRatio !== ratio) {
@@ -40,58 +39,35 @@ export const generatePageSets = ({
 				)
 			}
 
-			acc[idx] = imageSizes[idx].ratio >= 1
+			acc[idx] = ratio >= 1
 			return acc
 		},
 		{} as Record<number, boolean>,
 	)
 
-	// A user reported that the current implementation can lead to duplicate sets. I've
-	// tried really hard to reproduce this, but haven't found a scenario where it
-	// happens. To be safe, I've added this visitedSet to ensure we don't add any
-	// indexes to a set that has already been added
-	const visitedSet = new Set<number>()
-
-	let currentSet: number[] = []
-	for (let i = 0; i < pages; i++) {
-		if (secondPageSeparate && i === 1) {
-			sets.push([1])
-			visitedSet.add(1)
-			continue
-		}
-		if (visitedSet.has(i)) {
-			continue // Skip already processed pages
-		}
-
-		visitedSet.add(i)
-
-		// If a page is landscape, we only ever want to show it by itself
-		// If a page is portrait, we will only show it by itself if the next page is also portrait
-
+	const pageSets: PageSetIndexes[] = []
+	let i = 0
+	while (i < pages) {
+		const isFirst = i === 0
+		const separateSecond = i === 1 && secondPageSeparate
 		const isLandscape = landscapePages[i]
 		const isLast = i === pages - 1
+		// these next two conditions are because: if we are looking to pair page `i` with the next page `i+1`
+		// but the next page is separate, the current page has nothing to pair with, thus has to be separate too
 		const nextIsLandscape = landscapePages[i + 1]
 		const nextIsLast = i + 1 === pages - 1
 
-		if (isLandscape || i === 0) {
-			currentSet.push(i)
-			sets.push(currentSet)
-			currentSet = []
-		} else {
-			currentSet.push(i)
+		const keepPageSeparate =
+			isFirst || separateSecond || isLandscape || isLast || nextIsLandscape || nextIsLast
 
-			// The logic behind the following condition is:
-			// 1. The last page is always its own set, so we push the current set when either the current
-			//		page is the last page or the next page is last.
-			// 2. If the next page is landscape, we also push the current set to ensure that the landscape page
-			//		is not included in the current set.
-			// 3. If the current set has exactly two pages, we push it because the set is complete
-			if (isLast || nextIsLast || nextIsLandscape || currentSet.length === 2) {
-				sets.push(currentSet)
-				currentSet = []
-			}
+		if (keepPageSeparate) {
+			pageSets.push([i])
+			i++
+		} else {
+			pageSets.push([i, i + 1])
+			i += 2
 		}
 	}
 
-	return sets.filter((set) => set.length > 0)
+	return pageSets
 }


### PR DESCRIPTION
Adds blur to progress bars and smart list stats, but I couldn't get android working in the image reader footer though

I also noticed my recent changes made some of the types unhappy, so that's fixed, and with that came updating the `generatePageSets` function to be a bit more readable.