### PR TITLE
👷 Add cooldown period and min release age for dependencies updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
       - 'dependencies'
     versioning-strategy: increase
     target-branch: 'nightly'
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: 'cargo'
     directory: '/'
@@ -19,6 +21,8 @@ updates:
     labels:
       - 'dependencies'
     target-branch: 'nightly'
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: 'github-actions'
     directory: '/'
@@ -28,3 +32,5 @@ updates:
     labels:
       - 'dependencies'
     target-branch: 'nightly'
+    cooldown:
+      default-days: 3

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 strict-peer-dependencies=false
 node-linker=hoisted
+min-release-age=3


### PR DESCRIPTION
This PR adds a 3-day cooldown before Dependabot raises PRs for newly published dependency versions.

Supply chain attacks through compromised packages have been on the rise lately, TanStack being just one recent example. While there's no ultimate solution against these, a short cooldown gives security researchers and the community a window to catch and report a malicious release before we unknowingly pull it in. Three days is a small wait, but often enough for the worst offenders to get flagged.

E.g., the Tanstack comprosed packages were detected after 20 mins (according to post-mortem: 19:26:14	were the packages published, 19:46 step-security already reported the incident), so 3 days should be good enough. See: https://tanstack.com/blog/npm-supply-chain-compromise-postmortem