### PR TITLE
:wrench: Optimize Cargo profiles for improved performance, bundle size and dev experience

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,3 +113,16 @@ pretty_assertions = "1.4.1"
 
 # Only used to test with sea-orm
 maplit = { version = "1.0.2" }
+
+[profile.dev.package."*"]
+# Compile all dependencies with opt-level=3 to help speed up tests and
+# debug builds
+codegen-units = 1
+debug = "line-tables-only"
+opt-level = 3
+
+[profile.release]
+strip = "debuginfo"
+codegen-units = 1
+panic = "abort"
+


### PR DESCRIPTION
TLDR:

as i was trying to bootstrap to the Rust stuff, i was browsing other projects and noticed lot of them, ran with custom Cargo profile overrides. Samples include:
- https://github.com/meilisearch/meilisearch/blob/ff4029fa5190772edae86831d5aaff3b03ee675d/Cargo.toml#L46
- https://github.com/jj-vcs/jj/blob/f849d257b9020a3af6e97bc04c1ad0a592d94ccc/Cargo.toml#L182
- https://github.com/rustdesk/rustdesk/blob/d59d543ec1e1559027b4d845cdcdeca6b23930a8/Cargo.toml#L241

After a bit of research i think this make sense for us to do also.

For more general docs see: https://github.com/johnthagen/min-sized-rust


Added better `[profile.dev.package."*"]` and `[profile.release]` sections to `Cargo.toml` to reduce binary size in release builds.

Development Profile `[profile.dev.package."*"]`

Compiles all dependencies at `opt-level = 3` while keeping the dev profile's fast incremental compilation for first-party code. Debug info is reduced to `line-tables-only` to shrink the `target/debug` directory without losing the ability to get stack traces.

```toml
[profile.dev.package."*"]
# Compile all dependencies with opt-level=3 to help speed up tests and
# debug builds
codegen-units = 1
debug = "line-tables-only"
opt-level = 3
```

The `[profile.dev.package."*"]` glob override applies settings to all dependencies without affecting your own crate's compilation settings. This is the recommended pattern for speeding up test and debug runs where heavy crates (e.g., `serde`, `regex`, `tokio`) are the bottleneck. See [Cargo Docs, Profile Overrides](https://doc.rust-lang.org/cargo/reference/profiles.html#overrides).

Release profile (`[profile.release]`)

```toml
[profile.release]
strip = "debuginfo"
codegen-units = 1
panic = "abort"
```

### Settings explained

- `strip = "debuginfo"`: Strips DWARF debug sections from the binary without removing symbol names, keeping crash reports usable. The `"debuginfo"` variant is less aggressive than `"symbols"`, preserving backtraces in production logs. See [Cargo Docs, `strip`](https://doc.rust-lang.org/cargo/reference/profiles.html#strip).
- `codegen-units = 1`: Forces LLVM to compile the whole crate as a single unit, enabling more aggressive inlining, dead-code elimination, and cross-function optimization. The default is 16, which parallelizes compilation at the cost of optimization quality. See [Cargo Docs, `codegen-units`](https://doc.rust-lang.org/cargo/reference/profiles.html#codegen-units).
- `panic = "abort"`: Replaces Rust's stack-unwinding machinery with a direct `abort`, removing `libunwind` and all associated cleanup code from the binary entirely. Safe to use in most applications that do not rely on `catch_unwind`. See [Cargo Docs, `panic`](https://doc.rust-lang.org/cargo/reference/profiles.html#panic).



### (not very scientifically measured) clean build times, sizes etc...

| Profile | Binary Size | Clean Build Time |
| :--- | :--- | :--- |
| **Original Release** | 71 MB | 2m 38s |
| **Optimized Release** | **37 MB** | 3m 39s |
| **Original Dev** | 183 MB | 1m 22s |
| **Optimized Dev** | **129 MB** | 1m 45s |

Long story short: production binary dropped from 71 -> 37 MB (~48% reduction), directly translating to smaller Docker images

All benchmarks were run on an Apple M5 Pro (48 GB RAM) with clean builds. (You may not be able fully reproduce this. )