### PR TITLE
Fetch user info from OIDC provider

### DIFF
--- a/apps/server/src/config/oidc.rs
+++ b/apps/server/src/config/oidc.rs
@@ -4,10 +4,11 @@ use openidconnect::{
 		CoreErrorResponseType, CoreGenderClaim, CoreJsonWebKey,
 		CoreJweContentEncryptionAlgorithm, CoreProviderMetadata, CoreRevocableToken,
 		CoreRevocationErrorResponse, CoreTokenIntrospectionResponse, CoreTokenResponse,
+		CoreUserInfoClaims,
 	},
 	AuthorizationCode, Client, ClientId, ClientSecret, CsrfToken, EmptyAdditionalClaims,
-	EndpointMaybeSet, EndpointNotSet, EndpointSet, IssuerUrl, Nonce, RedirectUrl, Scope,
-	StandardErrorResponse, TokenResponse,
+	EndpointMaybeSet, EndpointNotSet, EndpointSet, IssuerUrl, Nonce, OAuth2TokenResponse,
+	RedirectUrl, Scope, StandardErrorResponse, TokenResponse,
 };
 use serde::{Deserialize, Serialize};
 use stump_core::config::OidcConfig;
@@ -147,17 +148,27 @@ pub async fn exchange_code_for_claims(
 			});
 	let id_token_claims = id_token.claims(&token_verifier, nonce_verifier)?;
 
+	let access_token = token_response.access_token();
+	let user_info: CoreUserInfoClaims = client
+		.user_info(access_token.to_owned(), None)?
+		.request_async(http_client)
+		.await
+		.map_err(|error| {
+			tracing::error!(?error, "User info fetch failed");
+			APIError::OIDCTokenExchangeFailed(error.to_string())
+		})?;
+
 	Ok(OidcClaims {
 		subject: id_token_claims.subject().to_string(),
-		email: id_token_claims
+		email: user_info
 			.email()
 			.ok_or(APIError::OIDCMissingEmail)?
 			.to_string(),
-		name: id_token_claims
+		name: user_info
 			.name()
 			.and_then(|n| n.get(None))
 			.map(|n| n.to_string()),
-		picture: id_token_claims
+		picture: user_info
 			.picture()
 			.and_then(|p| p.get(None))
 			.map(|p| p.to_string()),


### PR DESCRIPTION
Fixes #1135. OIDC providers aren't required to (and, in Authelia's case, explicitly discourage) include user info in the ID token, and require fetching from the OIDC provider's user info endpoint. This patch fectches that endpoint in the exchange code flow to get the required info.