### PR TITLE
🐛 (expo): Fix header button colour for pre-ios 26 devices

### DIFF
--- a/apps/expo/app/(tabs)/index/_layout.tsx
+++ b/apps/expo/app/(tabs)/index/_layout.tsx
@@ -2,7 +2,7 @@ import { Stack } from 'expo-router'
 import { Platform } from 'react-native'
 
 import { AddServerDialog } from '~/components/savedServer'
-import { IS_IOS_24_PLUS } from '~/lib/constants'
+import { IS_IOS_26_PLUS } from '~/lib/constants'
 import { useTranslate } from '~/lib/hooks'
 import { usePreferencesStore } from '~/stores'
 
@@ -18,7 +18,7 @@ export default function Screen() {
 				headerShown: true,
 				headerTransparent: Platform.OS === 'ios',
 				headerLargeTitle: true,
-				headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+				headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 				animation: animationEnabled ? 'default' : 'none',
 				headerRight: () => <AddServerDialog />,
 			}}

--- a/apps/expo/app/(tabs)/library/_layout.tsx
+++ b/apps/expo/app/(tabs)/library/_layout.tsx
@@ -5,7 +5,7 @@ import { Platform } from 'react-native'
 import { useStore } from 'zustand'
 
 import { SelectionLeftScreenHeader } from '~/components/selection'
-import { IS_IOS_24_PLUS } from '~/lib/constants'
+import { IS_IOS_26_PLUS } from '~/lib/constants'
 import { useTranslate } from '~/lib/hooks'
 import { usePreferencesStore } from '~/stores'
 import { createSelectionStore, SelectionContext } from '~/stores/selection'
