### PR TITLE
:bug: Fix inverted query condition for series completion

### DIFF
--- a/crates/graphql/src/mutation/series.rs
+++ b/crates/graphql/src/mutation/series.rs
@@ -13,11 +13,14 @@ use sea_orm::{
 	ActiveValue::Set,
 	QuerySelect, TransactionTrait,
 };
-use stump_core::filesystem::{
-	image::{generate_book_thumbnail, GenerateThumbnailOptions},
-	media::analysis::{AnalysisJobConfig, MediaAnalysisJobScope},
-};
 use stump_core::job::stump_job::StumpJob;
+use stump_core::{
+	database::SQLITE_BIND_LIMIT,
+	filesystem::{
+		image::{generate_book_thumbnail, GenerateThumbnailOptions},
+		media::analysis::{AnalysisJobConfig, MediaAnalysisJobScope},
+	},
+};
 
 use crate::{
 	data::{AuthContext, CoreContext},
@@ -287,7 +290,7 @@ async fn set_series_completed(
 		.collect::<std::collections::HashMap<_, _>>();
 
 	let now = DateTimeWithTimeZone::from(Utc::now());
-	let finished_sessions = book_ids_without_completion
+	let finished_sessions_chunks = book_ids_without_completion
 		.into_iter()
 		.map(|media_id| {
 			let prior = session_map.get(&media_id);
@@ -302,13 +305,14 @@ async fn set_series_completed(
 			}
 		})
 		.collect::<Vec<finished_reading_session::ActiveModel>>();
-
-	if !finished_sessions.is_empty() {
-		let count = finished_sessions.len();
-		let _ = finished_reading_session::Entity::insert_many(finished_sessions)
-			.exec(&tx)
-			.await?;
-		tracing::debug!(count, "Inserted finished reading sessions for series");
+	if !finished_sessions_chunks.is_empty() {
+		for chunk in finished_sessions_chunks.chunks(SQLITE_BIND_LIMIT) {
+			let count = chunk.len();
+			let _ = finished_reading_session::Entity::insert_many(chunk.to_vec())
+				.exec(&tx)
+				.await?;
+			tracing::debug!(count, "Inserted finished reading sessions for series");
+		}
 	} else {
 		tracing::debug!("No books to mark as finished in series");
 	}

--- a/crates/graphql/src/mutation/series.rs
+++ b/crates/graphql/src/mutation/series.rs
@@ -252,11 +252,9 @@ async fn set_series_completed(
 				),
 			),
 		)
+		.into_tuple::<String>()
 		.all(&tx)
-		.await?
-		.into_iter()
-		.map(|m| m.id)
-		.collect::<Vec<String>>();
+		.await?;
 
 	tracing::debug!(
 		count = book_ids_without_completion.len(),

--- a/crates/graphql/src/mutation/series.rs
+++ b/crates/graphql/src/mutation/series.rs
@@ -240,7 +240,8 @@ async fn set_series_completed(
 		.column(media::Column::Id)
 		.filter(
 			media::Column::SeriesId.eq(series.series.id.clone()).and(
-				media::Column::Id.in_subquery(
+				// to get books WITHOUT completion means they do not have a finished_reading_session
+				media::Column::Id.not_in_subquery(
 					Query::select()
 						.column(finished_reading_session::Column::MediaId)
 						.from(finished_reading_session::Entity)
@@ -256,9 +257,10 @@ async fn set_series_completed(
 		.into_iter()
 		.map(|m| m.id)
 		.collect::<Vec<String>>();
+
 	tracing::debug!(
 		count = book_ids_without_completion.len(),
-		"Fetched unread/incomplete books for series"
+		"Fetched unread books within series"
 	);
 
 	let deleted_sessions = reading_session::Entity::delete_many()


### PR DESCRIPTION
See https://discord.com/channels/972593831172272148/977261661108973578/1493692252214788157 for original discussion

The primary change is to correctly filter for books without a completion record, via `not_in_subquery` instead of `in_subquery`. The code in nightly effectively flipped the query, fetching books with completion instead of without.

A secondary fix that is more hygiene is I changed the query to chunk things, just in case there are too many active models in the insert statement. 