### PR TITLE
:sparkles: Persist JWT secrets to database

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -8,4 +8,5 @@ coverage:
         target: 0%
 ignore:
   - 'crates/cli'
+  - 'crates/migrations'
   - 'apps/desktop'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img alt="Stump's logo. Description: A young individual sitting on a tree stump reading a book. Inspired by Stump's creator's childhood, where a large amount of his time was spent sitting on a tree stump reading his comic books." src="./.github/images/logo.png" style="width: 50%" />
+  <img alt="Stump's logo. It depicts a young individual sitting on a tree stump reading a book. Inspired by the developer's childhood, where they spent a significant amount of time reading on a tree stump in their backyard" src="./.github/images/logo.png" style="width: 50%" />
   <br />
   <a href="https://github.com/awesome-selfhosted/awesome-selfhosted#document-management---e-books">
     <img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome Self-Hosted">

--- a/apps/server/src/config/jwt.rs
+++ b/apps/server/src/config/jwt.rs
@@ -1,10 +1,9 @@
-use std::sync::LazyLock;
+use std::sync::OnceLock;
 
 use chrono::{DateTime, Duration, FixedOffset, Utc};
 use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
-use models::entity::refresh_token;
-use rand::distr::{Alphanumeric, SampleString};
-use sea_orm::{prelude::*, ActiveValue, IntoActiveModel};
+use models::entity::{refresh_token, server_config};
+use sea_orm::{prelude::*, ActiveValue, IntoActiveModel, QuerySelect};
 use serde::{Deserialize, Serialize};
 use stump_core::config::StumpConfig;
 
@@ -13,16 +12,55 @@ use crate::{
 	errors::{APIError, APIResult},
 };
 
-/// The secret used to sign the JWT tokens, recycles every time the server is restarted*
-///
-/// Note: _Technically_ it will only be initialized after the first attempt to use it, not
-/// necessarily when the server starts. I don't see an issue with this, but it's worth noting.
-static ACCESS_TOKEN_SECRET: LazyLock<String> =
-	LazyLock::new(|| Alphanumeric.sample_string(&mut rand::rng(), 60));
+/// The secret used to sign the JWT tokens. If unset, will query the database
+/// for the value and cache it for consecutive calls
+static ACCESS_TOKEN_SECRET: OnceLock<String> = OnceLock::new();
 
-/// The secret used to sign the refresh tokens, recycles every time the server is restarted*
-static REFRESH_TOKEN_SECRET: LazyLock<String> =
-	LazyLock::new(|| Alphanumeric.sample_string(&mut rand::rng(), 60));
+/// The secret used to sign the JWT refresh tokens. If unset, will query the database
+/// for the value and cache it for consecutive calls
+static REFRESH_TOKEN_SECRET: OnceLock<String> = OnceLock::new();
+
+async fn get_access_token_secret(conn: &DatabaseConnection) -> APIResult<String> {
+	if let Some(secret) = ACCESS_TOKEN_SECRET.get() {
+		return Ok(secret.clone());
+	}
+
+	let Some(Some(secret)) = server_config::Entity::find()
+		.select_only()
+		.column(server_config::Column::JwtAccessSecret)
+		.into_tuple::<Option<String>>()
+		.one(conn)
+		.await?
+	else {
+		return Err(APIError::InternalServerError(
+			"JWT access secret not set".to_string(),
+		));
+	};
+
+	let _ = ACCESS_TOKEN_SECRET.set(secret.clone());
+	Ok(secret)
+}
+
+async fn get_refresh_token_secret(conn: &DatabaseConnection) -> APIResult<String> {
+	if let Some(secret) = REFRESH_TOKEN_SECRET.get() {
+		return Ok(secret.clone());
+	}
+
+	let Some(Some(refresh_secret)) = server_config::Entity::find()
+		.select_only()
+		.column(server_config::Column::JwtRefreshSecret)
+		.into_tuple::<Option<String>>()
+		.one(conn)
+		.await?
+	else {
+		return Err(APIError::InternalServerError(
+			"JWT refresh secret not set".to_string(),
+		));
+	};
+
+	let _ = REFRESH_TOKEN_SECRET.set(refresh_secret.clone());
+	Ok(refresh_secret)
+}
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -62,7 +100,7 @@ pub(crate) async fn create_jwt_auth(
 	let CreatedToken {
 		token: access_token,
 		expires_at,
-	} = generate_access_token(user_id, config)?;
+	} = generate_access_token(user_id, config, conn).await?;
 
 	let (
 		jti,
@@ -70,7 +108,7 @@ pub(crate) async fn create_jwt_auth(
 			token: refresh_token,
 			expires_at: refresh_expiry,
 		},
-	) = generate_refresh_token(user_id, config)?;
+	) = generate_refresh_token(user_id, config, conn).await?;
 
 	let active_model = refresh_token::ActiveModel {
 		id: ActiveValue::Set(jti),
@@ -87,10 +125,13 @@ pub(crate) async fn create_jwt_auth(
 	})
 }
 
