### PR TITLE
:adhesive_bandage: Add manual denylist for workbox

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -51,6 +51,12 @@ export default defineConfig({
 			},
 			workbox: {
 				inlineWorkboxRuntime: true,
+				navigateFallbackDenylist: [
+					/^\/api(?:\/|$)/,
+					/^\/opds(?:\/|$)/,
+					/^\/kobo(?:\/|$)/,
+					/^\/koreader(?:\/|$)/,
+				],
 				maximumFileSizeToCacheInBytes: 5 * 1024 * 1024, // 5MB
 			},
 			outDir: '../dist',


### PR DESCRIPTION
I noticed some routes were failing to "exit" the spa because of the service worker not understanding the boundaries. I've added a denylist for the few groups which should be excluded (e.g., going to the gql playground shouldn't route within the spa, etc)