### PR TITLE
♻️ Add infinite scrolling for files in UploadModal to improve UX when uploading large amount of files

### DIFF
--- a/packages/browser/src/components/explorer/upload/UploadModal.tsx
+++ b/packages/browser/src/components/explorer/upload/UploadModal.tsx
@@ -48,6 +48,21 @@ export default function UploadModal() {
 	const { currentPath, refetch, uploadConfig, libraryID } = useFileExplorerContext()
 
 	const [uploadProgress, setUploadProgress] = useState(0)
+	const [visibleCount, setVisibleCount] = useState(50)
+
+	useEffect(() => {
+		setVisibleCount(50)
+	}, [files.length, uploadType])
+
+	const handleScroll = useCallback(
+		(e: React.UIEvent<HTMLDivElement>) => {
+			const target = e.currentTarget
+			if (target.scrollHeight - target.scrollTop <= target.clientHeight + 150) {
+				setVisibleCount((prev) => Math.min(prev + 50, files.length))
+			}
+		},
+		[files.length],
+	)
 
 	const config = useMemo(
 		() => ({
@@ -261,82 +276,95 @@ export default function UploadModal() {
 					</Dialog.Header>
 
 					<div
-						{...getRootProps()}
-						className={cn(
-							'space-y-4 rounded-lg p-4 flex shrink-0 grow cursor-pointer flex-col items-center justify-center border border-dashed border-edge-subtle ring-2 ring-transparent ring-offset-2 ring-offset-background-overlay outline-none!',
-							{ 'ring-edge-brand': isFocused },
-						)}
+						className="space-y-4 pr-2 max-h-[55vh] overflow-y-auto"
+						onScroll={handleScroll}
+						style={{
+							scrollbarColor: 'var(--color-scrollbar-thumb) transparent',
+						}}
 					>
-						<input {...getInputProps()} />
-
-						{renderDropContent()}
-					</div>
-
-					{/* Conditionally render the series name input */}
-					{uploadType === 'series' && (
-						<div className="mt-2">
-							<Heading size="xs">Series name</Heading>
-							<Dialog.Description>
-								This will be used as the name of the series directory. Your zip archive will be
-								unpacked here.
-							</Dialog.Description>
-							<Input
-								placeholder="Enter series name"
-								value={seriesDirName}
-								onChange={(e) => setSeriesDirName(e.target.value)}
-								className="mt-2"
-							/>
-						</div>
-					)}
-
-					<Accordion type="single" collapsible>
-						<Accordion.Item
-							value="files"
-							className="rounded-lg px-4 py-2 border-none bg-background-surface/80"
+						<div
+							{...getRootProps()}
+							className={cn(
+								'space-y-4 rounded-lg p-4 flex shrink-0 grow cursor-pointer flex-col items-center justify-center border border-dashed border-edge-subtle ring-2 ring-transparent ring-offset-2 ring-offset-background-overlay outline-none!',
+								{ 'ring-edge-brand': isFocused },
+							)}
 						>
-							<Accordion.Trigger
-								noUnderline
-								asLabel
-								disabled={!files.length}
-								className={cn('py-2', { 'cursor-not-allowed opacity-50': !files.length })}
+							<input {...getInputProps()} />
+
+							{renderDropContent()}
+						</div>
+
+						{/* Conditionally render the series name input */}
+						{uploadType === 'series' && (
+							<div className="mt-2">
+								<Heading size="xs">Series name</Heading>
+								<Dialog.Description>
+									This will be used as the name of the series directory. Your zip archive will be
+									unpacked here.
+								</Dialog.Description>
+								<Input
+									placeholder="Enter series name"
+									value={seriesDirName}
+									onChange={(e) => setSeriesDirName(e.target.value)}
+									className="mt-2"
+								/>
+							</div>
+						)}
+
+						<Accordion type="single" collapsible>
+							<Accordion.Item
+								value="files"
+								className="rounded-lg px-4 py-2 border-none bg-background-surface/80"
 							>
-								<span>
-									{t(getKey('addedFiles'))}{' '}
-									<span className="text-sm text-foreground-muted">({files.length})</span>
-								</span>
-							</Accordion.Trigger>
+								<Accordion.Trigger
+									noUnderline
+									asLabel
+									disabled={!files.length}
+									className={cn('py-2', { 'cursor-not-allowed opacity-50': !files.length })}
+								>
+									<span>
+										{t(getKey('addedFiles'))}{' '}
+										<span className="text-sm text-foreground-muted">({files.length})</span>
+									</span>
+								</Accordion.Trigger>
 
-							<Accordion.Content>
-								<div className="space-y-1 flex flex-col">
-									{files.map((file, idx) => (
-										<div
-											key={file.name}
-											className="group gap-x-2 rounded-lg p-2 flex items-center border border-edge"
-										>
-											<Text size="sm" className="line-clamp-1">
-												{file.name}
-											</Text>
-											<Text size="sm" variant="muted" className="shrink-0">
-												{formatBytes(file.size)}
-											</Text>
-
-											<div className="flex-1" />
-											<Button
-												variant="ghost"
-												size="xs"
-												className="opacity-0 transition-opacity duration-200 group-hover:opacity-100"
-												onClick={() => {
-													setFiles((prev) => prev.filter((_, i) => i !== idx))
-												}}
+								<Accordion.Content>
+									<div className="space-y-1 flex flex-col">
+										{files.slice(0, visibleCount).map((file, idx) => (
+											<div
+												key={file.name}
+												className="group gap-x-2 rounded-lg p-2 flex items-center border border-edge"
 											>
-												{t('common.remove')}
-											</Button>
-										</div>
-									))}
-								</div>
-							</Accordion.Content>
-						</Accordion.Item>
-					</Accordion>
+												<Text size="sm" className="line-clamp-1">
+													{file.name}
+												</Text>
+												<Text size="sm" variant="muted" className="shrink-0">
+													{formatBytes(file.size)}
+												</Text>
+
+												<div className="flex-1" />
+												<Button
+													variant="ghost"
+													size="xs"
+													className="opacity-0 transition-opacity duration-200 group-hover:opacity-100"
+													onClick={() => {
+														setFiles((prev) => prev.filter((_, i) => i !== idx))
+													}}
+												>
+													{t('common.remove')}
+												</Button>
+											</div>
+										))}
+										{files.length > visibleCount && (
+											<div className="p-2 text-xs text-center text-foreground-muted italic">
+												...and {files.length - visibleCount} more files (scroll to load more)
+											</div>
+										)}
+									</div>
+								</Accordion.Content>
+							</Accordion.Item>
+						</Accordion>
+					</div>
 
 					<Dialog.Footer>
 						<Button variant="default" onClick={() => setUploadType(undefined)}>


### PR DESCRIPTION

This PR adds infinite scroll to the upload dialog so that users may use that to upload large amount of books in one sitting.

Previously, if there were too many books loaded there was layout overflow, that:
- was not scroll-able
- made it impossible to go forward with the upload
- loaded every book into DOM (though, not necessary problematic, but not exactly a great thing either)





### Before

*The modal expands off-screen, scrollbar is missing, the list is not scrollable at all, buttons are unreachable*
<img width="3452" height="1818" alt="image" src="https://github.com/user-attachments/assets/e9453dc2-44d0-4ce0-a0a0-71519aad45bc" />



### After


#### Autumn theme:

<img width="1478" height="1500" alt="image" src="https://github.com/user-attachments/assets/0cd272a4-cfb5-43b7-9220-aa5bb7336efe" />

#### White theme:

<img width="1572" height="1476" alt="image" src="https://github.com/user-attachments/assets/1307f7ab-6bd6-49fe-a498-5d8f9123e0ed" />


#### Dark theme:
<img width="1508" height="1480" alt="image" src="https://github.com/user-attachments/assets/74008961-9238-4480-a97c-c0e0d99ecddb" />




First PR so feel free to let me know if I forgot something. Thanks!