-pub(crate) fn extract_jti_from_refresh_token(token: &str) -> APIResult<String> {
+pub(crate) async fn extract_jti_from_refresh_token(
+	token: &str,
+	conn: &DatabaseConnection,
+) -> APIResult<String> {
 	let token_data = decode::<RefreshTokenClaims>(
 		token,
-		&DecodingKey::from_secret(REFRESH_TOKEN_SECRET.as_bytes()),
+		&DecodingKey::from_secret(get_refresh_token_secret(conn).await?.as_bytes()),
 		&Validation::default(),
 	)
 	.map_err(|e| {
@@ -101,7 +142,11 @@ pub(crate) fn extract_jti_from_refresh_token(token: &str) -> APIResult<String> {
 	Ok(token_data.claims.jti)
 }
 
-fn generate_access_token(user_id: &str, config: &StumpConfig) -> APIResult<CreatedToken> {
+async fn generate_access_token(
+	user_id: &str,
+	config: &StumpConfig,
+	conn: &DatabaseConnection,
+) -> APIResult<CreatedToken> {
 	let now = Utc::now();
 	let iat = now.timestamp() as usize;
 	let exp = (now + Duration::seconds(config.access_token_ttl)).timestamp() as usize;
@@ -115,19 +160,20 @@ fn generate_access_token(user_id: &str, config: &StumpConfig) -> APIResult<Creat
 	let token = encode(
 		&Header::default(),
 		&claims,
-		&EncodingKey::from_secret(ACCESS_TOKEN_SECRET.as_bytes()),
+		&EncodingKey::from_secret(get_access_token_secret(conn).await?.as_bytes()),
 	)
-	.map_err(|e| {
-		tracing::error!("Failed to encode JWT: {:?}", e);
+	.map_err(|error| {
+		tracing::error!(?error, "Failed to encode JWT!");
 		APIError::InternalServerError("Failed to encode JWT".to_string())
 	})?;
 
 	Ok(CreatedToken { token, expires_at })
 }
 
-fn generate_refresh_token(
+async fn generate_refresh_token(
 	user_id: &str,
 	config: &StumpConfig,
+	conn: &DatabaseConnection,
 ) -> APIResult<(String, CreatedToken)> {
 	let now = Utc::now();
 	let iat = now.timestamp() as usize;
@@ -144,10 +190,10 @@ fn generate_refresh_token(
 	let token = encode(
 		&Header::default(),
 		&claims,
-		&EncodingKey::from_secret(REFRESH_TOKEN_SECRET.as_bytes()),
+		&EncodingKey::from_secret(get_refresh_token_secret(conn).await?.as_bytes()),
 	)
-	.map_err(|e| {
-		tracing::error!("Failed to encode refresh token JWT: {:?}", e);
+	.map_err(|error| {
+		tracing::error!(?error, "Failed to encode refresh token JWT!");
 		APIError::InternalServerError("Failed to encode refresh token JWT".to_string())
 	})?;
 
@@ -155,14 +201,17 @@ fn generate_refresh_token(
 }
 
 /// A function that will take a JWT token and return the user ID
-pub(crate) fn extract_user_from_jwt(token: &str) -> APIResult<String> {
+pub(crate) async fn extract_user_from_jwt(
+	token: &str,
+	conn: &DatabaseConnection,
+) -> APIResult<String> {
 	let token_data = decode::<AccessTokenClaims>(
 		token,
-		&DecodingKey::from_secret(ACCESS_TOKEN_SECRET.as_bytes()),
+		&DecodingKey::from_secret(get_access_token_secret(conn).await?.as_bytes()),
 		&Validation::default(),
 	)
-	.map_err(|e| {
-		tracing::error!("Failed to decode JWT: {:?}", e);
+	.map_err(|error| {
+		tracing::error!(?error, "Failed to decode JWT");
 		APIError::Unauthorized
 	})?;
 

--- a/apps/server/src/config/jwt.rs
+++ b/apps/server/src/config/jwt.rs
@@ -241,3 +241,112 @@ pub(crate) async fn exchange_refresh_token(
 
 	Ok(jwt_pair)
 }
+
+#[cfg(test)]
+mod tests {
+	use ::tests::{db::test_database, fake_data};
+	use models::entity::server_config;
+	use sea_orm::{ActiveValue::Set, DbConn};
+	use stump_core::config::StumpConfig;
+
+	use super::*;
+
+	// note that the once locks are static and won't reset between tests, so ordering matters here
+
+	async fn setup_db(
+		access_secret: Option<&str>,
+		refresh_secret: Option<&str>,
+	) -> DbConn {
+		let db = test_database().await;
+
+		server_config::ActiveModel {
+			initial_wal_setup_complete: Set(false),
+			jwt_access_secret: Set(access_secret.map(str::to_string)),
+			jwt_refresh_secret: Set(refresh_secret.map(str::to_string)),
+			..Default::default()
+		}
+		.insert(&db)
+		.await
+		.expect("Failed to insert server_config row");
+
+		db
+	}
+
+	fn test_config() -> StumpConfig {
+		StumpConfig::debug()
+	}
+
+	#[tokio::test]
+	async fn test_missing_secret_returns_error() {
+		let db = setup_db(None, None).await;
+		let result = extract_user_from_jwt("not.a.real.token", &db).await;
+		assert!(result.is_err());
+	}
+
+	#[tokio::test]
+	async fn test_access_token_round_trip() {
+		let db = setup_db(Some("access-secret-abc"), Some("refresh-secret-abc")).await;
+		let config = test_config();
+		let user = fake_data::User::new("test-user-access").insert(&db).await;
+
+		let pair = create_jwt_auth(&user.id, &db, &config)
+			.await
+			.expect("Failed to create JWT pair");
+
+		let user_id = extract_user_from_jwt(&pair.access_token, &db)
+			.await
+			.expect("Failed to extract user from access token");
+
+		assert_eq!(user_id, user.id);
+	}
+
+	#[tokio::test]
+	async fn test_refresh_token_jti_extraction() {
+		let db = setup_db(Some("access-secret-abc"), Some("refresh-secret-abc")).await;
+		let config = test_config();
+		let user = fake_data::User::new("test-user-refresh").insert(&db).await;
+
+		let pair = create_jwt_auth(&user.id, &db, &config)
+			.await
+			.expect("Failed to create JWT pair");
+
+		let refresh_token_str = pair.refresh_token.expect("Expected a refresh token");
+		let jti = extract_jti_from_refresh_token(&refresh_token_str, &db)
+			.await
+			.expect("Failed to extract jti from refresh token");
+
+		assert!(!jti.is_empty());
+	}
+
+	#[tokio::test]
+	async fn test_secrets_cached_after_first_retrieval() {
+		let db = setup_db(Some("access-secret-abc"), Some("refresh-secret-abc")).await;
+		let config = test_config();
+		let user = fake_data::User::new("test-user-cached").insert(&db).await;
+
+		create_jwt_auth(&user.id, &db, &config)
+			.await
+			.expect("Failed to create JWT pair");
+
+		assert!(
+			ACCESS_TOKEN_SECRET.get().is_some(),
+			"ACCESS_TOKEN_SECRET should be cached after first use"
+		);
+		assert!(
+			REFRESH_TOKEN_SECRET.get().is_some(),
+			"REFRESH_TOKEN_SECRET should be cached after first use"
+		);
+	}
+
+	#[tokio::test]
+	async fn test_extract_user_from_invalid_token() {
+		let db = setup_db(Some("access-secret-abc"), Some("refresh-secret-abc")).await;
+
+		let result = extract_user_from_jwt("this.is.garbage", &db).await;
+
+		assert!(
+			matches!(result, Err(APIError::Unauthorized)),
+			"Expected Unauthorized for a malformed token, got: {result:?}"
+		);
+	}
+}

--- a/apps/server/src/http_server.rs
+++ b/apps/server/src/http_server.rs
@@ -43,6 +43,10 @@ pub async fn run_http_server(config: StumpConfig) -> ServerResult<()> {
 		.await
 		.map_err(|e| ServerError::ServerStartError(e.to_string()))?;
 
+	core.init_jwt_secrets()
+		.await
+		.map_err(|e| ServerError::ServerStartError(e.to_string()))?;
+
 	core.init_journal_mode()
 		.await
 		.map_err(|e| ServerError::ServerStartError(e.to_string()))?;

--- a/apps/server/src/middleware/auth.rs
+++ b/apps/server/src/middleware/auth.rs
@@ -315,7 +315,7 @@ async fn handle_bearer_auth(
 		_ => (),
 	};
 
-	let user_id = extract_user_from_jwt(&token)?;
+	let user_id = extract_user_from_jwt(&token, conn).await?;
 
 	let fetched_user = user::LoginUser::find()
 		.filter(user::Column::Id.eq(user_id.clone()))

--- a/apps/server/src/routers/api/v2/auth.rs
+++ b/apps/server/src/routers/api/v2/auth.rs
@@ -465,7 +465,7 @@ async fn refresh_token(
 
 	if auth_header.starts_with("Bearer ") {
 		let token = auth_header.trim_start_matches("Bearer ").to_string();
-		let jti = extract_jti_from_refresh_token(&token)?;
+		let jti = extract_jti_from_refresh_token(&token, state.conn.as_ref()).await?;
 		let jwt_pair = exchange_refresh_token(&jti, state).await?;
 		return Ok(Json(jwt_pair));
 	}

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -15,6 +15,8 @@ pub enum CoreError {
 	EntityBuilderError(#[from] UninitializedFieldError),
 	#[error("Encryption key must be set")]
 	EncryptionKeyNotSet,
+	#[error("JWT secrets must be set")]
+	JwtSecretsNotSet,
 	#[error("Failed to encrypt: {0}")]
 	EncryptionFailed(String),
 	#[error("Failed to decrypt: {0}")]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -41,6 +41,8 @@ use crate::database::JournalMode;
 type JournalModeChanged = bool;
 /// A type alias strictly for explicitness in the return type of `init_encryption`.
 type EncryptionKeySet = bool;
+/// A type alias strictly for explicitness in the return type of `init_jwt_secrets`.
+type JwtSecretsInitialized = bool;
 
 /// The [`StumpCore`] struct is the main entry point for any server-side Stump
 /// applications. It is responsible for managing incoming tasks ([`InternalCoreTask`]),
@@ -172,6 +174,48 @@ impl StumpCore {
 			tracing::trace!(affected_rows, "Updated encryption key");
 			if affected_rows > 1 {
 				tracing::warn!("More than one encryption key was updated? This is definitely not expected");
+			}
+			Ok(affected_rows > 0)
+		}
+	}
+
+	/// Initializes the JWT secrets into the database
+	#[tracing::instrument(skip(self), err)]
+	pub async fn init_jwt_secrets(&self) -> Result<JwtSecretsInitialized, CoreError> {
+		let conn = self.ctx.conn.as_ref();
+
+		let jwt_secrets_set = server_config::Entity::find()
+			.select_only()
+			.select_column(server_config::Column::JwtAccessSecret)
+			.select_column(server_config::Column::JwtRefreshSecret)
+			.into_model::<server_config::JwtSecretsSelect>()
+			.one(conn)
+			.await?
+			.is_some_and(|config| {
+				config.jwt_access_secret.is_some() && config.jwt_refresh_secret.is_some()
+			});
+		tracing::trace!(jwt_secrets_set, "JWT secrets set");
+
+		if jwt_secrets_set {
+			Ok(false)
+		} else {
+			let jwt_access_secret = utils::encryption::create_encryption_key()?;
+			let jwt_refresh_secret = utils::encryption::create_encryption_key()?;
+			let affected_rows = server_config::Entity::update_many()
+				.col_expr(
+					server_config::Column::JwtAccessSecret,
+					Expr::value(Some(jwt_access_secret)),
+				)
+				.col_expr(
+					server_config::Column::JwtRefreshSecret,
+					Expr::value(Some(jwt_refresh_secret)),
+				)
+				.exec(conn)
+				.await?
+				.rows_affected;
+			tracing::trace!(affected_rows, "Updated JWT secrets");
+			if affected_rows > 1 {
+				tracing::warn!("More than one JWT secrets row was updated? This is definitely not expected");
 			}
 			Ok(affected_rows > 0)
 		}

--- a/crates/graphql/src/mutation/server_config.rs
+++ b/crates/graphql/src/mutation/server_config.rs
@@ -6,6 +6,9 @@ use sea_orm::{prelude::*, ActiveValue::Set, IntoActiveModel};
 #[derive(Default)]
 pub struct ServerConfigMutation;
 
+// TODO: add hook into refreshing JWT secrets, so that if somehow they were compromised we have a friendly way for
+// folks to rotate em. it's stored in db so if compromised i think you have bigger problems, but still
+
 #[Object]
 impl ServerConfigMutation {
 	#[graphql(guard = "PermissionGuard::one(UserPermission::ManageServer)")]

--- a/crates/migrations/src/lib.rs
+++ b/crates/migrations/src/lib.rs
@@ -21,6 +21,7 @@ mod m20260307_000000_library_skip_book_overview;
 mod m20260311_000000_scheduled_jobs_redesign;
 mod m20260404_185829_add_name_indexes;
 mod m20260406_000000_add_kobo_sync_sessions;
+mod m20260505_231341_jwt_secrets;
 
 pub struct Migrator;
 
@@ -48,6 +49,7 @@ impl MigratorTrait for Migrator {
 			Box::new(m20260307_000000_library_skip_book_overview::Migration),
 			Box::new(m20260404_185829_add_name_indexes::Migration),
 			Box::new(m20260406_000000_add_kobo_sync_sessions::Migration),
+			Box::new(m20260505_231341_jwt_secrets::Migration),
 		]
 	}
 }

--- a/crates/migrations/src/m20260505_231341_jwt_secrets.rs
+++ b/crates/migrations/src/m20260505_231341_jwt_secrets.rs
@@ -1,0 +1,58 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+	async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+		manager
+			.alter_table(
+				Table::alter()
+					.table(ServerConfig::Table)
+					.add_column(ColumnDef::new(ServerConfig::JwtAccessSecret).text())
+					.to_owned(),
+			)
+			.await?;
+
+		manager
+			.alter_table(
+				Table::alter()
+					.table(ServerConfig::Table)
+					.add_column(ColumnDef::new(ServerConfig::JwtRefreshSecret).text())
+					.to_owned(),
+			)
+			.await?;
+
+		Ok(())
+	}
+
+	async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+		manager
+			.alter_table(
+				Table::alter()
+					.table(ServerConfig::Table)
+					.drop_column(ServerConfig::JwtAccessSecret)
+					.to_owned(),
+			)
+			.await?;
+
+		manager
+			.alter_table(
+				Table::alter()
+					.table(ServerConfig::Table)
+					.drop_column(ServerConfig::JwtRefreshSecret)
+					.to_owned(),
+			)
+			.await?;
+
+		Ok(())
+	}
+}
+
+#[derive(DeriveIden)]
+enum ServerConfig {
+	Table,
+	JwtAccessSecret,
+	JwtRefreshSecret,
+}

--- a/crates/models/src/entity/server_config.rs
+++ b/crates/models/src/entity/server_config.rs
@@ -13,11 +13,23 @@ pub struct Model {
 	#[sea_orm(column_type = "Text", nullable)]
 	#[graphql(skip)]
 	pub encryption_key: Option<String>,
+	#[sea_orm(column_type = "Text", nullable)]
+	#[graphql(skip)]
+	pub jwt_access_secret: Option<String>,
+	#[sea_orm(column_type = "Text", nullable)]
+	#[graphql(skip)]
+	pub jwt_refresh_secret: Option<String>,
 }
 
 #[derive(FromQueryResult)]
 pub struct EncryptionKeySelect {
 	pub encryption_key: Option<String>,
+}
+
+#[derive(FromQueryResult)]
+pub struct JwtSecretsSelect {
+	pub jwt_access_secret: Option<String>,
+	pub jwt_refresh_secret: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/tests/src/db.rs
+++ b/crates/tests/src/db.rs
@@ -1,7 +1,7 @@
 use models::entity::{
 	finished_reading_session, kobo_sync_session, library, library_exclusion, media,
-	media_metadata, media_tag, reading_session, registered_reading_device, series,
-	series_metadata, tag, user, user_preferences,
+	media_metadata, media_tag, reading_session, refresh_token, registered_reading_device,
+	series, series_metadata, server_config, tag, user, user_preferences,
 };
 use sea_orm::{ConnectionTrait, Database, DbBackend, DbConn, DbErr, Schema};
 pub async fn test_database() -> DbConn {
@@ -34,6 +34,8 @@ pub async fn create_database_tables(db: &DbConn) -> Result<(), DbErr> {
 		schema.create_table_from_entity(registered_reading_device::Entity),
 		schema.create_table_from_entity(tag::Entity),
 		schema.create_table_from_entity(media_tag::Entity),
+		schema.create_table_from_entity(server_config::Entity),
+		schema.create_table_from_entity(refresh_token::Entity),
 	];
 
 	for stmt in tables {


### PR DESCRIPTION
Resolves #1140

I opted to go the route of storing the secrets in the database, rather than requiring a value in config/env or reading from a file. If this feels like the wrong decision to you, let me know and we can chat about it.

I'll leave as a draft until I give it more testing time