### PR TITLE
🐛 Fix reading time updates for paged image reader

### DIFF
--- a/apps/expo/app/offline/[fileId]/read.tsx
+++ b/apps/expo/app/offline/[fileId]/read.tsx
@@ -33,7 +33,7 @@ import {
 	toAbsolutePath,
 	unpackedBookDirectory,
 } from '~/lib/filesystem'
-import { useAppState, useLocalAnnotationMutations, useLocalBookmarkMutations } from '~/lib/hooks'
+import { useLocalAnnotationMutations, useLocalBookmarkMutations } from '~/lib/hooks'
 import type { ReadiumLocator } from '~/modules/readium'
 import { intoReadiumLocator } from '~/modules/readium'
 import StumpStreamer from '~/modules/streamer'
@@ -174,9 +174,11 @@ function Reader({ record, bookmarks, annotations }: ReaderProps) {
 	const {
 		preferences: { trackElapsedTime },
 	} = useBookPreferences({ book, serverId: downloadedFile.serverId })
-	const { pause, resume, totalSeconds, isRunning, reset } = useBookTimer(book?.id || '', {
+	const showControls = useReaderStore((state) => state.showControls)
+
+	const timer = useBookTimer(book?.id || '', {
 		initial: book?.readProgress?.elapsedSeconds,
-		enabled: trackElapsedTime,
+		enabled: trackElapsedTime && !showControls,
 	})
 
 	const { mutate: updatePagedProgress } = useMutation({
@@ -189,6 +191,8 @@ function Reader({ record, bookmarks, annotations }: ReaderProps) {
 			serverId,
 			...input
 		}: PagedProgressInput & { bookId: string; serverId: string }) => {
+			const totalSeconds = timer.getCurrentTime()
+
 			const result = await db
 				.insert(readProgress)
 				.values({
@@ -231,6 +235,8 @@ function Reader({ record, bookmarks, annotations }: ReaderProps) {
 			percentage,
 			...epubProgress
 		}: ReadiumLocator & { bookId: string; serverId: string; percentage: number }) => {
+			const totalSeconds = timer.getCurrentTime()
+
 			const result = await db
 				.insert(readProgress)
 				.values({
@@ -313,29 +319,6 @@ function Reader({ record, bookmarks, annotations }: ReaderProps) {
 		[],
 	)
 
-	const onFocusedChanged = useCallback(
-		(focused: boolean) => {
-			if (!focused) {
-				pause()
-			} else if (focused) {
-				resume()
-			}
-		},
-		[pause, resume],
-	)
-
-	const appState = useAppState({
-		onStateChanged: onFocusedChanged,
-	})
-	const showControls = useReaderStore((state) => state.showControls)
-	useEffect(() => {
-		if ((showControls && isRunning) || appState !== 'active') {
-			pause()
-		} else if (!showControls && !isRunning && appState === 'active') {
-			resume()
-		}
-	}, [showControls, pause, resume, isRunning, appState])
-
 	if (extension?.match(EBOOK_EXTENSION)) {
 		const initialLocator = book.readProgress?.locator || undefined
 
@@ -367,7 +350,7 @@ function Reader({ record, bookmarks, annotations }: ReaderProps) {
 				book={book}
 				pageURL={pageURL}
 				onPageChanged={onPageChanged}
-				resetTimer={reset}
+				timer={timer}
 				serverId={downloadedFile.serverId}
 			/>
 		)
@@ -378,7 +361,7 @@ function Reader({ record, bookmarks, annotations }: ReaderProps) {
 				onPageChanged={onPageChanged}
 				offlineUri={`${booksDirectory(downloadedFile.serverId)}/${downloadedFile.filename}`}
 				initialPage={book.readProgress?.page || 1}
-				resetTimer={reset}
+				timer={timer}
 				serverId={downloadedFile.serverId}
 			/>
 		)

--- a/apps/expo/app/opds-legacy/[id]/read.tsx
+++ b/apps/expo/app/opds-legacy/[id]/read.tsx
@@ -12,7 +12,6 @@ import { ImageReaderBookRef } from '~/components/book/reader/image/context'
 import { useResolveURL } from '~/components/opds/utils'
 import { OPDSLegacyStreamingContextValue } from '~/context/opdsLegacy'
 import { db, downloadedFiles, readProgress, syncStatus } from '~/db'
-import { useAppState } from '~/lib/hooks'
 import { useReaderStore } from '~/stores'
 import { useBookPreferences, useBookTimer } from '~/stores/reader'
 
@@ -93,13 +92,16 @@ export default function Screen() {
 		preferences: { trackElapsedTime },
 	} = useBookPreferences({ book })
 
-	const { pause, resume, isRunning, totalSeconds, reset } = useBookTimer(contextValue.entryId, {
-		enabled: trackElapsedTime,
+	const showControls = useReaderStore((state) => state.showControls)
+	const timer = useBookTimer(contextValue.entryId, {
+		enabled: trackElapsedTime && !showControls,
 	})
 
 	const onPageChanged = useCallback(
 		async (pageNumber: number) => {
 			if (isLoadingRecord || !record) return
+			const totalSeconds = timer.getCurrentTime()
+
 			return db
 				.insert(readProgress)
 				.values({
@@ -119,32 +121,8 @@ export default function Screen() {
 					},
 				})
 		},
-		[isLoadingRecord, record, totalSeconds],
+		[isLoadingRecord, record, timer],
 	)
-
-	const onFocusedChanged = useCallback(
-		(focused: boolean) => {
-			if (!focused) {
-				pause()
-			} else if (focused) {
-				resume()
-			}
-		},
-		[pause, resume],
-	)
-
-	const appState = useAppState({
-		onStateChanged: onFocusedChanged,
-	})
-
-	const showControls = useReaderStore((state) => state.showControls)
-	useEffect(() => {
-		if ((showControls && isRunning) || appState !== 'active') {
-			pause()
-		} else if (!showControls && !isRunning && appState === 'active') {
-			resume()
-		}
-	}, [showControls, pause, resume, isRunning, appState])
 
 	const setIsReading = useReaderStore((state) => state.setIsReading)
 	const setShowControls = useReaderStore((state) => state.setShowControls)
@@ -184,7 +162,7 @@ export default function Screen() {
 			book={book}
 			pageURL={getStreamURLForPage}
 			requestHeaders={requestHeaders}
-			resetTimer={reset}
+			timer={timer}
 			onPageChanged={onPageChanged}
 			isOPDS
 		/>

--- a/apps/expo/app/opds/[id]/publication/read.tsx
+++ b/apps/expo/app/opds/[id]/publication/read.tsx
@@ -12,7 +12,6 @@ import { useActiveServer } from '~/components/activeServer'
 import { ImageBasedReader } from '~/components/book/reader'
 import { ImageReaderBookRef } from '~/components/book/reader/image/context'
 import { hashFromURL, useResolveURL } from '~/components/opds/utils'
-import { useAppState } from '~/lib/hooks'
 import { useReaderStore } from '~/stores'
 import { useBookPreferences, useBookTimer } from '~/stores/reader'
 
@@ -74,33 +73,9 @@ export default function Screen() {
 	const {
 		preferences: { trackElapsedTime },
 	} = useBookPreferences({ book })
-	const { pause, resume, isRunning, reset } = useBookTimer(id, {
-		enabled: trackElapsedTime,
-	})
-
-	const onFocusedChanged = useCallback(
-		(focused: boolean) => {
-			if (!focused) {
-				pause()
-			} else if (focused) {
-				resume()
-			}
-		},
-		[pause, resume],
-	)
-
-	const appState = useAppState({
-		onStateChanged: onFocusedChanged,
-	})
-
 	const showControls = useReaderStore((state) => state.showControls)
-	useEffect(() => {
-		if ((showControls && isRunning) || appState !== 'active') {
-			pause()
-		} else if (!showControls && !isRunning && appState === 'active') {
-			resume()
-		}
-	}, [showControls, pause, resume, isRunning, appState])
+
+	const timer = useBookTimer(id, { enabled: trackElapsedTime && !showControls })
 
 	const setIsReading = useReaderStore((state) => state.setIsReading)
 	const setShowControls = useReaderStore((state) => state.setShowControls)
@@ -230,7 +205,7 @@ export default function Screen() {
 			book={book}
 			pageURL={(page: number) => getPageURL(readingOrder![page - 1]?.href || '')}
 			requestHeaders={requestHeaders}
-			resetTimer={reset}
+			timer={timer}
 			onPageChanged={progressionURL ? onPageChanged : undefined}
 			isOPDS
 		/>

--- a/apps/expo/app/server/[id]/books/[id]/read.tsx
+++ b/apps/expo/app/server/[id]/books/[id]/read.tsx
@@ -26,7 +26,6 @@ import { NextInSeriesBookRef } from '~/components/book/reader/image/context'
 import { db, downloadedFiles } from '~/db'
 import { booksDirectory } from '~/lib/filesystem'
 import {
-	useAppState,
 	useSyncOnlineToOfflineAnnotations,
 	useSyncOnlineToOfflineBookmarks,
 	useSyncOnlineToOfflineProgress,
@@ -276,6 +275,7 @@ export default function Screen() {
 	const queryClient = useQueryClient()
 
 	const preferNativePdfReader = usePreferencesStore((store) => Boolean(store.preferNativePdf))
+	const showControls = useReaderStore((state) => state.showControls)
 
 	if (!book) {
 		throw new Error('Book not found')
@@ -304,9 +304,9 @@ export default function Screen() {
 	const {
 		preferences: { trackElapsedTime },
 	} = useBookPreferences({ book })
-	const { pause, resume, totalSeconds, isRunning, reset } = useBookTimer(book?.id || '', {
+	const timer = useBookTimer(book?.id || '', {
 		initial: book?.readProgress?.elapsedSeconds,
-		enabled: trackElapsedTime,
+		enabled: trackElapsedTime && !showControls,
 	})
 
 	const { syncProgress } = useSyncOnlineToOfflineProgress({ bookId: book.id, serverId })
@@ -323,6 +323,7 @@ export default function Screen() {
 
 	const onPageChanged = useCallback(
 		(page: number) => {
+			const totalSeconds = timer.getCurrentTime()
 			updateProgress({
 				id: book.id,
 				input: {
@@ -333,11 +334,12 @@ export default function Screen() {
 				},
 			})
 		},
-		[book.id, totalSeconds, updateProgress],
+		[book.id, timer, updateProgress],
 	)
 
 	const onLocationChanged = useCallback(
 		(locator: ReadiumLocator, percentage: number) => {
+			const totalSeconds = timer.getCurrentTime()
 			updateProgress({
 				id: book.id,
 				input: {
@@ -359,11 +361,12 @@ export default function Screen() {
 				},
 			})
 		},
-		[book.id, totalSeconds, updateProgress],
+		[book.id, timer, updateProgress],
 	)
 
 	const onReachedEnd = useCallback(
 		(locator: ReadiumLocator) => {
+			const totalSeconds = timer.getCurrentTime()
 			updateProgress({
 				id: book.id,
 				input: {
@@ -384,7 +387,7 @@ export default function Screen() {
 				},
 			})
 		},
-		[book.id, totalSeconds, updateProgress],
+		[book.id, timer, updateProgress],
 	)
 
 	const { syncCreate: syncBookmarkCreate, syncDelete: syncBookmarkDelete } =
@@ -544,29 +547,6 @@ export default function Screen() {
 		}
 	}, [setShowControls])
 
-	const onFocusedChanged = useCallback(
-		(focused: boolean) => {
-			if (!focused) {
-				pause()
-			} else if (focused) {
-				resume()
-			}
-		},
-		[pause, resume],
-	)
-
-	const appState = useAppState({
-		onStateChanged: onFocusedChanged,
-	})
-	const showControls = useReaderStore((state) => state.showControls)
-	useEffect(() => {
-		if ((showControls && isRunning) || appState !== 'active') {
-			pause()
-		} else if (!showControls && !isRunning && appState === 'active') {
-			resume()
-		}
-	}, [showControls, pause, resume, isRunning, appState])
-
 	/**
 	 * Invalidate the book query when a reader is unmounted so that the book overview
 	 * is updated with the latest read progress
@@ -630,7 +610,7 @@ export default function Screen() {
 				onPageChanged={onPageChanged}
 				serverId={serverId}
 				// incognito
-				resetTimer={reset}
+				timer={timer}
 			/>
 		)
 	} else if (book.extension.match(ARCHIVE_EXTENSION) || book.extension.match(PDF_EXTENSION)) {
@@ -640,7 +620,7 @@ export default function Screen() {
 				book={book}
 				pageURL={(page: number) => sdk.media.bookPageURL(book.id, page)}
 				onPageChanged={onPageChanged}
-				resetTimer={reset}
+				timer={timer}
 				nextInSeries={nextInSeries}
 				serverId={serverId}
 				requestHeaders={requestHeaders}

--- a/apps/expo/components/book/reader/image/Footer.tsx
+++ b/apps/expo/components/book/reader/image/Footer.tsx
@@ -14,7 +14,7 @@ import { useColors } from '~/lib/constants'
 import { useDisplay, usePrevious } from '~/lib/hooks'
 import { cn } from '~/lib/utils'
 import { usePreferencesStore, useReaderStore } from '~/stores'
-import { useBookPreferences, useBookReadTime } from '~/stores/reader'
+import { useBookPreferences } from '~/stores/reader'
 
 import { useReaderAnimations } from '../shared/readerAnimations'
 import { useImageBasedReader } from './context'
@@ -35,8 +35,8 @@ export default function Footer() {
 		isOPDS,
 		requestHeaders,
 		serverId,
+		timer,
 	} = useImageBasedReader()
-	const elapsedSeconds = useBookReadTime(book.id)
 	const {
 		preferences: {
 			footerControls = 'slider',
@@ -134,6 +134,7 @@ export default function Footer() {
 		}
 	}, [footerControls, currentPage, visible, visibilityChanged, pageSets, doublePageBehaviorChanged])
 
+	const elapsedSeconds = timer?.getCurrentTime() || 0
 	const formattedReadTime = formatHumanDuration(elapsedSeconds, { significantUnits: 2 })
 
 	const pageSource = useCallback(

--- a/apps/expo/components/book/reader/image/Header.tsx
+++ b/apps/expo/components/book/reader/image/Header.tsx
@@ -17,7 +17,7 @@ type Props = {
 }
 
 export default function Header({ onShowGlobalSettings }: Props) {
-	const { book, resetTimer, serverId } = useImageBasedReader()
+	const { book, timer, serverId } = useImageBasedReader()
 
 	const insets = useSafeAreaInsets()
 	const { secondaryStyle } = useReaderAnimations()
@@ -56,7 +56,7 @@ export default function Header({ onShowGlobalSettings }: Props) {
 				<PagedActionMenu
 					book={book}
 					serverId={serverId}
-					onResetTimer={resetTimer}
+					onResetTimer={timer?.reset}
 					onShowSettings={onShowGlobalSettings}
 				/>
 			</View>

--- a/apps/expo/components/book/reader/image/context.ts
+++ b/apps/expo/components/book/reader/image/context.ts
@@ -3,6 +3,8 @@ import { BookReadScreenQuery, ReadiumLocation, ReadiumLocator } from '@stump/gra
 import { ImageBasedBookPageRef, PageSetIndexes } from '@stump/sdk'
 import { createContext, useContext } from 'react'
 
+import { Timer } from '~/stores/reader'
+
 import { OfflineCompatibleReader } from '../types'
 
 type QueryData = NonNullable<BookReadScreenQuery['mediaById']>
@@ -52,7 +54,7 @@ export type IImageBasedReaderContext = {
 	pageThumbnailURL?: (page: number) => string
 	currentPage?: number
 	onPageChanged?: (page: number) => void
-	resetTimer?: () => void
+	timer?: Timer
 	isOPDS?: boolean
 } & OfflineCompatibleReader
 

--- a/apps/expo/components/book/reader/pdf/PdfReader.tsx
+++ b/apps/expo/components/book/reader/pdf/PdfReader.tsx
@@ -17,7 +17,7 @@ import {
 } from '~/modules/readium'
 import { useReaderStore } from '~/stores'
 import { usePdfStore } from '~/stores/pdf'
-import { useBookPreferences } from '~/stores/reader'
+import { Timer, useBookPreferences } from '~/stores/reader'
 
 import { ReaderBookRef } from '../image/context'
 import { ControlsBackdrop } from '../shared'
@@ -44,9 +44,9 @@ type Props = {
 	 */
 	offlineUri?: string
 	/**
-	 * A callback to reset the reading timer
+	 * The active book's timer
 	 */
-	resetTimer?: () => void
+	timer?: Timer
 } & OfflineCompatibleReader
 
 // TODO(expo-pdf): Long term, consider just using a library like https://github.com/wonday/react-native-pdf

--- a/apps/expo/components/book/reader/pdf/PdfReaderHeader.tsx
+++ b/apps/expo/components/book/reader/pdf/PdfReaderHeader.tsx
@@ -13,7 +13,7 @@ import { PagedActionMenu } from '../shared/paged-action-menu/PagedActionMenu'
 import { usePdfReaderContext } from './context'
 
 export function PdfReaderHeader() {
-	const { serverId, resetTimer } = usePdfReaderContext()
+	const { serverId, timer } = usePdfReaderContext()
 
 	const book = usePdfStore((state) => state.book)
 	const { secondaryStyle } = useReaderAnimations()
@@ -24,13 +24,13 @@ export function PdfReaderHeader() {
 	return (
 		<Animated.View
 			key={book?.id}
-			className="inset-x-safe absolute z-20 gap-4 px-4"
+			className="inset-x-safe gap-4 px-4 absolute z-20"
 			style={[{ top: initialWindowMetrics?.insets.top || insets.top }, secondaryStyle]}
 		>
 			<View className="flex-row items-center justify-between">
 				<HeaderButton onPress={() => router.back()} ios={{ variant: 'glass' }} />
 
-				{book && <PagedActionMenu book={book} serverId={serverId} onResetTimer={resetTimer} />}
+				{book && <PagedActionMenu book={book} serverId={serverId} onResetTimer={timer?.reset} />}
 			</View>
 
 			<Heading

--- a/apps/expo/components/book/reader/pdf/context.ts
+++ b/apps/expo/components/book/reader/pdf/context.ts
@@ -1,8 +1,10 @@
 import { createContext, useContext } from 'react'
 
+import { Timer } from '~/stores/reader'
+
 export type IPdfReaderContext = {
 	serverId: string
-	resetTimer?: () => void
+	timer?: Timer
 }
 
 export const PdfReaderContext = createContext<IPdfReaderContext | null>(null)

--- a/apps/expo/stores/reader.ts
+++ b/apps/expo/stores/reader.ts
@@ -7,6 +7,7 @@ import { useShallow } from 'zustand/react/shallow'
 
 import { useActiveServerSafe } from '~/components/activeServer'
 import { ImageReaderBookRef } from '~/components/book/reader/image/context'
+import { useAppState } from '~/lib/hooks'
 import { ColumnCount, ImageFilter, TextAlignment } from '~/modules/readium'
 
 import { ZustandMMKVStorage } from './store'
@@ -236,69 +237,72 @@ type UseBookTimerParams = {
 	enabled?: boolean
 }
 
-export const useBookReadTime = (
-	id: string,
-	{ initial }: Omit<UseBookTimerParams, 'enabled'> = {},
-) => {
-	const bookTimers = useReaderStore((state) => state.bookTimers)
-	const bookTimer = useMemo(() => bookTimers[id] || 0, [bookTimers, id])
-	return bookTimer || initial || 0
-}
-
 const defaultParams: UseBookTimerParams = {
 	initial: 0,
 	enabled: true,
 }
 
 export const useBookTimer = (id: string, params: UseBookTimerParams = defaultParams) => {
-	const [initial] = useState(() => params.initial)
+	const [initial, setInitial] = useState(params.initial)
+	const startDateRef = useRef<number | null>(null)
 
-	const bookTimers = useReaderStore((state) => state.bookTimers)
-	const bookTimer = useMemo(() => bookTimers[id] || 0, [bookTimers, id])
-	const setBookTimer = useReaderStore((state) => state.setBookTimer)
+	const getCurrentTime = useCallback(() => {
+		const bookTimer = useReaderStore.getState().bookTimers[id] || 0
+		const resolvedTimer = !!initial && initial > bookTimer ? initial : bookTimer
 
-	const resolvedTimer = useMemo(
-		() => (!!initial && initial > bookTimer ? initial : bookTimer),
-		[initial, bookTimer],
-	)
+		if (startDateRef.current === null) {
+			return resolvedTimer
+		}
 
-	const resolvedTimerRef = useRef(resolvedTimer)
-	// eslint-disable-next-line react-hooks/purity
-	const startDateRef = useRef(Date.now())
-	const [isRunning, setIsRunning] = useState(true)
-
-	resolvedTimerRef.current = resolvedTimer
-
-	const pauseTimer = useCallback(() => {
-		if (!isRunning) return
 		const elapsed = Math.trunc((Date.now() - startDateRef.current) / 1000)
-		setBookTimer(id, resolvedTimerRef.current + elapsed)
-		setIsRunning(false)
-	}, [id, isRunning, setBookTimer])
+		return resolvedTimer + elapsed
+	}, [id, initial])
 
-	const resumeTimer = useCallback(() => {
-		if (!params.enabled || isRunning) return
-		startDateRef.current = Date.now()
-		setIsRunning(true)
-	}, [params.enabled, isRunning])
+	const pause = useCallback(() => {
+		if (startDateRef.current === null) return
 
-	const resetTimer = useCallback(() => {
+		const elapsedSeconds = getCurrentTime()
+		useReaderStore.getState().setBookTimer(id, elapsedSeconds)
+
+		startDateRef.current = null
+	}, [id, getCurrentTime])
+
+	const resume = useCallback(() => {
+		if (!params.enabled || startDateRef.current !== null) return
 		startDateRef.current = Date.now()
-		setBookTimer(id, 0)
-	}, [id, setBookTimer])
+	}, [params.enabled])
+
+	const reset = useCallback(() => {
+		setInitial(0)
+		useReaderStore.getState().setBookTimer(id, 0)
+		startDateRef.current = startDateRef.current !== null ? Date.now() : null
+	}, [id])
 
 	useEffect(() => {
-		if (!params.enabled) pauseTimer()
-	}, [params.enabled, pauseTimer])
+		if (!params.enabled) {
+			pause()
+		} else {
+			resume()
+		}
+	}, [params.enabled, pause, resume])
 
-	return {
-		totalSeconds: resolvedTimer,
-		pause: pauseTimer,
-		resume: resumeTimer,
-		reset: resetTimer,
-		isRunning: isRunning,
-	}
+	const handleFocusedChanged = useCallback(
+		(focused: boolean) => {
+			if (!focused) {
+				pause()
+			} else {
+				resume()
+			}
+		},
+		[pause, resume],
+	)
+
+	useAppState({ onStateChanged: handleFocusedChanged })
+
+	return { getCurrentTime, pause, resume, reset }
 }
+
+export type Timer = ReturnType<typeof useBookTimer>
 
 export const useHideSystemBars = () => {
 	const { isReading, showControls } = useReaderStore(

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -65,7 +65,6 @@
 		"react-router-dom": "^6.30.0",
 		"react-scrollbar-size": "^5.0.0",
 		"react-swipeable": "^7.0.2",
-		"react-timer-hook": "^4.0.1",
 		"react-use": "^17.6.0",
 		"react-virtualized-auto-sizer": "^1.0.24",
 		"react-virtuoso": "^4.10.3",

--- a/packages/browser/src/components/readers/imageBased/ImageBasedReader.tsx
+++ b/packages/browser/src/components/readers/imageBased/ImageBasedReader.tsx
@@ -33,7 +33,6 @@ type Props = {
 	onProgress?: (page: number, elapsedSeconds: number) => void
 }
 
-// TODO: support read time
 export default function ImageBasedReader({ media, isIncognito, initialPage, onProgress }: Props) {
 	const { sdk } = useSDK()
 	const paths = usePaths()
@@ -60,18 +59,10 @@ export default function ImageBasedReader({ media, isIncognito, initialPage, onPr
 		setSettings,
 	} = useBookPreferences({ book: media })
 
-	const { pause, resume, totalSeconds, isRunning, reset } = useBookTimer(media?.id || '', {
+	const timer = useBookTimer(media?.id || '', {
 		initial: media?.readProgress?.elapsedSeconds,
-		enabled: trackElapsedTime,
+		enabled: trackElapsedTime && !showToolBar,
 	})
-
-	useEffect(() => {
-		if (showToolBar && isRunning) {
-			pause()
-		} else if (!showToolBar && !isRunning) {
-			resume()
-		}
-	}, [showToolBar, isRunning, pause, resume])
 
 	const windowSize = useWindowSize()
 
@@ -112,18 +103,6 @@ export default function ImageBasedReader({ media, isIncognito, initialPage, onPr
 	])
 
 	/**
-	 * A callback to update the read progress, if the reader is not in incognito mode.
-	 */
-	const handleUpdateProgress = useCallback(
-		(page: number) => {
-			if (!isIncognito) {
-				onProgress?.(page, totalSeconds)
-			}
-		},
-		[onProgress, isIncognito, totalSeconds],
-	)
-
-	/**
 	 * A callback to handle when the page changes. This will update the URL to reflect the new page
 	 * if the reader mode is not continuous.
 	 */
@@ -135,8 +114,13 @@ export default function ImageBasedReader({ media, isIncognito, initialPage, onPr
 				setCurrentPage(newPage)
 				navigate(paths.bookReader(media.id, { isIncognito, page: newPage }))
 			}
+
+			if (!isIncognito) {
+				const elapsedSeconds = timer.getCurrentTime()
+				onProgress?.(newPage, elapsedSeconds)
+			}
 		},
-		[media.id, isIncognito, navigate, readingMode, paths],
+		[media.id, isIncognito, navigate, readingMode, paths, timer, onProgress],
 	)
 
 	/**
@@ -202,7 +186,6 @@ export default function ImageBasedReader({ media, isIncognito, initialPage, onPr
 					media={media}
 					initialPage={currentPage}
 					getPageUrl={getPageUrl}
-					onProgressUpdate={handleUpdateProgress}
 					onPageChanged={handleChangePage}
 					orientation={
 						(readingMode.split('_')[1]?.toLowerCase() as 'vertical' | 'horizontal') || 'vertical'
@@ -227,7 +210,7 @@ export default function ImageBasedReader({ media, isIncognito, initialPage, onPr
 				getPageUrl,
 				setPageSize,
 				pageSets,
-				resetTimer: reset,
+				timer,
 				toggleToolbar: () => setSettings({ showToolBar: !showToolBar }),
 			}}
 		>

--- a/packages/browser/src/components/readers/imageBased/container/ControlsOverlay.tsx
+++ b/packages/browser/src/components/readers/imageBased/container/ControlsOverlay.tsx
@@ -1,4 +1,3 @@
-import { ReadingMode } from '@stump/graphql'
 import { motion } from 'framer-motion'
 import { Fragment } from 'react'
 
@@ -14,10 +13,7 @@ export default function ControlsOverlay() {
 	const {
 		settings: { showToolBar },
 		setSettings,
-		bookPreferences: { readingMode },
 	} = useBookPreferences({ book })
-
-	const showBottomToolbar = readingMode === ReadingMode.Paged
 
 	return (
 		<Fragment>
@@ -39,7 +35,7 @@ export default function ControlsOverlay() {
 
 			<NextInSeries />
 
-			{showBottomToolbar && <ReaderFooter />}
+			<ReaderFooter />
 		</Fragment>
 	)
 }

--- a/packages/browser/src/components/readers/imageBased/container/ReaderFooter.tsx
+++ b/packages/browser/src/components/readers/imageBased/container/ReaderFooter.tsx
@@ -10,7 +10,6 @@ import { ItemProps, ScrollerProps, Virtuoso, VirtuosoHandle } from 'react-virtuo
 import { EntityImage } from '@/components/entity'
 import { usePreferences } from '@/hooks/usePreferences'
 import { useBookPreferences } from '@/scenes/book/reader/useBookPreferences'
-import { useBookReadTime } from '@/stores/reader'
 
 import { useImageBaseReaderContext } from '../context'
 
@@ -18,13 +17,12 @@ const SIZE_MODIFIER = 1.5
 
 export default function ReaderFooter() {
 	const { sdk } = useSDK()
-	const { book, currentPage, setCurrentPage, imageSizes, setPageSize, pageSets } =
+	const { book, currentPage, setCurrentPage, imageSizes, setPageSize, pageSets, timer } =
 		useImageBaseReaderContext()
 	const {
 		settings: { showToolBar, preload },
 		bookPreferences: { readingDirection, trackElapsedTime },
 	} = useBookPreferences({ book })
-	const elapsedSeconds = useBookReadTime(book.id)
 	const {
 		preferences: { thumbnailRatio },
 	} = usePreferences()
@@ -54,6 +52,7 @@ export default function ReaderFooter() {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [showToolBar, currentPageSetIdx])
 
+	const elapsedSeconds = timer.getCurrentTime()
 	const formattedReadTime = formatHumanDuration(elapsedSeconds)
 
 	const renderItem = useCallback(

--- a/packages/browser/src/components/readers/imageBased/container/ReaderFooter.tsx
+++ b/packages/browser/src/components/readers/imageBased/container/ReaderFooter.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-compiler/react-compiler */
 import { useSDK } from '@stump/client'
 import { cn, ProgressBar, Text, usePreviousIsDifferent } from '@stump/components'
-import { ReadingDirection } from '@stump/graphql'
+import { ReadingDirection, ReadingMode } from '@stump/graphql'
 import { formatHumanDuration } from '@stump/i18n'
 import { motion } from 'framer-motion'
 import { forwardRef, useCallback, useEffect, useMemo, useRef } from 'react'
@@ -21,7 +21,7 @@ export default function ReaderFooter() {
 		useImageBaseReaderContext()
 	const {
 		settings: { showToolBar, preload },
-		bookPreferences: { readingDirection, trackElapsedTime },
+		bookPreferences: { readingMode, readingDirection, trackElapsedTime },
 	} = useBookPreferences({ book })
 	const {
 		preferences: { thumbnailRatio },
@@ -137,29 +137,31 @@ export default function ReaderFooter() {
 			// @ts-expect-error: It does have className?
 			className="bottom-0 left-0 gap-2 text-white shadow-lg fixed z-100 flex w-full flex-col justify-end overflow-hidden"
 		>
-			<Virtuoso
-				ref={virtuosoRef}
-				style={{
-					height:
-						(100 / thumbnailRatio) * SIZE_MODIFIER + // item height (all items have the same fixed height)
-						12 + // scrollbar vertical height
-						10 + // translateY padding
-						8, // add some vertical padding between the scrollbar and items
-				}}
-				horizontalDirection
-				data={pageSets}
-				components={{
-					Item,
-					Scroller,
-				}}
-				itemContent={renderItem}
-				overscan={{ main: preload.ahead || 1, reverse: preload.behind || 1 }}
-				initialTopMostItemIndex={
-					readingDirection === ReadingDirection.Rtl
-						? pageSets.length - currentPageSetIdx
-						: currentPageSetIdx
-				}
-			/>
+			{readingMode === ReadingMode.Paged && (
+				<Virtuoso
+					ref={virtuosoRef}
+					style={{
+						height:
+							(100 / thumbnailRatio) * SIZE_MODIFIER + // item height (all items have the same fixed height)
+							12 + // scrollbar vertical height
+							10 + // translateY padding
+							8, // add some vertical padding between the scrollbar and items
+					}}
+					horizontalDirection
+					data={pageSets}
+					components={{
+						Item,
+						Scroller,
+					}}
+					itemContent={renderItem}
+					overscan={{ main: preload.ahead || 1, reverse: preload.behind || 1 }}
+					initialTopMostItemIndex={
+						readingDirection === ReadingDirection.Rtl
+							? pageSets.length - currentPageSetIdx
+							: currentPageSetIdx
+					}
+				/>
+			)}
 
 			<div className="gap-2 px-4 pb-4 flex w-full flex-col">
 				<ProgressBar
@@ -168,7 +170,7 @@ export default function ReaderFooter() {
 					max={book.pages}
 					className="bg-[#0c0c0c]"
 					indicatorClassName="bg-[#898d94]"
-					inverted={readingDirection === ReadingDirection.Rtl}
+					inverted={readingDirection === ReadingDirection.Rtl && readingMode === ReadingMode.Paged}
 				/>
 
 				<div

--- a/packages/browser/src/components/readers/imageBased/container/TimerMenu.tsx
+++ b/packages/browser/src/components/readers/imageBased/container/TimerMenu.tsx
@@ -7,7 +7,7 @@ import { useImageBaseReaderContext } from '../context'
 import ControlButton from './ControlButton'
 
 export default function TimerMenu() {
-	const { book, resetTimer } = useImageBaseReaderContext()
+	const { book, timer } = useImageBaseReaderContext()
 	const {
 		bookPreferences: { trackElapsedTime },
 		setBookPreferences,
@@ -26,7 +26,7 @@ export default function TimerMenu() {
 					{trackElapsedTime ? 'Stop Timer' : 'Start Timer'}
 				</Dropdown.Item>
 
-				<Dropdown.Item onClick={resetTimer}>Reset Timer</Dropdown.Item>
+				<Dropdown.Item onClick={timer.reset}>Reset Timer</Dropdown.Item>
 			</Dropdown.Content>
 		</Dropdown>
 	)

--- a/packages/browser/src/components/readers/imageBased/container/TimerMenu.tsx
+++ b/packages/browser/src/components/readers/imageBased/container/TimerMenu.tsx
@@ -21,7 +21,7 @@ export default function TimerMenu() {
 				</ControlButton>
 			</Dropdown.Trigger>
 
-			<Dropdown.Content align="end">
+			<Dropdown.Content align="end" onCloseAutoFocus={(e) => e.preventDefault()}>
 				<Dropdown.Item onClick={() => setBookPreferences({ trackElapsedTime: !trackElapsedTime })}>
 					{trackElapsedTime ? 'Stop Timer' : 'Start Timer'}
 				</Dropdown.Item>

--- a/packages/browser/src/components/readers/imageBased/context.ts
+++ b/packages/browser/src/components/readers/imageBased/context.ts
@@ -1,6 +1,8 @@
 import { BookReaderSceneQuery } from '@stump/graphql'
 import { createContext, useContext } from 'react'
 
+import { Timer } from '@/stores/reader'
+
 export type ImageReaderBookRef = NonNullable<BookReaderSceneQuery['mediaById']>
 
 export type NextInSeriesBookRef = {
@@ -48,9 +50,9 @@ export type IImageBaseReaderContext = {
 	 */
 	pageSets: number[][]
 	/**
-	 * A function to reset the read timer
+	 * The active book's timer
 	 */
-	resetTimer: () => void
+	timer: Timer
 
 	toggleToolbar: () => void
 }

--- a/packages/browser/src/components/readers/imageBased/continuous/ContinuousScrollReader.tsx
+++ b/packages/browser/src/components/readers/imageBased/continuous/ContinuousScrollReader.tsx
@@ -30,10 +30,6 @@ type Props = {
 	 */
 	getPageUrl(page: number): string
 	/**
-	 * A callback to report the progress of the current page. If undefined, no progress will be reported.
-	 */
-	onProgressUpdate?(page: number): void
-	/**
 	 * A callback to report when the page has changed. If undefined, no callback will be called.
 	 */
 	onPageChanged?(page: number): void
@@ -51,7 +47,6 @@ export default function ContinuousScrollReader({
 	initialPage,
 	getPageUrl,
 	orientation,
-	onProgressUpdate,
 	onPageChanged,
 }: Props) {
 	const [search, setSearch] = useSearchParams()
@@ -80,10 +75,9 @@ export default function ContinuousScrollReader({
 	useEffect(() => {
 		const page = currentIndex + 1
 		if (pageDidChange) {
-			onProgressUpdate?.(page)
 			onPageChanged?.(page)
 		}
-	}, [currentIndex, onProgressUpdate, onPageChanged, pageDidChange])
+	}, [currentIndex, onPageChanged, pageDidChange])
 
 	const containerStyle = useCallback(
 		({ height, width }: { height: number; width: number }) =>

--- a/packages/browser/src/scenes/book/reader/BookReaderScene.tsx
+++ b/packages/browser/src/scenes/book/reader/BookReaderScene.tsx
@@ -135,21 +135,6 @@ function BookReaderScene({ book }: Props) {
 		}
 	}, [sdk, client])
 
-	/**
-	 * An effect to update the read progress whenever the page changes in the URL
-	 */
-	useEffect(() => {
-		if (isIncognito) return
-
-		const parsedPage = parseInt(page || '', 10)
-		if (!parsedPage || isNaN(parsedPage) || !book) return
-
-		const maxPage = book.pages
-		if (parsedPage <= 0 || parsedPage > maxPage) return
-
-		updateProgress(parsedPage, book.readProgress?.elapsedSeconds || 0)
-	}, [page, updateProgress, book, isIncognito])
-
 	const initialPage = useMemo(() => (page ? parseInt(page, 10) : undefined), [page])
 
 	useEffect(() => {

--- a/packages/browser/src/stores/reader.ts
+++ b/packages/browser/src/stores/reader.ts
@@ -1,5 +1,5 @@
 import { createReaderStore } from '@stump/client'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 export const useReaderStore = createReaderStore(localStorage)
 
@@ -14,35 +14,29 @@ const defaultParams: UseBookTimerParams = {
 }
 
 export const useBookTimer = (id: string, params: UseBookTimerParams = defaultParams) => {
-	const [initial, setInitial] = useState(() => params.initial)
-
-	const bookTimers = useReaderStore((state) => state.bookTimers)
-	const bookTimer = useMemo(() => bookTimers[id] || 0, [bookTimers, id])
-	const setBookTimer = useReaderStore((state) => state.setBookTimer)
-
-	const resolvedTimer = useMemo(
-		() => (!!initial && initial > bookTimer ? initial : bookTimer),
-		[initial, bookTimer],
-	)
-
+	const [initial, setInitial] = useState(params.initial)
 	const startDateRef = useRef<number | null>(null)
 
 	const getCurrentTime = useCallback(() => {
-		let elapsed = 0
-		if (startDateRef.current !== null) {
-			elapsed = Math.trunc((Date.now() - startDateRef.current) / 1000)
+		const bookTimer = useReaderStore.getState().bookTimers[id] || 0
+		const resolvedTimer = !!initial && initial > bookTimer ? initial : bookTimer
+
+		if (startDateRef.current === null) {
+			return resolvedTimer
 		}
+
+		const elapsed = Math.trunc((Date.now() - startDateRef.current) / 1000)
 		return resolvedTimer + elapsed
-	}, [resolvedTimer])
+	}, [id, initial])
 
 	const pause = useCallback(() => {
 		if (startDateRef.current === null) return
 
 		const elapsedSeconds = getCurrentTime()
-		setBookTimer(id, elapsedSeconds)
+		useReaderStore.getState().setBookTimer(id, elapsedSeconds)
 
 		startDateRef.current = null
-	}, [id, setBookTimer, getCurrentTime])
+	}, [id, getCurrentTime])
 
 	const resume = useCallback(() => {
 		if (!params.enabled || startDateRef.current !== null) return
@@ -51,9 +45,9 @@ export const useBookTimer = (id: string, params: UseBookTimerParams = defaultPar
 
 	const reset = useCallback(() => {
 		setInitial(0)
-		setBookTimer(id, 0)
+		useReaderStore.getState().setBookTimer(id, 0)
 		startDateRef.current = startDateRef.current !== null ? Date.now() : null
-	}, [id, setBookTimer])
+	}, [id])
 
 	useEffect(() => {
 		if (!params.enabled) {

--- a/packages/browser/src/stores/reader.ts
+++ b/packages/browser/src/stores/reader.ts
@@ -1,7 +1,5 @@
 import { createReaderStore } from '@stump/client'
-import { addSeconds } from 'date-fns'
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import { useStopwatch } from 'react-timer-hook'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 export const useReaderStore = createReaderStore(localStorage)
 
@@ -10,22 +8,13 @@ type UseBookTimerParams = {
 	enabled?: boolean
 }
 
-export const useBookReadTime = (
-	id: string,
-	{ initial }: Omit<UseBookTimerParams, 'enabled'> = {},
-) => {
-	const bookTimers = useReaderStore((state) => state.bookTimers)
-	const bookTimer = useMemo(() => bookTimers[id] || 0, [bookTimers, id])
-	return bookTimer || initial || 0
-}
-
 const defaultParams: UseBookTimerParams = {
 	initial: 0,
 	enabled: true,
 }
 
 export const useBookTimer = (id: string, params: UseBookTimerParams = defaultParams) => {
-	const [initial] = useState(() => params.initial)
+	const [initial, setInitial] = useState(() => params.initial)
 
 	const bookTimers = useReaderStore((state) => state.bookTimers)
 	const bookTimer = useMemo(() => bookTimers[id] || 0, [bookTimers, id])
@@ -36,42 +25,45 @@ export const useBookTimer = (id: string, params: UseBookTimerParams = defaultPar
 		[initial, bookTimer],
 	)
 
-	const { pause, totalSeconds, reset, isRunning } = useStopwatch({
-		autoStart: !!id && !!params.enabled,
-		offsetTimestamp: addSeconds(new Date(), resolvedTimer || 0),
-	})
+	const startDateRef = useRef<number | null>(null)
 
-	const pauseTimer = useCallback(() => {
-		if (isRunning) {
-			pause()
-			setBookTimer(id, totalSeconds)
+	const getCurrentTime = useCallback(() => {
+		let elapsed = 0
+		if (startDateRef.current !== null) {
+			elapsed = Math.trunc((Date.now() - startDateRef.current) / 1000)
 		}
-	}, [id, pause, setBookTimer, totalSeconds, isRunning])
+		return resolvedTimer + elapsed
+	}, [resolvedTimer])
 
-	const resumeTimer = useCallback(() => {
-		if (!params.enabled) return
+	const pause = useCallback(() => {
+		if (startDateRef.current === null) return
 
-		if (!isRunning) {
-			const offset = addSeconds(new Date(), totalSeconds)
-			reset(offset)
-		}
-	}, [totalSeconds, reset, isRunning, params.enabled])
+		const elapsedSeconds = getCurrentTime()
+		setBookTimer(id, elapsedSeconds)
 
-	const resetTimer = useCallback(() => {
-		reset(undefined, params.enabled)
+		startDateRef.current = null
+	}, [id, setBookTimer, getCurrentTime])
+
+	const resume = useCallback(() => {
+		if (!params.enabled || startDateRef.current !== null) return
+		startDateRef.current = Date.now()
+	}, [params.enabled])
+
+	const reset = useCallback(() => {
+		setInitial(0)
 		setBookTimer(id, 0)
-	}, [reset, params.enabled, id, setBookTimer])
-
-	useEffect(() => {
-		reset(addSeconds(new Date(), resolvedTimer || 0))
-	}, [resolvedTimer, reset])
+		startDateRef.current = startDateRef.current !== null ? Date.now() : null
+	}, [id, setBookTimer])
 
 	useEffect(() => {
 		if (!params.enabled) {
 			pause()
-			setBookTimer(id, totalSeconds)
+		} else {
+			resume()
 		}
-	}, [params.enabled, isRunning, pause, setBookTimer, id, totalSeconds])
+	}, [params.enabled, pause, resume])
 
-	return { totalSeconds, pause: pauseTimer, resume: resumeTimer, reset: resetTimer, isRunning }
+	return { getCurrentTime, pause, resume, reset }
 }
+
+export type Timer = ReturnType<typeof useBookTimer>

--- a/yarn.lock
+++ b/yarn.lock
@@ -21523,11 +21523,6 @@ react-swipeable@^7.0.2:
   resolved "https://registry.yarnpkg.com/react-swipeable/-/react-swipeable-7.0.2.tgz#ef8858096a47144ba7060675af1cd672e00ecc12"
   integrity sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==
 
-react-timer-hook@^4.0.1:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/react-timer-hook/-/react-timer-hook-4.0.5.tgz#887447dda64da9c9bd1bf13a116951bc37bf0ee4"
-  integrity sha512-elDxx4OIxBTbm4rXSK5cjBHkq06prO2qY9JzoYxOa11AkL3ij69jp0VuDUOqcehEK38CV0uu7FzUKtPVISRLKA==
-
 react-universal-interface@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/react-universal-interface/-/react-universal-interface-0.6.2.tgz#5e8d438a01729a4dbbcbeeceb0b86be146fe2b3b"
@@ -23191,16 +23186,7 @@ string-trim-spaces-only@^5.1.0:
   resolved "https://registry.yarnpkg.com/string-trim-spaces-only/-/string-trim-spaces-only-5.1.0.tgz#d68e328f4f11cbb96642334ae1582bf3c02582f5"
   integrity sha512-632znq4SGCNM7Vw7QITbx05oej+Xly2s7OtDxN9jvNbOoWcQuA5fq14CAS5TlpiiB04LDETzJj9fk851PnWLgg==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -23326,7 +23312,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -23346,13 +23332,6 @@ strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.2"
@@ -25434,7 +25413,7 @@ workbox-window@7.4.0, workbox-window@^7.4.0:
     "@types/trusted-types" "^2.0.2"
     workbox-core "7.4.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -25447,15 +25426,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Fixes reading time not updating the database when using the browser's paged image reader, and the reset timer button not resetting the timer properly on browser and mobile.

One thing I haven't fixed: only when changing page does the database update, so clicking `Reset Timer` doesn't push the newly reset timer until you change page. Not too much point in fixing this, and we'll have a new reading timer for the reading journal which will change things anyways