### PR TITLE
:adhesive_bandage: Restore position prefix

### DIFF
--- a/apps/expo/app/offline/[fileId]/index.tsx
+++ b/apps/expo/app/offline/[fileId]/index.tsx
@@ -100,9 +100,12 @@ export default function Screen() {
 	const seriesName = metadata?.series || downloadedFile.series?.name
 	const seriesPosition = formatSeriesPosition(
 		(Number(metadata?.number) || undefined) ?? null,
-		// We don't have totalBooks offline, pass 0 so it always shows "X in Series"
+		// We don't have totalBooks offline, pass 0 so it always shows "Book X in Series"
 		0,
-		{ seriesName: seriesName ?? null },
+		{
+			seriesName: seriesName ?? null,
+			t,
+		},
 	)
 
 	const getProgressPercentage = () => {

--- a/apps/expo/app/opds/[id]/publication/index.tsx
+++ b/apps/expo/app/opds/[id]/publication/index.tsx
@@ -140,7 +140,7 @@ export default function Screen() {
 	)
 	const seriesPosition = formatSeriesPosition(belongsToSeries?.position ?? null, 0, {
 		seriesName: belongsToSeries?.name ?? null,
-		prefix: t('common.publication') + ' ',
+
 		t,
 	})
 	const seriesText = seriesPosition ?? belongsToSeries?.name

--- a/apps/expo/app/opds/[id]/publication/index.tsx
+++ b/apps/expo/app/opds/[id]/publication/index.tsx
@@ -38,6 +38,7 @@ import {
 	useIsOPDSBookDownloading,
 	useIsOPDSPublicationDownloaded,
 	useOPDSDownload,
+	useTranslate,
 } from '~/lib/hooks'
 import { cn } from '~/lib/utils'
 import { usePreferencesStore } from '~/stores'
@@ -45,6 +46,7 @@ import { usePreferencesStore } from '~/stores'
 import { usePublicationContext } from './context'
 
 export default function Screen() {
+	const { t } = useTranslate()
 	const { sdk } = useSDK()
 	const {
 		activeServer: { id: serverID, kind },
@@ -138,6 +140,8 @@ export default function Screen() {
 	)
 	const seriesPosition = formatSeriesPosition(belongsToSeries?.position ?? null, 0, {
 		seriesName: belongsToSeries?.name ?? null,
+		prefix: t('common.publication') + ' ',
+		t,
 	})
 	const seriesText = seriesPosition ?? belongsToSeries?.name
 	const belongsToCollection = Array.isArray(belongsTo?.collection)

--- a/apps/expo/app/server/[id]/books/[id]/index.tsx
+++ b/apps/expo/app/server/[id]/books/[id]/index.tsx
@@ -221,7 +221,6 @@ export default function Screen() {
 		{
 			t,
 			seriesName,
-			prefix: t('common.book'),
 		},
 	)
 

--- a/apps/expo/app/server/[id]/books/[id]/index.tsx
+++ b/apps/expo/app/server/[id]/books/[id]/index.tsx
@@ -32,7 +32,7 @@ import RefreshControl from '~/components/RefreshControl'
 import { Button, Card, Heading, ListLabel, Text } from '~/components/ui'
 import { formatSeriesPosition } from '~/lib/bookUtils'
 import { formatBytes, parseGraphQLDecimal } from '~/lib/format'
-import { useDownload } from '~/lib/hooks'
+import { useDownload, useTranslate } from '~/lib/hooks'
 import { cn } from '~/lib/utils'
 import { usePreferencesStore } from '~/stores'
 
@@ -143,6 +143,7 @@ type ActiveReadingSession = NonNullable<
 
 export default function Screen() {
 	const { id: bookID } = useLocalSearchParams<{ id: string }>()
+	const { t } = useTranslate()
 	const {
 		activeServer: { id: serverID },
 	} = useActiveServer()
@@ -218,7 +219,9 @@ export default function Screen() {
 		(Number(book.metadata?.number) || book.seriesPosition) ?? null,
 		book.series.metadata?.totalIssues ?? null,
 		{
+			t,
 			seriesName,
+			prefix: t('common.book'),
 		},
 	)
 

--- a/apps/expo/components/book/OnDeckBookItem.tsx
+++ b/apps/expo/components/book/OnDeckBookItem.tsx
@@ -85,7 +85,7 @@ function OnDeckBookItem({ book }: Props) {
 		{
 			t,
 			seriesName: data.series.resolvedName,
-			prefix: '#',
+			prefix: 'hashtag',
 		},
 	)
 

--- a/apps/expo/components/book/OnDeckBookItem.tsx
+++ b/apps/expo/components/book/OnDeckBookItem.tsx
@@ -7,7 +7,7 @@ import { easeGradient } from 'react-native-easing-gradient'
 
 import { formatSeriesPosition } from '~/lib/bookUtils'
 import { COLORS } from '~/lib/constants'
-import { useListItemSize } from '~/lib/hooks'
+import { useListItemSize, useTranslate } from '~/lib/hooks'
 
 import { useActiveServer } from '../activeServer'
 import { ThumbnailImage } from '../image'
@@ -58,6 +58,7 @@ function OnDeckBookItem({ book }: Props) {
 		activeServer: { id: serverID },
 	} = useActiveServer()
 
+	const { t } = useTranslate()
 	const { height, width } = useListItemSize()
 
 	const router = useRouter()
@@ -82,7 +83,9 @@ function OnDeckBookItem({ book }: Props) {
 		Number(data.metadata?.number) || data.seriesPosition,
 		data.series.metadata?.totalIssues ?? null,
 		{
+			t,
 			seriesName: data.series.resolvedName,
+			prefix: '#',
 		},
 	)
 

--- a/apps/expo/components/book/reader/image/NextUpOverlay.tsx
+++ b/apps/expo/components/book/reader/image/NextUpOverlay.tsx
@@ -69,7 +69,7 @@ export default function NextUpOverlay({ isVisible, book, onClose }: Props) {
 	const insets = useSafeAreaInsets()
 
 	return (
-		<Animated.View className={cn('absolute inset-0 z-10 flex-1')} style={containerStyles}>
+		<Animated.View className={cn('inset-0 absolute z-10 flex-1')} style={containerStyles}>
 			<View
 				className="absolute z-30"
 				style={{
@@ -78,7 +78,7 @@ export default function NextUpOverlay({ isVisible, book, onClose }: Props) {
 			>
 				<View className="flex-row items-center justify-between">
 					<Button
-						className="squircle h-[unset] w-[unset] rounded-full border p-1 tablet:p-2"
+						className="squircle p-1 tablet:p-2 h-[unset] w-[unset] rounded-full border"
 						variant="ghost"
 						size="icon"
 						style={{
@@ -104,10 +104,10 @@ export default function NextUpOverlay({ isVisible, book, onClose }: Props) {
 
 			<View style={{ flex: 1, backgroundColor: 'hsla(0, 0%, 0%, 0.75)' }} />
 
-			<View className="absolute inset-0 flex-1 items-center justify-center gap-4">
+			<View className="inset-0 gap-4 absolute flex-1 items-center justify-center">
 				<View>
 					<Label className="text-white opacity-80">Next Up:</Label>
-					<Heading size="xl" className="text-center text-white">
+					<Heading size="xl" className="text-white text-center">
 						{book.name}
 					</Heading>
 				</View>
@@ -125,12 +125,12 @@ export default function NextUpOverlay({ isVisible, book, onClose }: Props) {
 				/>
 
 				<View
-					className="flex flex-row items-center tablet:max-w-sm tablet:self-center"
+					className="tablet:max-w-sm flex flex-row items-center tablet:self-center"
 					style={{
 						width: size + 16,
 					}}
 				>
-					<Button className="flex-1 border border-edge bg-white opacity-80" onPress={onReadNext}>
+					<Button className="bg-white flex-1 border border-edge opacity-80" onPress={onReadNext}>
 						<Text className="text-black">Read Next</Text>
 					</Button>
 				</View>

--- a/apps/expo/lib/__tests__/bookUtils.test.ts
+++ b/apps/expo/lib/__tests__/bookUtils.test.ts
@@ -1,49 +1,115 @@
+import { describe, expect, it, vi } from 'vitest'
+
 import { formatSeriesPosition } from '../bookUtils'
 
 describe('bookUtils', () => {
 	describe('formatSeriesPosition', () => {
 		it('returns null if position is null or undefined', () => {
-			expect(formatSeriesPosition(null, 5)).toBeNull()
-			expect(formatSeriesPosition(undefined, 5)).toBeNull()
+			const t = vi.fn()
+			expect(formatSeriesPosition(null, 5, { t })).toBeNull()
+			expect(formatSeriesPosition(undefined, 5, { t })).toBeNull()
+			expect(t).not.toHaveBeenCalled()
 		})
 
-		it('formats fractional positions correctly (ignores totalBooks)', () => {
-			expect(formatSeriesPosition(1.5, 5)).toBe('1.5 in series')
-			expect(formatSeriesPosition(1.5, null)).toBe('1.5 in series')
+		it('calls t with positionWithTotal key when position <= totalBooks', () => {
+			const t = vi.fn()
+			formatSeriesPosition(1, 3, { prefix: null, t })
+			expect(t).toHaveBeenCalledWith('formatSeriesPosition.positionWithTotal', {
+				position: 1,
+				total: 3,
+				seriesName: undefined,
+			})
 		})
 
-		it('formats integer positions without totalBooks', () => {
-			expect(formatSeriesPosition(1, null)).toBe('1 in series')
-			expect(formatSeriesPosition(1, undefined)).toBe('1 in series')
-			expect(formatSeriesPosition(1, 0)).toBe('1 in series')
+		it('calls t with position key when totalBooks is null', () => {
+			const t = vi.fn()
+			formatSeriesPosition(1, null, { prefix: null, t })
+			expect(t).toHaveBeenCalledWith('formatSeriesPosition.position', {
+				position: 1,
+				total: undefined,
+				seriesName: undefined,
+			})
 		})
 
-		it('formats integer positions with totalBooks correctly', () => {
-			expect(formatSeriesPosition(1, 3)).toBe('1 of 3')
-			expect(formatSeriesPosition(3, 3)).toBe('3 of 3')
+		it('calls t with position key when totalBooks is undefined', () => {
+			const t = vi.fn()
+			formatSeriesPosition(1, undefined, { prefix: null, t })
+			expect(t).toHaveBeenCalledWith('formatSeriesPosition.position', {
+				position: 1,
+				total: undefined,
+				seriesName: undefined,
+			})
 		})
 
-		it('ignores totalBooks if position > totalBooks', () => {
-			expect(formatSeriesPosition(4, 3)).toBe('4 in series')
+		it('calls t with position key when totalBooks is 0', () => {
+			const t = vi.fn()
+			formatSeriesPosition(1, 0, { prefix: null, t })
+			expect(t).toHaveBeenCalledWith('formatSeriesPosition.position', {
+				position: 1,
+				total: undefined,
+				seriesName: undefined,
+			})
 		})
 
-		it('applies prefix correctly', () => {
-			expect(formatSeriesPosition(1, 3, { prefix: 'Book' })).toBe('Book 1 of 3')
-			expect(formatSeriesPosition(1.5, 3, { prefix: 'Book' })).toBe('Book 1.5 in series')
-			expect(formatSeriesPosition(1, null, { prefix: 'Issue' })).toBe('Issue 1 in series')
+		it('calls t with position key when position > totalBooks', () => {
+			const t = vi.fn()
+			formatSeriesPosition(4, 3, { prefix: null, t })
+			expect(t).toHaveBeenCalledWith('formatSeriesPosition.position', {
+				position: 4,
+				total: 3,
+				seriesName: undefined,
+			})
 		})
 
-		it('applies seriesName correctly', () => {
-			expect(formatSeriesPosition(1, 3, { seriesName: 'Spiderman' })).toBe('1 of 3 in Spiderman')
-			expect(formatSeriesPosition(1.5, 3, { seriesName: 'Spiderman' })).toBe('1.5 in Spiderman')
-			expect(formatSeriesPosition(4, 3, { seriesName: 'Spiderman' })).toBe('4 in Spiderman')
+		it('returns t result directly when prefix is null', () => {
+			const t = vi.fn().mockReturnValue('1 of 3')
+			expect(formatSeriesPosition(1, 3, { prefix: null, t })).toBe('1 of 3')
+			expect(t).toHaveBeenCalledOnce()
 		})
 
-		it('decodes HTML entities in seriesName', () => {
-			expect(formatSeriesPosition(1, 3, { seriesName: 'Batman &amp; Robin' })).toBe(
-				'1 of 3 in Batman & Robin',
-			)
-			expect(formatSeriesPosition(1, null, { seriesName: 'Q &amp; A&#039;s' })).toBe("1 in Q & A's")
+		it('uses default prefix when prefix is not provided', () => {
+			const t = vi
+				.fn()
+				.mockReturnValueOnce('1 of 3') // primaryClause call
+				.mockReturnValueOnce('Book') // common.book call
+			const result = formatSeriesPosition(1, 3, { t })
+			expect(t).toHaveBeenCalledWith('common.book')
+			expect(result).toBe('Book 1 of 3')
+		})
+
+		it('prepends a custom prefix to the result of t', () => {
+			const t = vi.fn().mockReturnValue('1 of 3')
+			expect(formatSeriesPosition(1, 3, { prefix: '#', t })).toBe('#1 of 3')
+		})
+
+		it('passes decoded seriesName to t', () => {
+			const t = vi.fn()
+			formatSeriesPosition(1, 3, { seriesName: 'Batman &amp; Robin', prefix: null, t })
+			expect(t).toHaveBeenCalledWith('formatSeriesPosition.positionWithTotal', {
+				position: 1,
+				total: 3,
+				seriesName: 'Batman & Robin',
+			})
+		})
+
+		it('passes decoded seriesName with multiple entities to t', () => {
+			const t = vi.fn()
+			formatSeriesPosition(1, null, { seriesName: 'Q &amp; A&#039;s', prefix: null, t })
+			expect(t).toHaveBeenCalledWith('formatSeriesPosition.position', {
+				position: 1,
+				total: undefined,
+				seriesName: "Q & A's",
+			})
+		})
+
+		it('passes undefined seriesName to t when seriesName is null', () => {
+			const t = vi.fn()
+			formatSeriesPosition(1, 3, { seriesName: null, prefix: null, t })
+			expect(t).toHaveBeenCalledWith('formatSeriesPosition.positionWithTotal', {
+				position: 1,
+				total: 3,
+				seriesName: undefined,
+			})
 		})
 	})
 })

--- a/apps/expo/lib/__tests__/bookUtils.test.ts
+++ b/apps/expo/lib/__tests__/bookUtils.test.ts
@@ -11,10 +11,27 @@ describe('bookUtils', () => {
 			expect(t).not.toHaveBeenCalled()
 		})
 
+		it('properly handles all prefix options', () => {
+			const t = vi.fn()
+			for (const prefix of [null, undefined, 'book', 'hashtag'] as const) {
+				formatSeriesPosition(1, 3, {
+					prefix,
+					t,
+					// set so we don't worry about extra translation call
+					seriesName: 'Murderbot Diaries',
+				})
+				const expectedPrefixKey = prefix === null ? 'none' : prefix === undefined ? 'book' : prefix
+				expect(t).toHaveBeenCalledWith(
+					`formatSeriesPosition.${expectedPrefixKey}.positionWithTotal`,
+					expect.anything(),
+				)
+			}
+		})
+
 		it('calls t with positionWithTotal key when position <= totalBooks', () => {
 			const t = vi.fn()
-			formatSeriesPosition(1, 3, { prefix: null, t })
-			expect(t).toHaveBeenCalledWith('formatSeriesPosition.positionWithTotal', {
+			formatSeriesPosition(1, 3, { t })
+			expect(t).toHaveBeenCalledWith('formatSeriesPosition.book.positionWithTotal', {
 				position: 1,
 				total: 3,
 				seriesName: undefined,
@@ -23,8 +40,8 @@ describe('bookUtils', () => {
 
 		it('calls t with position key when totalBooks is null', () => {
 			const t = vi.fn()
-			formatSeriesPosition(1, null, { prefix: null, t })
-			expect(t).toHaveBeenCalledWith('formatSeriesPosition.position', {
+			formatSeriesPosition(1, null, { t })
+			expect(t).toHaveBeenCalledWith('formatSeriesPosition.book.position', {
 				position: 1,
 				total: undefined,
 				seriesName: undefined,
@@ -33,8 +50,8 @@ describe('bookUtils', () => {
 
 		it('calls t with position key when totalBooks is undefined', () => {
 			const t = vi.fn()
-			formatSeriesPosition(1, undefined, { prefix: null, t })
-			expect(t).toHaveBeenCalledWith('formatSeriesPosition.position', {
+			formatSeriesPosition(1, undefined, { t })
+			expect(t).toHaveBeenCalledWith('formatSeriesPosition.book.position', {
 				position: 1,
 				total: undefined,
 				seriesName: undefined,
@@ -43,8 +60,8 @@ describe('bookUtils', () => {
 
 		it('calls t with position key when totalBooks is 0', () => {
 			const t = vi.fn()
-			formatSeriesPosition(1, 0, { prefix: null, t })
-			expect(t).toHaveBeenCalledWith('formatSeriesPosition.position', {
+			formatSeriesPosition(1, 0, { t })
+			expect(t).toHaveBeenCalledWith('formatSeriesPosition.book.position', {
 				position: 1,
 				total: undefined,
 				seriesName: undefined,
@@ -53,40 +70,18 @@ describe('bookUtils', () => {
 
 		it('calls t with position key when position > totalBooks', () => {
 			const t = vi.fn()
-			formatSeriesPosition(4, 3, { prefix: null, t })
-			expect(t).toHaveBeenCalledWith('formatSeriesPosition.position', {
+			formatSeriesPosition(4, 3, { t })
+			expect(t).toHaveBeenCalledWith('formatSeriesPosition.book.position', {
 				position: 4,
 				total: 3,
 				seriesName: undefined,
 			})
 		})
 
-		it('returns t result directly when prefix is null', () => {
-			const t = vi.fn().mockReturnValue('1 of 3')
-			expect(formatSeriesPosition(1, 3, { prefix: null, t })).toBe('1 of 3')
-			expect(t).toHaveBeenCalledWith('formatSeriesPosition.unknownSeriesName')
-		})
-
-		it('uses default prefix when prefix is not provided', () => {
-			const t = vi
-				.fn()
-				.mockReturnValueOnce('series') // unknownSeriesName call
-				.mockReturnValueOnce('1 of 3') // primaryClause call
-				.mockReturnValueOnce('Book') // common.book call
-			const result = formatSeriesPosition(1, 3, { t })
-			expect(t).toHaveBeenCalledWith('common.book')
-			expect(result).toBe('Book 1 of 3')
-		})
-
-		it('prepends a custom prefix to the result of t', () => {
-			const t = vi.fn().mockReturnValue('1 of 3')
-			expect(formatSeriesPosition(1, 3, { prefix: '#', t })).toBe('#1 of 3')
-		})
-
 		it('passes decoded seriesName to t', () => {
 			const t = vi.fn()
 			formatSeriesPosition(1, 3, { seriesName: 'Batman &amp; Robin', prefix: null, t })
-			expect(t).toHaveBeenCalledWith('formatSeriesPosition.positionWithTotal', {
+			expect(t).toHaveBeenCalledWith('formatSeriesPosition.none.positionWithTotal', {
 				position: 1,
 				total: 3,
 				seriesName: 'Batman & Robin',
@@ -96,7 +91,7 @@ describe('bookUtils', () => {
 		it('passes decoded seriesName with multiple entities to t', () => {
 			const t = vi.fn()
 			formatSeriesPosition(1, null, { seriesName: 'Q &amp; A&#039;s', prefix: null, t })
-			expect(t).toHaveBeenCalledWith('formatSeriesPosition.position', {
+			expect(t).toHaveBeenCalledWith('formatSeriesPosition.none.position', {
 				position: 1,
 				total: undefined,
 				seriesName: "Q & A's",
@@ -106,7 +101,7 @@ describe('bookUtils', () => {
 		it('passes undefined seriesName to t when seriesName is null', () => {
 			const t = vi.fn()
 			formatSeriesPosition(1, 3, { seriesName: null, prefix: null, t })
-			expect(t).toHaveBeenCalledWith('formatSeriesPosition.positionWithTotal', {
+			expect(t).toHaveBeenCalledWith('formatSeriesPosition.none.positionWithTotal', {
 				position: 1,
 				total: 3,
 				seriesName: undefined,

--- a/apps/expo/lib/__tests__/bookUtils.test.ts
+++ b/apps/expo/lib/__tests__/bookUtils.test.ts
@@ -64,12 +64,13 @@ describe('bookUtils', () => {
 		it('returns t result directly when prefix is null', () => {
 			const t = vi.fn().mockReturnValue('1 of 3')
 			expect(formatSeriesPosition(1, 3, { prefix: null, t })).toBe('1 of 3')
-			expect(t).toHaveBeenCalledOnce()
+			expect(t).toHaveBeenCalledWith('formatSeriesPosition.unknownSeriesName')
 		})
 
 		it('uses default prefix when prefix is not provided', () => {
 			const t = vi
 				.fn()
+				.mockReturnValueOnce('series') // unknownSeriesName call
 				.mockReturnValueOnce('1 of 3') // primaryClause call
 				.mockReturnValueOnce('Book') // common.book call
 			const result = formatSeriesPosition(1, 3, { t })

--- a/apps/expo/lib/bookUtils.ts
+++ b/apps/expo/lib/bookUtils.ts
@@ -1,7 +1,11 @@
+import { match } from 'ts-pattern'
+
+type KnownPrefix = 'book' | 'hashtag'
+
 type FormatSeriesPositionParams = {
 	seriesName?: string | null
-	// null = no prefix, undefined = default prefix
-	prefix?: string | null
+	// null = no prefix, undefined = default prefix (book)
+	prefix?: KnownPrefix | null
 	t: (key: string, args?: Record<string, unknown>) => string
 }
 
@@ -48,20 +52,23 @@ export const formatSeriesPosition = (
 
 	const showOfY = totalBooks != null && totalBooks > 0 && position <= totalBooks
 
-	const primaryClauseKey = showOfY
-		? 'formatSeriesPosition.positionWithTotal'
-		: 'formatSeriesPosition.position'
+	const resolvedPrefix = match(params.prefix)
+		.with(null, () => 'none' as const)
+		.with(undefined, () => 'book' satisfies KnownPrefix)
+		.otherwise((val) => val)
 
-	const primaryClause = t(primaryClauseKey, {
+	// it comes with a little bit of duplication to handle the prefix in this way,
+	// i.e. a bunch of almost identical positionWithTotal/position keys, but since languages
+	// differ in grammar this was just easiest
+	const primaryClauseKey = showOfY
+		? `formatSeriesPosition.${resolvedPrefix}.positionWithTotal`
+		: `formatSeriesPosition.${resolvedPrefix}.position`
+
+	return t(primaryClauseKey, {
 		position,
 		total: totalBooks || undefined,
 		seriesName: params.seriesName
 			? decodeHtmlEntities(params.seriesName)
 			: t('formatSeriesPosition.unknownSeriesName'),
 	})
-
-	// null = no prefix
-	const prefix = params.prefix === null ? undefined : (params.prefix ?? t('common.book') + ' ')
-
-	return prefix ? `${prefix}${primaryClause}` : primaryClause
 }

--- a/apps/expo/lib/bookUtils.ts
+++ b/apps/expo/lib/bookUtils.ts
@@ -55,7 +55,9 @@ export const formatSeriesPosition = (
 	const primaryClause = t(primaryClauseKey, {
 		position,
 		total: totalBooks || undefined,
-		seriesName: params.seriesName ? decodeHtmlEntities(params.seriesName) : undefined,
+		seriesName: params.seriesName
+			? decodeHtmlEntities(params.seriesName)
+			: t('formatSeriesPosition.unknownSeriesName'),
 	})
 
 	// null = no prefix

--- a/apps/expo/lib/bookUtils.ts
+++ b/apps/expo/lib/bookUtils.ts
@@ -1,6 +1,7 @@
 type FormatSeriesPositionParams = {
 	seriesName?: string | null
 	prefix?: string
+	t: (key: string, args?: Record<string, unknown>) => string
 }
 
 // TODO(metadata): Fix this at the core
@@ -26,21 +27,21 @@ const decodeHtmlEntities = (str: string): string =>
 export const formatSeriesPosition = (
 	position: number | null | undefined,
 	totalBooks: number | null | undefined,
-	params?: FormatSeriesPositionParams,
+	{ t, ...params }: FormatSeriesPositionParams,
 ): string | null => {
 	if (position == null) return null
 	const isFractional = !Number.isInteger(position)
 	const showOfY = !isFractional && totalBooks != null && totalBooks > 0 && position <= totalBooks
 
-	const primaryClause = showOfY ? `${position} of ${totalBooks}` : `${position}`
+	const primaryClauseKey = showOfY
+		? 'formatSeriesPosition.positionWithTotal'
+		: 'formatSeriesPosition.position'
 
-	const withPrefix = params?.prefix ? `${params.prefix} ${primaryClause}` : primaryClause
+	const primaryClause = t(primaryClauseKey, {
+		position,
+		total: totalBooks || undefined,
+		seriesName: params.seriesName ? decodeHtmlEntities(params.seriesName) : undefined,
+	})
 
-	if (params?.seriesName) {
-		return `${withPrefix} in ${decodeHtmlEntities(params.seriesName)}`
-	} else if (!showOfY) {
-		return `${withPrefix} in series`
-	}
-
-	return withPrefix
+	return params.prefix ? `${params.prefix} ${primaryClause}` : primaryClause
 }

--- a/apps/expo/lib/bookUtils.ts
+++ b/apps/expo/lib/bookUtils.ts
@@ -1,6 +1,7 @@
 type FormatSeriesPositionParams = {
 	seriesName?: string | null
-	prefix?: string
+	// null = no prefix, undefined = default prefix
+	prefix?: string | null
 	t: (key: string, args?: Record<string, unknown>) => string
 }
 
@@ -15,14 +16,28 @@ const decodeHtmlEntities = (str: string): string =>
 		.replace(/&quot;/g, '"')
 		.replace(/&#039;/g, "'")
 
+// TODO(metadata-library): callers of formatSeriesPosition should ideally pass the total count for non-metadata-driven libraries.
+// for users who have libraries that are largely filesystem-driven, we can use the total count of books in the series. The reason this
+// was changed (for now) to be optional is because of the scenario where:
+// - a series has 3 books
+// - the number for each book is: 0.5, 1, 2
+// - the count would be 3
+// - the position data would never be able to reach 3, because the metadata position for final book is 2
+// ^ the crux of the problem imo is that for whatever reason metadata providers don't always consider fractional numbers
+// when determining the total of a series, which makes sense because wtf does "series has 2.5 books" even mean lol but still
+// this isn't ideal but is what it is for now
+
 /**
  * A helper to align how Stump formats book positions in a series.
  *
- * If fractional, shows "Book X in series"
- * If integer, shows "Book X of Y"
+ * If we have a total provided, we show "{prefix} X of Y"
+ * If we don't have a total, we show "{prefix} X in Series"
+ *
+ * The prefix is there to allow a future where the library type can inform a more semantic
+ * prefix specific to the library, e.g. "Volume" or "Issue" or "Book"
  *
  * @param position The position of the book in the series
- * @param totalBooks The total number of books in the series, derived from series_metadata.total_issues
+ * @param totalBooks The total number of books in the series
  */
 export const formatSeriesPosition = (
 	position: number | null | undefined,
@@ -30,8 +45,8 @@ export const formatSeriesPosition = (
 	{ t, ...params }: FormatSeriesPositionParams,
 ): string | null => {
 	if (position == null) return null
-	const isFractional = !Number.isInteger(position)
-	const showOfY = !isFractional && totalBooks != null && totalBooks > 0 && position <= totalBooks
+
+	const showOfY = totalBooks != null && totalBooks > 0 && position <= totalBooks
 
 	const primaryClauseKey = showOfY
 		? 'formatSeriesPosition.positionWithTotal'
@@ -43,5 +58,8 @@ export const formatSeriesPosition = (
 		seriesName: params.seriesName ? decodeHtmlEntities(params.seriesName) : undefined,
 	})
 
-	return params.prefix ? `${params.prefix} ${primaryClause}` : primaryClause
+	// null = no prefix
+	const prefix = params.prefix === null ? undefined : (params.prefix ?? t('common.book') + ' ')
+
+	return prefix ? `${prefix}${primaryClause}` : primaryClause
 }

--- a/packages/i18n/src/locales/en-US.json
+++ b/packages/i18n/src/locales/en-US.json
@@ -2831,8 +2831,18 @@
 			"version": "Version"
 		},
 		"formatSeriesPosition": {
-			"positionWithTotal": "{{position}} of {{total}} in {{seriesName}}",
-			"position": "{{position}} in {{seriesName}}",
+			"none": {
+				"positionWithTotal": "{{position}} of {{total}} in {{seriesName}}",
+				"position": "{{position}} in {{seriesName}}"
+			},
+			"book": {
+				"positionWithTotal": "Book {{position}} of {{total}} in {{seriesName}}",
+				"position": "Book {{position}} in {{seriesName}}"
+			},
+			"hashtag": {
+				"positionWithTotal": "#{{position}} of {{total}} in {{seriesName}}",
+				"position": "#{{position}} in {{seriesName}}"
+			},
 			"unknownSeriesName": "series"
 		},
 		"emptyState": {

--- a/packages/i18n/src/locales/en-US.json
+++ b/packages/i18n/src/locales/en-US.json
@@ -2790,6 +2790,7 @@
 			"year": "Year"
 		},
 		"common": {
+			"book":"Book",
 			"cancel": "Cancel",
 			"chapter": "Chapter",
 			"clear": "Clear",
@@ -2813,6 +2814,7 @@
 			"pages": "Pages",
 			"password": "Password",
 			"progress": "Progress",
+			"publication": "Publication",
 			"readTime": "Read time",
 			"readMore": "Read more",
 			"save": "Save",
@@ -2830,7 +2832,8 @@
 		},
 		"formatSeriesPosition": {
 			"positionWithTotal": "{{position}} of {{total}} in {{seriesName}}",
-			"position": "{{position}} in {{seriesName}}"
+			"position": "{{position}} in {{seriesName}}",
+			"unknownSeriesName": "series"
 		},
 		"emptyState": {
 			"noStumpServers": "No Stump servers added",

--- a/packages/i18n/src/locales/en-US.json
+++ b/packages/i18n/src/locales/en-US.json
@@ -2828,6 +2828,10 @@
 			"value": "Value",
 			"version": "Version"
 		},
+		"formatSeriesPosition": {
+			"positionWithTotal": "{{position}} of {{total}} in {{seriesName}}",
+			"position": "{{position}} in {{seriesName}}"
+		},
 		"emptyState": {
 			"noStumpServers": "No Stump servers added",
 			"noOPDSServers": "No OPDS servers added",


### PR DESCRIPTION
The prefix for the series position got lost in the shuffle of changes somewhere to the logic. This restores it with a few changes:

- A default prefix of `Book ` is added, routed through localization this time around
- Fractional displays exactly the same as integer (e.g., `Book 0.5 of 8 in Murderbot Diaries`)
- The position in on-deck items uses a `#` instead of `Book`, e.g. `#1 in Series`)

I did not change the source of the `totalBooks` for `formatSeriesPosition`, as that would undo the work aimed at satisfying #1066. I did outline the awkward situation though, where folks with metadata-driven libraries are at odds with folks with self-reliant filesystem-driven libraries wrt how the client determines these kinds of things.