@@ -37,7 +37,7 @@ export default function Screen() {
 						headerShown: true,
 						headerTransparent: Platform.OS === 'ios',
 						headerLargeTitle: true,
-						headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+						headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 						animation: animationEnabled ? 'default' : 'none',
 						headerLargeTitleStyle: {
 							fontSize: 30,

--- a/apps/expo/app/(tabs)/settings/_layout.tsx
+++ b/apps/expo/app/(tabs)/settings/_layout.tsx
@@ -3,7 +3,7 @@ import { Stack } from 'expo-router'
 import { Platform } from 'react-native'
 
 import { settingsQueryClient } from '~/components/appSettings/queryClient'
-import { IS_IOS_24_PLUS } from '~/lib/constants'
+import { IS_IOS_26_PLUS } from '~/lib/constants'
 import { useTranslate } from '~/lib/hooks'
 import { usePreferencesStore } from '~/stores'
 
@@ -26,7 +26,7 @@ export default function Layout() {
 						title: t('common.settings'),
 						headerShown: true,
 						headerTransparent: Platform.OS === 'ios',
-						headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+						headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 						animation: animationEnabled ? 'default' : 'none',
 					}}
 				/>

--- a/apps/expo/app/offline/[fileId]/_layout.tsx
+++ b/apps/expo/app/offline/[fileId]/_layout.tsx
@@ -2,7 +2,7 @@ import { Stack } from 'expo-router'
 import { Platform } from 'react-native'
 
 import BackLink from '~/components/BackLink'
-import { IS_IOS_24_PLUS } from '~/lib/constants'
+import { IS_IOS_26_PLUS } from '~/lib/constants'
 import { usePreferencesStore } from '~/stores'
 
 export default function Screen() {
@@ -22,7 +22,7 @@ export default function Screen() {
 					headerTitle: '',
 					headerShown: Platform.OS === 'ios',
 					headerTransparent: true,
-					headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+					headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 					headerLeft: () => <BackLink />,
 				}}
 			/>

--- a/apps/expo/app/opds-legacy/[id]/(tabs)/feed/_layout.tsx
+++ b/apps/expo/app/opds-legacy/[id]/(tabs)/feed/_layout.tsx
@@ -1,7 +1,7 @@
 import { Stack } from 'expo-router'
 import { Platform } from 'react-native'
 
-import { IS_IOS_24_PLUS } from '~/lib/constants'
+import { IS_IOS_26_PLUS } from '~/lib/constants'
 import { usePreferencesStore } from '~/stores'
 
 export default function Layout() {
@@ -20,7 +20,7 @@ export default function Layout() {
 					headerShown: true,
 					title: 'Feeds',
 					headerTransparent: Platform.OS === 'ios',
-					headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+					headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 					headerLargeTitle: Platform.OS === 'ios',
 					headerLargeTitleStyle: {
 						fontSize: 30,
@@ -34,7 +34,7 @@ export default function Layout() {
 					title: '',
 					headerShown: true,
 					headerTransparent: Platform.OS === 'ios',
-					headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+					headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 				}}
 			/>
 		</Stack>

--- a/apps/expo/app/opds-legacy/[id]/(tabs)/search/_layout.tsx
+++ b/apps/expo/app/opds-legacy/[id]/(tabs)/search/_layout.tsx
@@ -1,7 +1,7 @@
 import { Stack } from 'expo-router'
 import { Platform } from 'react-native'
 
-import { IS_IOS_24_PLUS } from '~/lib/constants'
+import { IS_IOS_26_PLUS } from '~/lib/constants'
 import { usePreferencesStore } from '~/stores'
 
 export default function Layout() {
@@ -20,7 +20,7 @@ export default function Layout() {
 					headerShown: true,
 					title: 'Search',
 					headerTransparent: Platform.OS === 'ios',
-					headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+					headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 				}}
 			/>
 
@@ -29,7 +29,7 @@ export default function Layout() {
 				options={{
 					headerShown: false,
 					headerTransparent: Platform.OS === 'ios',
-					headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+					headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 				}}
 			/>
 		</Stack>

--- a/apps/expo/app/opds-legacy/[id]/(tabs)/search/index.tsx
+++ b/apps/expo/app/opds-legacy/[id]/(tabs)/search/index.tsx
@@ -8,7 +8,7 @@ import Owl from '~/components/Owl'
 import { SearchHistoryAndFavorites } from '~/components/search/SearchHistoryAndFavorites'
 import { Text } from '~/components/ui'
 import { useOPDSLegacyFeedContext } from '~/context/opdsLegacy'
-import { IS_IOS_24_PLUS, useColors } from '~/lib/constants'
+import { IS_IOS_26_PLUS, useColors } from '~/lib/constants'
 import { useSearchStore } from '~/stores/search'
 
 export default function Screen() {
@@ -51,7 +51,7 @@ export default function Screen() {
 		navigation.setOptions({
 			headerShown: true,
 			headerTransparent: Platform.OS === 'ios',
-			headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+			headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 			headerSearchBarOptions: {
 				placeholder: 'Search',
 				onChangeText: (e: NativeSyntheticEvent<TextInputChangeEventData>) =>
@@ -71,11 +71,11 @@ export default function Screen() {
 
 	if (!isInputFocused) {
 		return (
-			<View className="flex-1 items-center justify-center gap-4 bg-background p-4 tablet:p-7">
+			<View className="gap-4 p-4 tablet:p-7 flex-1 items-center justify-center bg-background">
 				<Owl owl="search" />
 
 				<View className="gap-2 px-4 tablet:max-w-lg">
-					<Text size="xl" className="text-center font-semibold leading-tight">
+					<Text size="xl" className="font-semibold leading-tight text-center">
 						Search the feed
 					</Text>
 

--- a/apps/expo/app/opds/[id]/(tabs)/feed/_layout.tsx
+++ b/apps/expo/app/opds/[id]/(tabs)/feed/_layout.tsx
@@ -1,7 +1,7 @@
 import { Stack } from 'expo-router'
 import { Platform } from 'react-native'
 
-import { IS_IOS_24_PLUS } from '~/lib/constants'
+import { IS_IOS_26_PLUS } from '~/lib/constants'
 import { usePreferencesStore } from '~/stores'
 
 export default function Layout() {
@@ -20,7 +20,7 @@ export default function Layout() {
 					headerShown: true,
 					title: 'Feeds',
 					headerTransparent: Platform.OS === 'ios',
-					headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+					headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 					headerLargeTitle: Platform.OS === 'ios',
 					headerLargeTitleStyle: {
 						fontSize: 30,
@@ -34,7 +34,7 @@ export default function Layout() {
 					title: '',
 					headerShown: true,
 					headerTransparent: Platform.OS === 'ios',
-					headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+					headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 				}}
 			/>
 		</Stack>

--- a/apps/expo/app/opds/[id]/(tabs)/search/_layout.tsx
+++ b/apps/expo/app/opds/[id]/(tabs)/search/_layout.tsx
@@ -1,7 +1,7 @@
 import { Stack } from 'expo-router'
 import { Platform } from 'react-native'
 
-import { IS_IOS_24_PLUS } from '~/lib/constants'
+import { IS_IOS_26_PLUS } from '~/lib/constants'
 import { usePreferencesStore } from '~/stores'
 
 export default function Layout() {
@@ -20,7 +20,7 @@ export default function Layout() {
 					headerShown: true,
 					title: 'Search',
 					headerTransparent: Platform.OS === 'ios',
-					headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+					headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 				}}
 			/>
 
@@ -29,7 +29,7 @@ export default function Layout() {
 				options={{
 					headerShown: false,
 					headerTransparent: Platform.OS === 'ios',
-					headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+					headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 				}}
 			/>
 		</Stack>

--- a/apps/expo/app/opds/[id]/(tabs)/search/index.tsx
+++ b/apps/expo/app/opds/[id]/(tabs)/search/index.tsx
@@ -8,7 +8,7 @@ import Owl from '~/components/Owl'
 import { SearchHistoryAndFavorites } from '~/components/search/SearchHistoryAndFavorites'
 import { Text } from '~/components/ui'
 import { useOPDSFeedContext } from '~/context/opds'
-import { IS_IOS_24_PLUS, useColors } from '~/lib/constants'
+import { IS_IOS_26_PLUS, useColors } from '~/lib/constants'
 import { useSearchStore } from '~/stores/search'
 
 export default function Screen() {
@@ -51,7 +51,7 @@ export default function Screen() {
 		navigation.setOptions({
 			headerShown: true,
 			headerTransparent: Platform.OS === 'ios',
-			headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+			headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 			headerSearchBarOptions: {
 				placeholder: 'Search',
 				onChangeText: (e: NativeSyntheticEvent<TextInputChangeEventData>) =>
@@ -71,11 +71,11 @@ export default function Screen() {
 
 	if (!isInputFocused) {
 		return (
-			<View className="flex-1 items-center justify-center gap-4 bg-background p-4 tablet:p-7">
+			<View className="gap-4 p-4 tablet:p-7 flex-1 items-center justify-center bg-background">
 				<Owl owl="search" />
 
 				<View className="gap-2 px-4 tablet:max-w-lg">
-					<Text size="xl" className="text-center font-semibold leading-tight">
+					<Text size="xl" className="font-semibold leading-tight text-center">
 						Search the feed
 					</Text>
 

--- a/apps/expo/app/opds/[id]/publication/_layout.tsx
+++ b/apps/expo/app/opds/[id]/publication/_layout.tsx
@@ -6,7 +6,7 @@ import { Platform } from 'react-native'
 
 import BackLink from '~/components/BackLink'
 import { getProgressionURL } from '~/components/opds/utils'
-import { IS_IOS_24_PLUS } from '~/lib/constants'
+import { IS_IOS_26_PLUS } from '~/lib/constants'
 
 import { PublicationContext } from './context'
 
@@ -41,7 +41,7 @@ export default function Layout() {
 						headerTitle: '',
 						headerShown: true,
 						headerTransparent: true,
-						headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+						headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 						headerLeft: Platform.OS === 'ios' ? () => <BackLink /> : undefined,
 					}}
 				/>

--- a/apps/expo/app/server/[id]/(tabs)/browse/_layout.tsx
+++ b/apps/expo/app/server/[id]/(tabs)/browse/_layout.tsx
@@ -1,7 +1,7 @@
 import { Stack } from 'expo-router'
 import { Platform } from 'react-native'
 
-import { IS_IOS_24_PLUS } from '~/lib/constants'
+import { IS_IOS_26_PLUS } from '~/lib/constants'
 
 export default function Layout() {
 	return (
@@ -12,7 +12,7 @@ export default function Layout() {
 					headerShown: true,
 					headerTitle: 'Browse',
 					headerTransparent: Platform.OS === 'ios',
-					headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+					headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 					headerLargeTitle: true,
 					headerLargeTitleStyle: {
 						fontSize: 30,

--- a/apps/expo/app/server/[id]/(tabs)/clubs/_layout.tsx
+++ b/apps/expo/app/server/[id]/(tabs)/clubs/_layout.tsx
@@ -7,7 +7,7 @@ import { Platform } from 'react-native'
 import { useActiveServer, useStumpServer } from '~/components/activeServer'
 import BackLink from '~/components/BackLink'
 import { Icon } from '~/components/ui'
-import { IS_IOS_24_PLUS } from '~/lib/constants'
+import { IS_IOS_26_PLUS } from '~/lib/constants'
 import { usePreferencesStore } from '~/stores'
 
 export default function Layout() {
@@ -27,7 +27,7 @@ export default function Layout() {
 					headerShown: true,
 					headerTitle: 'Clubs',
 					headerTransparent: Platform.OS === 'ios',
-					headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+					headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 					headerLargeTitle: true,
 					headerLargeTitleStyle: { fontSize: 30 },
 					headerRight:
@@ -43,7 +43,7 @@ export default function Layout() {
 					headerShown: true,
 					title: 'Invites',
 					headerTransparent: Platform.OS === 'ios',
-					headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+					headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 					animation: animationEnabled ? 'default' : 'none',
 					presentation: 'formSheet',
 					headerLeft: Platform.OS === 'android' ? undefined : () => <BackLink />,
@@ -57,7 +57,7 @@ export default function Layout() {
 						headerShown: true,
 						title: 'Create Club',
 						headerTransparent: Platform.OS === 'ios',
-						headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+						headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 						presentation: 'formSheet',
 						animation: animationEnabled ? 'default' : 'none',
 						headerLeft: Platform.OS === 'android' ? undefined : () => <BackLink />,

--- a/apps/expo/app/server/[id]/(tabs)/index/_layout.tsx
+++ b/apps/expo/app/server/[id]/(tabs)/index/_layout.tsx
@@ -2,7 +2,7 @@ import { Stack } from 'expo-router'
 import { Platform } from 'react-native'
 
 import { useActiveServer } from '~/components/activeServer'
-import { IS_IOS_24_PLUS } from '~/lib/constants'
+import { IS_IOS_26_PLUS } from '~/lib/constants'
 import { usePreferencesStore } from '~/stores'
 
 export default function Layout() {
@@ -24,7 +24,7 @@ export default function Layout() {
 						fontSize: 30,
 					},
 					headerLargeTitle: true,
-					headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+					headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 					animation: animationEnabled ? 'default' : 'none',
 				}}
 			/>

--- a/apps/expo/app/server/[id]/(tabs)/search/_layout.tsx
+++ b/apps/expo/app/server/[id]/(tabs)/search/_layout.tsx
@@ -1,7 +1,7 @@
 import { Stack } from 'expo-router'
 import { Platform } from 'react-native'
 
-import { IS_IOS_24_PLUS } from '~/lib/constants'
+import { IS_IOS_26_PLUS } from '~/lib/constants'
 
 export default function Layout() {
 	return (
@@ -16,7 +16,7 @@ export default function Layout() {
 					headerShown: true,
 					title: 'Search',
 					headerTransparent: Platform.OS === 'ios',
-					headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+					headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 				}}
 			/>
 
@@ -25,7 +25,7 @@ export default function Layout() {
 				options={{
 					headerShown: false,
 					headerTransparent: Platform.OS === 'ios',
-					headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+					headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 				}}
 			/>
 		</Stack>

--- a/apps/expo/app/server/[id]/(tabs)/search/index.tsx
+++ b/apps/expo/app/server/[id]/(tabs)/search/index.tsx
@@ -10,7 +10,7 @@ import { useActiveServer } from '~/components/activeServer'
 import Owl from '~/components/Owl'
 import { SearchHistoryAndFavorites } from '~/components/search/SearchHistoryAndFavorites'
 import { Text } from '~/components/ui'
-import { IS_IOS_24_PLUS, useColors } from '~/lib/constants'
+import { IS_IOS_26_PLUS, useColors } from '~/lib/constants'
 import { useSearchStore } from '~/stores/search'
 
 import { prefetchBookSearch } from '../../books/search[q]'
@@ -59,7 +59,7 @@ export default function Screen() {
 		navigation.setOptions({
 			headerShown: true,
 			headerTransparent: Platform.OS === 'ios',
-			headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+			headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 			headerSearchBarOptions: {
 				placeholder: 'Search',
 				onChangeText: (e: NativeSyntheticEvent<TextInputChangeEventData>) =>
@@ -79,10 +79,10 @@ export default function Screen() {
 
 	if (!isInputFocused) {
 		return (
-			<View className="flex-1 items-center justify-center gap-4 bg-background p-4 tablet:p-7">
+			<View className="gap-4 p-4 tablet:p-7 flex-1 items-center justify-center bg-background">
 				<Owl owl="search" />
 				<View className="gap-2 px-4 tablet:max-w-lg">
-					<Text size="xl" className="text-center font-semibold leading-tight">
+					<Text size="xl" className="font-semibold leading-tight text-center">
 						Search the server
 					</Text>
 					<Text size="lg" className="text-center text-foreground-muted">

--- a/apps/expo/app/server/[id]/books/[id]/_layout.tsx
+++ b/apps/expo/app/server/[id]/books/[id]/_layout.tsx
@@ -2,7 +2,7 @@ import { Stack } from 'expo-router'
 import { Platform } from 'react-native'
 
 import BackLink from '~/components/BackLink'
-import { IS_IOS_24_PLUS } from '~/lib/constants'
+import { IS_IOS_26_PLUS } from '~/lib/constants'
 import { usePreferencesStore } from '~/stores'
 
 export default function Screen() {
@@ -22,7 +22,7 @@ export default function Screen() {
 					headerTitle: '',
 					headerShown: Platform.OS === 'ios',
 					headerTransparent: true,
-					headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+					headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 					headerLeft: () => <BackLink />,
 				}}
 			/>

--- a/apps/expo/app/server/[id]/books/_layout.tsx
+++ b/apps/expo/app/server/[id]/books/_layout.tsx
@@ -2,7 +2,7 @@ import { Stack } from 'expo-router'
 import { Platform } from 'react-native'
 
 import BackLink from '~/components/BackLink'
-import { IS_IOS_24_PLUS } from '~/lib/constants'
+import { IS_IOS_26_PLUS } from '~/lib/constants'
 import { usePreferencesStore } from '~/stores'
 
 export default function Screen() {
@@ -21,7 +21,7 @@ export default function Screen() {
 					headerShown: true,
 					headerTitle: 'Books',
 					headerTransparent: Platform.OS === 'ios',
-					headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+					headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 					headerLargeTitle: false,
 					headerLeft: Platform.OS === 'android' ? undefined : () => <BackLink />,
 				}}

--- a/apps/expo/app/server/[id]/clubs/[clubId]/_layout.tsx
+++ b/apps/expo/app/server/[id]/clubs/[clubId]/_layout.tsx
@@ -5,7 +5,7 @@ import { Platform } from 'react-native'
 
 import BackLink from '~/components/BackLink'
 import { BookClubContext } from '~/components/bookClub/context'
-import { IS_IOS_24_PLUS } from '~/lib/constants'
+import { IS_IOS_26_PLUS } from '~/lib/constants'
 import { usePreferencesStore } from '~/stores'
 
 const clubContextQuery = graphql(`
@@ -39,7 +39,7 @@ export default function Screen() {
 						headerShown: false,
 						title: '',
 						headerTransparent: Platform.OS === 'ios',
-						headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+						headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 						headerLargeTitleStyle: {
 							fontSize: 30,
 						},
@@ -71,7 +71,7 @@ export default function Screen() {
 						headerShown: false,
 						title: '',
 						headerTransparent: Platform.OS === 'ios',
-						headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+						headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 						headerLeft: Platform.OS === 'android' ? undefined : () => <BackLink />,
 					}}
 				/>

--- a/apps/expo/app/server/[id]/files/_layout.tsx
+++ b/apps/expo/app/server/[id]/files/_layout.tsx
@@ -3,7 +3,7 @@ import { Platform, View } from 'react-native'
 
 import BackLink from '~/components/BackLink'
 import { FileExplorerAssetsProvider } from '~/components/fileExplorer'
-import { ENABLE_LARGE_HEADER, IS_IOS_24_PLUS } from '~/lib/constants'
+import { IS_IOS_26_PLUS } from '~/lib/constants'
 import { usePreferencesStore } from '~/stores'
 
 export default function Screen() {
@@ -41,8 +41,7 @@ export default function Screen() {
 						headerLargeTitleStyle: {
 							fontSize: 24,
 						},
-						headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
-						headerLargeTitle: ENABLE_LARGE_HEADER,
+						headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 					}}
 				/>
 
@@ -52,7 +51,7 @@ export default function Screen() {
 						headerShown: true,
 						headerTitle: '',
 						headerTransparent: Platform.OS === 'ios',
-						headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+						headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 					}}
 					dangerouslySingular
 				/>

--- a/apps/expo/app/server/[id]/libraries/_layout.tsx
+++ b/apps/expo/app/server/[id]/libraries/_layout.tsx
@@ -2,7 +2,7 @@ import { Stack } from 'expo-router'
 import { Platform } from 'react-native'
 
 import BackLink from '~/components/BackLink'
-import { IS_IOS_24_PLUS } from '~/lib/constants'
+import { IS_IOS_26_PLUS } from '~/lib/constants'
 import { usePreferencesStore } from '~/stores'
 
 export default function Screen() {
@@ -20,7 +20,7 @@ export default function Screen() {
 						fontSize: 30,
 					},
 					headerLargeTitle: Platform.OS === 'ios',
-					headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+					headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 					animation: animationEnabled ? 'default' : 'none',
 					headerLeft: Platform.OS === 'android' ? undefined : () => <BackLink />,
 				}}

--- a/apps/expo/app/server/[id]/series/_layout.tsx
+++ b/apps/expo/app/server/[id]/series/_layout.tsx
@@ -3,7 +3,7 @@ import { useRef } from 'react'
 import { Platform } from 'react-native'
 
 import BackLink from '~/components/BackLink'
-import { IS_IOS_24_PLUS } from '~/lib/constants'
+import { IS_IOS_26_PLUS } from '~/lib/constants'
 import { usePreferencesStore } from '~/stores'
 import { createSeriesFilterStore, SeriesFilterContext } from '~/stores/filters'
 
@@ -32,7 +32,7 @@ export default function Screen() {
 							fontSize: 30,
 						},
 						headerLargeTitle: Platform.OS === 'ios',
-						headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+						headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 						animation: animationEnabled ? 'default' : 'none',
 						headerLeft: Platform.OS === 'android' ? undefined : () => <BackLink />,
 					}}
@@ -44,7 +44,7 @@ export default function Screen() {
 						headerShown: true,
 						headerTitle: '',
 						headerTransparent: Platform.OS === 'ios',
-						headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+						headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 						animation: animationEnabled ? 'default' : 'none',
 					}}
 				/>

--- a/apps/expo/app/server/[id]/smart-lists/_layout.tsx
+++ b/apps/expo/app/server/[id]/smart-lists/_layout.tsx
@@ -2,7 +2,7 @@ import { Stack } from 'expo-router'
 import { Platform } from 'react-native'
 
 import BackLink from '~/components/BackLink'
-import { IS_IOS_24_PLUS } from '~/lib/constants'
+import { IS_IOS_26_PLUS } from '~/lib/constants'
 import { usePreferencesStore } from '~/stores'
 
 export default function Screen() {
@@ -20,7 +20,7 @@ export default function Screen() {
 						fontSize: 30,
 					},
 					headerLargeTitle: Platform.OS === 'ios',
-					headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+					headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 					animation: animationEnabled ? 'default' : 'none',
 					headerLeft: Platform.OS === 'android' ? undefined : () => <BackLink />,
 				}}

--- a/apps/expo/components/book/overview/DescriptionSection.tsx
+++ b/apps/expo/components/book/overview/DescriptionSection.tsx
@@ -6,7 +6,7 @@ import { stripHtml } from 'string-strip-html'
 
 import { SheetBackDetection } from '~/components/SheetBackDetection'
 import { Markdown, Text } from '~/components/ui'
-import { IS_IOS_24_PLUS, useColors } from '~/lib/constants'
+import { IS_IOS_26_PLUS, useColors } from '~/lib/constants'
 import { useTranslate } from '~/lib/hooks'
 
 import { DottedLine } from './DottedLine'
@@ -61,7 +61,7 @@ export default function DescriptionSection({ description }: Props) {
 				detents={Platform.OS === 'android' ? [0.5, 1] : ['auto']}
 				grabber
 				scrollable
-				backgroundColor={IS_IOS_24_PLUS ? undefined : colors.background.DEFAULT}
+				backgroundColor={IS_IOS_26_PLUS ? undefined : colors.background.DEFAULT}
 				grabberOptions={{ color: colors.sheet.grabber }}
 				onDidPresent={() => setIsOpen(true)}
 				onDidDismiss={() => setIsOpen(false)}

--- a/apps/expo/components/book/overview/IdentifiersSheet.tsx
+++ b/apps/expo/components/book/overview/IdentifiersSheet.tsx
@@ -5,7 +5,7 @@ import { Platform, Pressable, ScrollView, View } from 'react-native'
 
 import { SheetBackDetection } from '~/components/SheetBackDetection'
 import { Card, Text } from '~/components/ui'
-import { IS_IOS_24_PLUS, useColors } from '~/lib/constants'
+import { IS_IOS_26_PLUS, useColors } from '~/lib/constants'
 
 import { DottedLine } from './DottedLine'
 
@@ -59,7 +59,7 @@ export default function IdentifiersSheet({ identifiers }: Props) {
 				detents={Platform.OS === 'android' ? [0.4, 1] : ['auto']}
 				grabber
 				scrollable
-				backgroundColor={IS_IOS_24_PLUS ? undefined : colors.background.DEFAULT}
+				backgroundColor={IS_IOS_26_PLUS ? undefined : colors.background.DEFAULT}
 				grabberOptions={{ color: colors.sheet.grabber }}
 				onDidPresent={() => setIsOpen(true)}
 				onDidDismiss={() => setIsOpen(false)}

--- a/apps/expo/components/book/reader/epub/CustomizeThemeSheet.tsx
+++ b/apps/expo/components/book/reader/epub/CustomizeThemeSheet.tsx
@@ -4,7 +4,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useShallow } from 'zustand/react/shallow'
 
 import { SheetBackDetection } from '~/components/SheetBackDetection'
-import { IS_IOS_24_PLUS, useColors } from '~/lib/constants'
+import { IS_IOS_26_PLUS, useColors } from '~/lib/constants'
 import { useEpubSheetStore } from '~/stores/epubSheet'
 
 import { CustomizeTheme } from './controls/customTheme'
@@ -35,7 +35,7 @@ export default function CustomizeThemeSheet() {
 				detents={[1]}
 				grabber
 				scrollable
-				backgroundColor={IS_IOS_24_PLUS ? undefined : colors.background.DEFAULT}
+				backgroundColor={IS_IOS_26_PLUS ? undefined : colors.background.DEFAULT}
 				grabberOptions={{ color: colors.sheet.grabber }}
 				style={{
 					paddingBottom: insets.bottom,

--- a/apps/expo/components/book/reader/epub/EpubLocationsSheet.tsx
+++ b/apps/expo/components/book/reader/epub/EpubLocationsSheet.tsx
@@ -5,7 +5,7 @@ import { Platform } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 import { SheetBackDetection } from '~/components/SheetBackDetection'
-import { IS_IOS_24_PLUS, useColors } from '~/lib/constants'
+import { IS_IOS_26_PLUS, useColors } from '~/lib/constants'
 import { PortalHostContext } from '~/lib/PortalHostContext'
 import { useEpubSheetStore } from '~/stores/epubSheet'
 
@@ -29,7 +29,7 @@ export default function EpubLocationsSheet() {
 				dimmed={false}
 				scrollable
 				grabber
-				backgroundColor={IS_IOS_24_PLUS ? undefined : colors.background.DEFAULT}
+				backgroundColor={IS_IOS_26_PLUS ? undefined : colors.background.DEFAULT}
 				grabberOptions={{ color: colors.sheet.grabber }}
 				style={{
 					paddingBottom: insets.bottom,

--- a/apps/expo/components/book/reader/epub/EpubSettingsSheet.tsx
+++ b/apps/expo/components/book/reader/epub/EpubSettingsSheet.tsx
@@ -5,7 +5,7 @@ import { Platform, ScrollView } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 import { SheetBackDetection } from '~/components/SheetBackDetection'
-import { IS_IOS_24_PLUS, useColors } from '~/lib/constants'
+import { IS_IOS_26_PLUS, useColors } from '~/lib/constants'
 import { PortalHostContext } from '~/lib/PortalHostContext'
 import { useEpubSheetStore } from '~/stores/epubSheet'
 
@@ -29,7 +29,7 @@ export default function EpubSettingsSheet(props: TrueSheetProps) {
 				dimmed={false}
 				grabber
 				scrollable
-				backgroundColor={IS_IOS_24_PLUS ? undefined : colors.background.DEFAULT}
+				backgroundColor={IS_IOS_26_PLUS ? undefined : colors.background.DEFAULT}
 				grabberOptions={{ color: colors.sheet.grabber }}
 				style={{
 					paddingBottom: insets.bottom,

--- a/apps/expo/components/book/reader/epub/annotations/CreateAnnotationSheet.tsx
+++ b/apps/expo/components/book/reader/epub/annotations/CreateAnnotationSheet.tsx
@@ -4,7 +4,7 @@ import { TextInput, View } from 'react-native'
 
 import { SheetBackDetection } from '~/components/SheetBackDetection'
 import { Text } from '~/components/ui'
-import { IS_IOS_24_PLUS, useColors } from '~/lib/constants'
+import { IS_IOS_26_PLUS, useColors } from '~/lib/constants'
 import { ReadiumLocator } from '~/modules/readium'
 
 import AnnotationSheetHeader from './AnnotationSheetHeader'
@@ -62,7 +62,7 @@ const CreateAnnotationSheet = forwardRef<CreateAnnotationSheetRef, Props>(
 					ref={sheetRef}
 					detents={['auto', 1]}
 					grabber
-					backgroundColor={IS_IOS_24_PLUS ? undefined : colors.background.DEFAULT}
+					backgroundColor={IS_IOS_26_PLUS ? undefined : colors.background.DEFAULT}
 					grabberOptions={{
 						color: colors.sheet.grabber,
 					}}

--- a/apps/expo/components/book/reader/epub/annotations/UpdateAnnotationSheet.tsx
+++ b/apps/expo/components/book/reader/epub/annotations/UpdateAnnotationSheet.tsx
@@ -4,7 +4,7 @@ import { Alert, TextInput, View } from 'react-native'
 
 import { SheetBackDetection } from '~/components/SheetBackDetection'
 import { Button, Text } from '~/components/ui'
-import { IS_IOS_24_PLUS, useColors } from '~/lib/constants'
+import { IS_IOS_26_PLUS, useColors } from '~/lib/constants'
 import { Decoration } from '~/modules/readium'
 
 import AnnotationSheetHeader from './AnnotationSheetHeader'
@@ -82,7 +82,7 @@ const UpdateAnnotationSheet = forwardRef<UpdateAnnotationSheetRef, Props>(
 					ref={sheetRef}
 					detents={['auto', 1]}
 					grabber
-					backgroundColor={IS_IOS_24_PLUS ? undefined : colors.background.DEFAULT}
+					backgroundColor={IS_IOS_26_PLUS ? undefined : colors.background.DEFAULT}
 					grabberOptions={{
 						color: colors.sheet.grabber,
 					}}

--- a/apps/expo/components/book/reader/epub/controls/ThemeSelect.tsx
+++ b/apps/expo/components/book/reader/epub/controls/ThemeSelect.tsx
@@ -5,7 +5,7 @@ import * as ContextMenu from 'zeego/context-menu'
 import { useShallow } from 'zustand/react/shallow'
 
 import { Icon } from '~/components/ui/icon'
-import { IS_IOS_24_PLUS } from '~/lib/constants'
+import { IS_IOS_26_PLUS } from '~/lib/constants'
 import { useColorScheme } from '~/lib/useColorScheme'
 import { cn } from '~/lib/utils'
 import { EPUBReaderThemeConfig } from '~/modules/readium'
@@ -33,7 +33,7 @@ export default function ThemeSelect() {
 			horizontal
 			showsHorizontalScrollIndicator={false}
 			// The sheet has p-6 (21px), so we remove 1px to look like the scroll is going under the ios 26+ sheet border
-			className={cn('-mx-6 -my-16', IS_IOS_24_PLUS && '-mx-[20px]')}
+			className={cn('-mx-6 -my-16', IS_IOS_26_PLUS && '-mx-[20px]')}
 			// Context menu (long press) has a massive shadow on ios so we need a lot of padding to not have it be cut off
 			contentContainerClassName="px-8 py-16 gap-2"
 		>

--- a/apps/expo/components/book/reader/epub/controls/customTheme/ThemeHeaderPreview.tsx
+++ b/apps/expo/components/book/reader/epub/controls/customTheme/ThemeHeaderPreview.tsx
@@ -4,7 +4,7 @@ import { Pressable, TextStyle, View } from 'react-native'
 import { useShallow } from 'zustand/react/shallow'
 
 import { Text } from '~/components/ui'
-import { IS_IOS_24_PLUS } from '~/lib/constants'
+import { IS_IOS_26_PLUS } from '~/lib/constants'
 import { useColorScheme } from '~/lib/useColorScheme'
 import { useReaderStore } from '~/stores'
 import {
@@ -81,11 +81,11 @@ export const ThemeHeaderPreview = ({ customTheme: customThemeProp, onCancel, onS
 			style={{
 				height: HEIGHT,
 				backgroundColor: displayTheme.colors?.background,
-				paddingTop: IS_IOS_24_PLUS ? 16 : 0,
+				paddingTop: IS_IOS_26_PLUS ? 16 : 0,
 			}}
 		>
 			{onCancel && onSaved && (
-				<View className="h-12 flex-row items-center justify-between px-4">
+				<View className="h-12 px-4 flex-row items-center justify-between">
 					<Pressable onPress={handleCancel}>
 						{({ pressed }) => (
 							<Text
@@ -150,7 +150,7 @@ export const ThemeHeaderPreview = ({ customTheme: customThemeProp, onCancel, onS
 
 const getNumberOfLines = (fontSize: number, lineHeight: number, hasHeader: boolean) => {
 	const sizePlusPadding =
-		(IS_IOS_24_PLUS ? HEIGHT + 16 : HEIGHT) -
+		(IS_IOS_26_PLUS ? HEIGHT + 16 : HEIGHT) -
 		48 - // 48 for header
 		32 - // Secondary padding
 		(hasHeader ? 48 / 2 : 0) -

--- a/apps/expo/components/book/reader/image/Header.tsx
+++ b/apps/expo/components/book/reader/image/Header.tsx
@@ -6,7 +6,7 @@ import { initialWindowMetrics, useSafeAreaInsets } from 'react-native-safe-area-
 
 import { Heading } from '~/components/ui'
 import { HeaderButton } from '~/components/ui/header-button/header-button'
-import { COLORS } from '~/lib/constants'
+import { COLORS, IS_IOS_24_PLUS } from '~/lib/constants'
 
 import { PagedActionMenu } from '../shared/paged-action-menu/PagedActionMenu'
 import { useReaderAnimations } from '../shared/readerAnimations'
@@ -34,7 +34,10 @@ export default function Header({ onShowGlobalSettings }: Props) {
 					icon={{
 						android: X,
 						ios: 'xmark',
-						color: Platform.OS === 'android' ? COLORS.dark.foreground.DEFAULT : 'primary',
+						color:
+							Platform.OS === 'android' || !IS_IOS_24_PLUS
+								? COLORS.dark.foreground.DEFAULT
+								: 'primary',
 					}}
 					onPress={() => router.back()}
 					ios={{ variant: 'glass' }}

--- a/apps/expo/components/book/reader/image/Header.tsx
+++ b/apps/expo/components/book/reader/image/Header.tsx
@@ -6,7 +6,7 @@ import { initialWindowMetrics, useSafeAreaInsets } from 'react-native-safe-area-
 
 import { Heading } from '~/components/ui'
 import { HeaderButton } from '~/components/ui/header-button/header-button'
-import { COLORS, IS_IOS_24_PLUS } from '~/lib/constants'
+import { COLORS, IS_IOS_26_PLUS } from '~/lib/constants'
 
 import { PagedActionMenu } from '../shared/paged-action-menu/PagedActionMenu'
 import { useReaderAnimations } from '../shared/readerAnimations'
@@ -35,7 +35,7 @@ export default function Header({ onShowGlobalSettings }: Props) {
 						android: X,
 						ios: 'xmark',
 						color:
-							Platform.OS === 'android' || !IS_IOS_24_PLUS
+							Platform.OS === 'android' || !IS_IOS_26_PLUS
 								? COLORS.dark.foreground.DEFAULT
 								: 'primary',
 					}}

--- a/apps/expo/components/book/reader/image/ImageReaderSettingsSheet.tsx
+++ b/apps/expo/components/book/reader/image/ImageReaderSettingsSheet.tsx
@@ -11,7 +11,7 @@ import Animated, {
 
 import { SheetBackDetection } from '~/components/SheetBackDetection'
 import { Heading, Switch, Text } from '~/components/ui'
-import { IS_IOS_24_PLUS, useColors } from '~/lib/constants'
+import { IS_IOS_26_PLUS, useColors } from '~/lib/constants'
 import { useTranslate } from '~/lib/hooks'
 import { useColorScheme } from '~/lib/useColorScheme'
 import { usePreferencesStore, useReaderStore } from '~/stores'
@@ -64,7 +64,7 @@ export default function ImageReaderSettingsSheet(props: TrueSheetProps) {
 				detents={[0.5, 1]}
 				grabber
 				scrollable
-				backgroundColor={IS_IOS_24_PLUS ? undefined : colors.background.DEFAULT}
+				backgroundColor={IS_IOS_26_PLUS ? undefined : colors.background.DEFAULT}
 				grabberOptions={{ color: colors.sheet.grabber }}
 				insetAdjustment="automatic"
 				{...props}

--- a/apps/expo/components/book/reader/shared/paged-action-menu/PagedActionMenu.ios.tsx
+++ b/apps/expo/components/book/reader/shared/paged-action-menu/PagedActionMenu.ios.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import * as NativeDropdownMenu from 'zeego/dropdown-menu'
 
 import { HeaderButton } from '~/components/ui/header-button/header-button'
-import { COLORS, IS_IOS_24_PLUS } from '~/lib/constants'
+import { COLORS, IS_IOS_26_PLUS } from '~/lib/constants'
 import { useTranslate } from '~/lib/hooks'
 import { BookPreferences, useBookPreferences } from '~/stores/reader'
 
@@ -42,7 +42,7 @@ export function PagedActionMenu({
 					icon={{
 						ios: 'ellipsis',
 						android: Ellipsis,
-						color: !IS_IOS_24_PLUS ? COLORS.dark.foreground.DEFAULT : 'primary',
+						color: !IS_IOS_26_PLUS ? COLORS.dark.foreground.DEFAULT : 'primary',
 					}}
 					ios={{
 						variant: 'glass',

--- a/apps/expo/components/book/reader/shared/paged-action-menu/PagedActionMenu.ios.tsx
+++ b/apps/expo/components/book/reader/shared/paged-action-menu/PagedActionMenu.ios.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import * as NativeDropdownMenu from 'zeego/dropdown-menu'
 
 import { HeaderButton } from '~/components/ui/header-button/header-button'
+import { COLORS, IS_IOS_24_PLUS } from '~/lib/constants'
 import { useTranslate } from '~/lib/hooks'
 import { BookPreferences, useBookPreferences } from '~/stores/reader'
 
@@ -38,7 +39,11 @@ export function PagedActionMenu({
 		<NativeDropdownMenu.Root open={isOpen} onOpenChange={setIsOpen}>
 			<NativeDropdownMenu.Trigger>
 				<HeaderButton
-					icon={{ ios: 'ellipsis', android: Ellipsis }}
+					icon={{
+						ios: 'ellipsis',
+						android: Ellipsis,
+						color: !IS_IOS_24_PLUS ? COLORS.dark.foreground.DEFAULT : 'primary',
+					}}
 					ios={{
 						variant: 'glass',
 					}}

--- a/apps/expo/components/bookClub/AddBookOptionsSheet.tsx
+++ b/apps/expo/components/bookClub/AddBookOptionsSheet.tsx
@@ -6,7 +6,7 @@ import { forwardRef, useCallback, useImperativeHandle, useRef } from 'react'
 import { Platform, View } from 'react-native'
 import { Pressable } from 'react-native-gesture-handler'
 
-import { IS_IOS_24_PLUS, useColors } from '~/lib/constants'
+import { IS_IOS_26_PLUS, useColors } from '~/lib/constants'
 
 import { Icon, Text } from '../ui'
 import { AddBookSheet, type AddBookSheetRef, usePrefetchAddBookSheet } from './AddBookSheet'
@@ -65,7 +65,7 @@ export const AddBookOptionsSheet = forwardRef<AddBookOptionsSheetRef, Props>(
 				ref={sheetRef}
 				detents={['auto']}
 				grabber
-				backgroundColor={IS_IOS_24_PLUS ? undefined : colors.sheet.background}
+				backgroundColor={IS_IOS_26_PLUS ? undefined : colors.sheet.background}
 				grabberOptions={{ color: colors.sheet.grabber }}
 				onDidPresent={prefetchAddBookSheet}
 			>

--- a/apps/expo/components/bookClub/AddBookSheet.tsx
+++ b/apps/expo/components/bookClub/AddBookSheet.tsx
@@ -5,7 +5,7 @@ import { BookClubBookInput, graphql, InterfaceLayout, MediaFilterInput } from '@
 import { forwardRef, useCallback, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
-import { IS_IOS_24_PLUS, ON_END_REACHED_THRESHOLD, useColors } from '~/lib/constants'
+import { IS_IOS_26_PLUS, ON_END_REACHED_THRESHOLD, useColors } from '~/lib/constants'
 
 import { useActiveServer } from '../activeServer'
 import BookListItem from '../book/BookListItem'
@@ -141,7 +141,7 @@ export const AddBookSheet = forwardRef<AddBookSheetRef, Props>(({ onAddBook }, r
 				dimmed={false}
 				grabber
 				scrollable
-				backgroundColor={IS_IOS_24_PLUS ? undefined : colors.sheet.background}
+				backgroundColor={IS_IOS_26_PLUS ? undefined : colors.sheet.background}
 				grabberOptions={{
 					color: colors.sheet.grabber,
 				}}

--- a/apps/expo/components/bookClub/CurrentBookSheet.tsx
+++ b/apps/expo/components/bookClub/CurrentBookSheet.tsx
@@ -9,7 +9,7 @@ import Animated from 'react-native-reanimated'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import TImage from 'react-native-turbo-image'
 
-import { IS_IOS_24_PLUS, useColors } from '~/lib/constants'
+import { IS_IOS_26_PLUS, useColors } from '~/lib/constants'
 import { usePreferencesStore } from '~/stores'
 
 import { useActiveServer } from '../activeServer'
@@ -80,7 +80,7 @@ export const CurrentBookSheet = forwardRef<CurrentBookSheetRef, Props>(({ book }
 				dimmed={false}
 				grabber
 				scrollable
-				backgroundColor={IS_IOS_24_PLUS ? undefined : colors.sheet.background}
+				backgroundColor={IS_IOS_26_PLUS ? undefined : colors.sheet.background}
 				grabberOptions={{
 					color: colors.sheet.grabber,
 				}}

--- a/apps/expo/components/bookClub/ManualBookEntrySheet.tsx
+++ b/apps/expo/components/bookClub/ManualBookEntrySheet.tsx
@@ -6,7 +6,7 @@ import { Controller, useForm, useFormState } from 'react-hook-form'
 import { ScrollView, View } from 'react-native'
 import { z } from 'zod'
 
-import { IS_IOS_24_PLUS, useColors } from '~/lib/constants'
+import { IS_IOS_26_PLUS, useColors } from '~/lib/constants'
 
 import { SheetBackDetection } from '../SheetBackDetection'
 import { Input, SheetHeader } from '../ui'
@@ -83,7 +83,7 @@ export const ManualBookEntrySheet = forwardRef<ManualBookEntrySheetRef, Props>(
 					detents={['auto', 1]}
 					grabber
 					scrollable
-					backgroundColor={IS_IOS_24_PLUS ? undefined : colors.sheet.background}
+					backgroundColor={IS_IOS_26_PLUS ? undefined : colors.sheet.background}
 					grabberOptions={{ color: colors.sheet.grabber }}
 					onDidPresent={() => setIsOpen(true)}
 					onDidDismiss={handleDismiss}

--- a/apps/expo/components/bookClub/PreviewBookSheet.tsx
+++ b/apps/expo/components/bookClub/PreviewBookSheet.tsx
@@ -7,7 +7,7 @@ import Animated from 'react-native-reanimated'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import TImage from 'react-native-turbo-image'
 
-import { IS_IOS_24_PLUS, useColors } from '~/lib/constants'
+import { IS_IOS_26_PLUS, useColors } from '~/lib/constants'
 import { usePreferencesStore } from '~/stores'
 
 import { useOverviewAnimations } from '../book/overview'
@@ -89,7 +89,7 @@ export const PreviewBookSheet = forwardRef<PreviewBookSheetRef, Props>(
 				dimmed={false}
 				grabber
 				scrollable
-				backgroundColor={IS_IOS_24_PLUS ? undefined : colors.sheet.background}
+				backgroundColor={IS_IOS_26_PLUS ? undefined : colors.sheet.background}
 				grabberOptions={{
 					color: colors.sheet.grabber,
 				}}

--- a/apps/expo/components/bookClub/SuggestionsPickerSheet.tsx
+++ b/apps/expo/components/bookClub/SuggestionsPickerSheet.tsx
@@ -13,7 +13,7 @@ import { View } from 'react-native'
 import { Pressable } from 'react-native-gesture-handler'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
-import { IS_IOS_24_PLUS, useColors } from '~/lib/constants'
+import { IS_IOS_26_PLUS, useColors } from '~/lib/constants'
 
 import ListEmpty from '../ListEmpty'
 import { SheetBackDetection } from '../SheetBackDetection'
@@ -102,7 +102,7 @@ export const SuggestionsPickerSheet = forwardRef<SuggestionsPickerSheetRef, Prop
 					detents={[1]}
 					grabber
 					scrollable
-					backgroundColor={IS_IOS_24_PLUS ? undefined : colors.sheet.background}
+					backgroundColor={IS_IOS_26_PLUS ? undefined : colors.sheet.background}
 					grabberOptions={{ color: colors.sheet.grabber }}
 					style={{ paddingBottom: insets.bottom }}
 					insetAdjustment="automatic"

--- a/apps/expo/components/bookClub/discussion/MessageActionSheet.tsx
+++ b/apps/expo/components/bookClub/discussion/MessageActionSheet.tsx
@@ -6,7 +6,7 @@ import { View } from 'react-native'
 import { Pressable } from 'react-native-gesture-handler'
 
 import { Divider } from '~/components/Divider'
-import { IS_IOS_24_PLUS, useColors } from '~/lib/constants'
+import { IS_IOS_26_PLUS, useColors } from '~/lib/constants'
 import { cn } from '~/lib/utils'
 
 import { EmojiPickerSheet, type EmojiPickerSheetRef } from '../../emoji/EmojiPickerSheet'
@@ -101,7 +101,7 @@ export const MessageActionSheet = forwardRef<MessageActionSheetRef, Props>(
 				ref={sheetRef}
 				detents={['auto']}
 				grabber
-				backgroundColor={IS_IOS_24_PLUS ? undefined : colors.sheet.background}
+				backgroundColor={IS_IOS_26_PLUS ? undefined : colors.sheet.background}
 				grabberOptions={{ color: colors.sheet.grabber }}
 			>
 				<View className="pb-8 pt-2">

--- a/apps/expo/components/emoji/EmojiPickerSheet.tsx
+++ b/apps/expo/components/emoji/EmojiPickerSheet.tsx
@@ -4,7 +4,7 @@ import { useSDK } from '@stump/client'
 import { forwardRef, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import { Image, Pressable, View } from 'react-native'
 
-import { IS_IOS_24_PLUS, useColors } from '~/lib/constants'
+import { IS_IOS_26_PLUS, useColors } from '~/lib/constants'
 import { useDisplay } from '~/lib/hooks'
 
 import { Input, SheetHeader, Text } from '../ui'
@@ -261,7 +261,7 @@ export const EmojiPickerSheet = forwardRef<EmojiPickerSheetRef, Props>(({ onEmoj
 			ref={sheetRef}
 			detents={[1]}
 			grabber
-			backgroundColor={IS_IOS_24_PLUS ? undefined : colors.sheet.background}
+			backgroundColor={IS_IOS_26_PLUS ? undefined : colors.sheet.background}
 			grabberOptions={{ color: colors.sheet.grabber }}
 			header={<SheetHeader title="Emojis" onClose={dismissSheet} />}
 			scrollable

--- a/apps/expo/components/library/LibraryOverviewSheet.tsx
+++ b/apps/expo/components/library/LibraryOverviewSheet.tsx
@@ -9,7 +9,7 @@ import { View } from 'react-native'
 import { ScrollView } from 'react-native-gesture-handler'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
-import { IS_IOS_24_PLUS, STAT_COLORS, useColors } from '~/lib/constants'
+import { IS_IOS_26_PLUS, STAT_COLORS, useColors } from '~/lib/constants'
 import { formatBytesSeparate } from '~/lib/format'
 
 import { useGridItemSize } from '../listLayout/grid/useGridItemSize'
@@ -75,7 +75,7 @@ export const LibraryOverviewSheet = forwardRef<TrueSheet, Props>(({ libraryId },
 				detents={[0.5, 1]}
 				grabber
 				scrollable
-				backgroundColor={IS_IOS_24_PLUS ? undefined : colors.sheet.background}
+				backgroundColor={IS_IOS_26_PLUS ? undefined : colors.sheet.background}
 				grabberOptions={{
 					color: colors.sheet.grabber,
 				}}

--- a/apps/expo/components/opds/FeedSubtitle.tsx
+++ b/apps/expo/components/opds/FeedSubtitle.tsx
@@ -3,7 +3,7 @@ import { Fragment, useRef, useState } from 'react'
 import { Platform, Pressable, ScrollView } from 'react-native'
 
 import { Text } from '~/components/ui'
-import { IS_IOS_24_PLUS, useColors } from '~/lib/constants'
+import { IS_IOS_26_PLUS, useColors } from '~/lib/constants'
 
 import { SheetBackDetection } from '../SheetBackDetection'
 
@@ -32,7 +32,7 @@ export default function FeedSubtitle({ value }: Props) {
 				detents={Platform.OS === 'android' ? [0.4, 1] : ['auto']}
 				grabber
 				scrollable
-				backgroundColor={IS_IOS_24_PLUS ? undefined : colors.background.DEFAULT}
+				backgroundColor={IS_IOS_26_PLUS ? undefined : colors.background.DEFAULT}
 				grabberOptions={{ color: colors.sheet.grabber }}
 				onDidPresent={() => setIsOpen(true)}
 				onDidDismiss={() => setIsOpen(false)}

--- a/apps/expo/components/opds/useFeedTitle.ts
+++ b/apps/expo/components/opds/useFeedTitle.ts
@@ -3,7 +3,7 @@ import { useNavigation } from 'expo-router'
 import { useLayoutEffect, useMemo } from 'react'
 import { Platform } from 'react-native'
 
-import { IS_IOS_24_PLUS } from '~/lib/constants'
+import { IS_IOS_26_PLUS } from '~/lib/constants'
 
 export function useFeedTitle(feed?: OPDSFeed | null) {
 	const title = useMemo(() => (feed ? feed.metadata.title || 'OPDS Feed' : null), [feed])
@@ -18,7 +18,7 @@ export function useFeedTitle(feed?: OPDSFeed | null) {
 				fontSize: 30,
 			},
 			headerLargeTitle: Platform.OS === 'ios',
-			headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+			headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 		})
 	}, [navigation, title])
 }

--- a/apps/expo/components/savedServer/AddServerDialog.tsx
+++ b/apps/expo/components/savedServer/AddServerDialog.tsx
@@ -5,7 +5,7 @@ import { View } from 'react-native'
 import { ScrollView } from 'react-native'
 import { Pressable } from 'react-native-gesture-handler'
 
-import { IS_IOS_24_PLUS, useColors } from '~/lib/constants'
+import { IS_IOS_26_PLUS, useColors } from '~/lib/constants'
 import { cn } from '~/lib/utils'
 import { useSavedServers } from '~/stores'
 
@@ -37,7 +37,7 @@ export default function AddServerDialog() {
 			<Pressable
 				onPress={() => ref.current?.present()}
 				style={
-					IS_IOS_24_PLUS
+					IS_IOS_26_PLUS
 						? {
 								width: 35,
 								height: 35,

--- a/apps/expo/components/series/SeriesOverviewSheet.tsx
+++ b/apps/expo/components/series/SeriesOverviewSheet.tsx
@@ -9,7 +9,7 @@ import { View } from 'react-native'
 import { ScrollView } from 'react-native-gesture-handler'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
-import { IS_IOS_24_PLUS, STAT_COLORS, useColors } from '~/lib/constants'
+import { IS_IOS_26_PLUS, STAT_COLORS, useColors } from '~/lib/constants'
 import { formatBytesSeparate } from '~/lib/format'
 
 import { useGridItemSize } from '../listLayout/grid/useGridItemSize'
@@ -101,7 +101,7 @@ export const SeriesOverviewSheet = forwardRef<TrueSheet, Props>(({ seriesId }, r
 				detents={[0.5, 1]}
 				grabber
 				scrollable
-				backgroundColor={IS_IOS_24_PLUS ? undefined : colors.sheet.background}
+				backgroundColor={IS_IOS_26_PLUS ? undefined : colors.sheet.background}
 				grabberOptions={{
 					color: colors.sheet.grabber,
 				}}

--- a/apps/expo/lib/constants.ts
+++ b/apps/expo/lib/constants.ts
@@ -19,13 +19,7 @@ import { useColorScheme } from './useColorScheme'
 ColorSpace.register(sRGB)
 ColorSpace.register(OKLCH)
 
-export const ENABLE_LARGE_HEADER = Platform.select({
-	// iOS 26+ has a bug that causes freezes when using large headers
-	ios: typeof Platform.Version === 'number' ? Platform.Version < 26 : Number(Platform.Version) < 26,
-	default: true,
-})
-
-export const IS_IOS_24_PLUS = Platform.OS === 'ios' && parseInt(Platform.Version, 10) >= 24
+export const IS_IOS_26_PLUS = Platform.OS === 'ios' && parseInt(Platform.Version, 10) >= 26
 
 export const ON_END_REACHED_THRESHOLD = Platform.OS === 'ios' ? 0.75 : 0.6
 

--- a/apps/expo/lib/hooks/useDynamicHeader.tsx
+++ b/apps/expo/lib/hooks/useDynamicHeader.tsx
@@ -5,7 +5,7 @@ import { NativeSyntheticEvent, Platform, TextInputChangeEvent, View } from 'reac
 
 import { Icon } from '~/components/ui'
 
-import { IS_IOS_24_PLUS } from '../constants'
+import { IS_IOS_26_PLUS } from '../constants'
 
 type Params = {
 	title: string
@@ -60,7 +60,7 @@ export function useDynamicHeader({
 				fontSize: 24,
 				lineHeight: 32,
 			},
-			headerBlurEffect: IS_IOS_24_PLUS ? undefined : 'regular',
+			headerBlurEffect: IS_IOS_26_PLUS ? undefined : 'regular',
 			...rest,
 		})
 	}, [navigation, title, headerLeft, headerRight, rest, resolvedHeaderLeft, showBackButton])


### PR DESCRIPTION
Fixes header button colour for pre-ios 26 devices so that they're easily visible in light mode. It should probably be made into a proper ios looking button rather than just the icon (like it used to be ages ago / currently does on android), but I don't feel like doing that right now.

Also rename `IS_IOS_24_PLUS` to `IS_IOS_26_PLUS`, and remove unused `ENABLE_LARGE_HEADER`