### PR TITLE
🐛 (expo): Fix offline-to-online sync issues

### DIFF
--- a/apps/expo/__tests__/utils/db.ts
+++ b/apps/expo/__tests__/utils/db.ts
@@ -1,0 +1,87 @@
+/**
+ * shared test database utilities since working with drizzle in tests is really really annoying
+ *
+ * but why use better-sqlite3 aaron? see https://github.com/drizzle-team/drizzle-orm/issues/435
+ * but tldr; not all drivers expose a `mock` function, and better-sqlite3 runs within node
+ * which vitest runs in, and so this lets us create an in-mem db for tests. not great but
+ * i guess not the end of the world
+ *
+ * copypasta:
+ *
+ * ```ts
+ * import { createTestDb, dbProxy, type TestDb } from '~/__tests__/utils/db'
+ *
+ * vi.mock('~/db', async () => {
+ *   const { createDbMock } = await import('~/__tests__/utils/db')
+ *   return createDbMock()
+ * })
+ *
+ * beforeEach(() => { dbProxy.current = createTestDb() })
+ * ```
+ */
+
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import fs from 'fs'
+import path from 'path'
+
+import * as schema from '~/db/schema'
+
+const MIGRATIONS_DIR = path.join(__dirname, '..', '..', 'drizzle')
+
+function splitMigration(sql: string): string[] {
+	return (
+		sql
+			// drizzle separates statements with `--> statement-breakpoint` comments
+			// so we split on it to run each separately
+			.split(/--> statement-breakpoint/)
+			.map((s) => s.trim())
+			.filter(Boolean)
+			.filter((s) => !/^INSERT\s+INTO\s+.+\s+SELECT\s+/i.test(s))
+	)
+}
+
+/**
+ * create an in-memory database and apply migrations
+ */
+export function createTestDb() {
+	const sqlite = new Database(':memory:')
+
+	const files = fs
+		.readdirSync(MIGRATIONS_DIR)
+		.filter((f) => f.endsWith('.sql'))
+		.sort() // should be fine, files are padded (e.g., 0001)
+
+	for (const file of files) {
+		const sql = fs.readFileSync(path.join(MIGRATIONS_DIR, file), 'utf8')
+		for (const stmt of splitMigration(sql)) {
+			sqlite.exec(stmt)
+		}
+	}
+
+	return drizzle(sqlite, { schema })
+}
+
+export type TestDb = ReturnType<typeof createTestDb>
+
+export const dbProxy: { current: TestDb } = { current: null! }
+
+/**
+ * returns the module shape for easy mocking of `~/db`, e.g.,
+ *
+ * ```ts
+ * vi.mock('~/db', async () => {
+ *   const { createDbMock } = await import('~/__tests__/utils/db')
+ *   return createDbMock()
+ * })
+ * ```
+ */
+export async function createDbMock() {
+	const schema = await import('~/db/schema')
+	return {
+		...schema,
+		get db() {
+			return dbProxy.current
+		},
+	}
+}

--- a/apps/expo/backgroundTasks/__tests__/pullServerProgress.test.ts
+++ b/apps/expo/backgroundTasks/__tests__/pullServerProgress.test.ts
@@ -1,0 +1,312 @@
+import { ReadthroughRecord, ResumeReadingCursor } from '@stump/graphql'
+import { Api } from '@stump/sdk'
+import { eq } from 'drizzle-orm'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createTestDb, dbProxy, type TestDb } from '~/__tests__/utils/db'
+import { downloadedFiles, readProgress, syncStatus } from '~/db/schema'
+
+vi.mock('@sentry/react-native', () => ({
+	captureException: vi.fn(),
+	captureMessage: vi.fn(),
+}))
+
+vi.mock('@stump/graphql', () => ({
+	graphql: vi.fn((q) => q),
+}))
+
+vi.mock('~/db', async () => {
+	const { createDbMock } = await import('~/__tests__/utils/db')
+	return createDbMock()
+})
+
+// we import dynamically so that the mocked db is in place. not overly ideal, but figuring out
+// how to test the database without a full disgusting mock was a bit of a headache
+const loadPullProgressFn = () =>
+	import('../pullServerProgress').then((m) => m.executeSingleServerPullSync)
+
+const SERVER_ID = 'server-1'
+const BOOK_ID = 'book-1'
+const OLDER_DATE = '2026-06-01T00:00:00.000Z'
+const NEWER_DATE = '2026-06-03T00:00:00.000Z'
+
+async function seedBook(db: TestDb, bookId = BOOK_ID) {
+	await db.insert(downloadedFiles).values({
+		id: bookId,
+		filename: `${bookId}.epub`,
+		uri: `/books/${bookId}.epub`,
+		serverId: SERVER_ID,
+		downloadedAt: new Date(),
+	})
+}
+
+async function seedProgress(
+	db: TestDb,
+	overrides: {
+		bookId?: string
+		syncStatus?: string
+		elapsedSeconds?: number
+		lastSyncedElapsedSeconds?: number
+		lastModified?: Date
+	} = {},
+) {
+	await db.insert(readProgress).values({
+		bookId: overrides.bookId ?? BOOK_ID,
+		serverId: SERVER_ID,
+		page: 5,
+		elapsedSeconds: overrides.elapsedSeconds ?? 300,
+		lastSyncedElapsedSeconds: overrides.lastSyncedElapsedSeconds ?? 300,
+		percentage: '0.25',
+		syncStatus: overrides.syncStatus ?? syncStatus.enum.SYNCED,
+		lastModified: overrides.lastModified ?? new Date(OLDER_DATE),
+	})
+}
+
+type FakeServerMedia = {
+	id: string
+	readProgress: Omit<ResumeReadingCursor, '__typename' | 'readthroughNumber'> | null
+	readHistory: Array<Pick<ReadthroughRecord, 'completedAt'>>
+}
+
+function makeServerMedia(overrides: Partial<FakeServerMedia> = {}) {
+	return {
+		id: overrides.id ?? BOOK_ID,
+		readProgress:
+			overrides.readProgress !== undefined
+				? overrides.readProgress
+				: {
+						page: 10,
+						percentageCompleted: '0.5',
+						epubcfi: null,
+						updatedAt: NEWER_DATE,
+						elapsedSeconds: 600,
+						locator: null,
+					},
+		readHistory: overrides.readHistory ?? [],
+	} as FakeServerMedia
+}
+
+function makeMockApi(serverMedia: FakeServerMedia[]) {
+	return {
+		execute: vi.fn().mockResolvedValue({
+			media: { nodes: serverMedia },
+		}),
+	} as unknown as Api
+}
+
+beforeEach(() => {
+	vi.clearAllMocks()
+	dbProxy.current = createTestDb()
+})
+
+describe('conflict resolution', () => {
+	it.each([syncStatus.enum.UNSYNCED, syncStatus.enum.SYNCING, syncStatus.enum.ERROR])(
+		'leaves local record unchanged when syncStatus is %s and local timestamp is newer',
+		async (status) => {
+			const db = dbProxy.current
+			const executeSingleServerPullSync = await loadPullProgressFn()
+
+			await seedBook(db)
+			await seedProgress(db, { syncStatus: status, lastModified: new Date(NEWER_DATE) })
+
+			const originalRecord = await db
+				.select()
+				.from(readProgress)
+				.where(eq(readProgress.bookId, BOOK_ID))
+				.then((r) => r[0])
+
+			// server is older than local
+			const api = makeMockApi([
+				makeServerMedia({
+					readProgress: {
+						page: 10,
+						percentageCompleted: '0.5',
+						epubcfi: null,
+						updatedAt: OLDER_DATE,
+						elapsedSeconds: 600,
+						locator: null,
+					},
+				}),
+			])
+			const result = await executeSingleServerPullSync(SERVER_ID, api as never)
+
+			expect(result.failedBookIds).toHaveLength(0)
+
+			const afterRecord = await db
+				.select()
+				.from(readProgress)
+				.where(eq(readProgress.bookId, BOOK_ID))
+				.then((r) => r[0])
+			expect(afterRecord).toEqual(originalRecord) // no change
+		},
+	)
+
+	it.each([syncStatus.enum.UNSYNCED, syncStatus.enum.SYNCING, syncStatus.enum.ERROR])(
+		'overwrites local record when syncStatus is %s but server timestamp is newer',
+		async (status) => {
+			const db = dbProxy.current
+			const executeSingleServerPullSync = await loadPullProgressFn()
+
+			await seedBook(db)
+			await seedProgress(db, { syncStatus: status, lastModified: new Date(OLDER_DATE) })
+
+			// server is newer than local
+			const api = makeMockApi([makeServerMedia()])
+			await executeSingleServerPullSync(SERVER_ID, api as never)
+
+			const after = await db
+				.select()
+				.from(readProgress)
+				.where(eq(readProgress.bookId, BOOK_ID))
+				.then((r) => r[0])
+
+			expect(after!.page).toBe(10)
+			expect(after!.elapsedSeconds).toBe(600)
+			expect(after!.syncStatus).toBe(syncStatus.enum.SYNCED)
+		},
+	)
+
+	it('applies the server record when local syncStatus is SYNCED and the server is newer', async () => {
+		const db = dbProxy.current
+		const executeSingleServerPullSync = await loadPullProgressFn()
+
+		await seedBook(db)
+		await seedProgress(db, {
+			syncStatus: syncStatus.enum.SYNCED,
+			elapsedSeconds: 300,
+		})
+
+		const api = makeMockApi([makeServerMedia()]) // 1 hour ahead
+		await executeSingleServerPullSync(SERVER_ID, api as never)
+
+		const after = await db
+			.select()
+			.from(readProgress)
+			.where(eq(readProgress.bookId, BOOK_ID))
+			.then((r) => r[0])
+
+		expect(after).toBeTruthy()
+		expect(after!.page).toBe(10)
+		expect(after!.elapsedSeconds).toBe(600)
+		expect(after!.syncStatus).toBe(syncStatus.enum.SYNCED)
+	})
+
+	it('creates a local record when no progress exists yet', async () => {
+		const db = dbProxy.current
+		const executeSingleServerPullSync = await loadPullProgressFn()
+
+		await seedBook(db)
+
+		const api = makeMockApi([makeServerMedia()])
+		await executeSingleServerPullSync(SERVER_ID, api as never)
+
+		const records = await db.select().from(readProgress).where(eq(readProgress.bookId, BOOK_ID))
+		expect(records).toHaveLength(1)
+		expect(records[0]!.page).toBe(10)
+	})
+})
+
+describe('completed books', () => {
+	// TODO: this is how it works but perhaps it would be better to preserve it until the book is deleted
+	it('deletes local progress when the server reports the book as completed and the completion is more recent', async () => {
+		const db = dbProxy.current
+		const executeSingleServerPullSync = await loadPullProgressFn()
+
+		await seedBook(db)
+		await seedProgress(db, { lastModified: new Date(OLDER_DATE) })
+
+		const api = makeMockApi([
+			makeServerMedia({
+				readProgress: null,
+				readHistory: [{ completedAt: NEWER_DATE }],
+			}),
+		])
+		await executeSingleServerPullSync(SERVER_ID, api as never)
+
+		const records = await db.select().from(readProgress).where(eq(readProgress.bookId, BOOK_ID))
+		expect(records).toHaveLength(0)
+	})
+
+	it('preserves local progress when local read is more recent than the server completion', async () => {
+		const db = dbProxy.current
+		const executeSingleServerPullSync = await loadPullProgressFn()
+
+		await seedBook(db)
+		// local is more recent than the server completion
+		await seedProgress(db, { lastModified: new Date(NEWER_DATE) })
+
+		const api = makeMockApi([
+			makeServerMedia({
+				readHistory: [{ completedAt: OLDER_DATE }],
+			}),
+		])
+		await executeSingleServerPullSync(SERVER_ID, api as never)
+
+		const records = await db.select().from(readProgress).where(eq(readProgress.bookId, BOOK_ID))
+		expect(records).toHaveLength(1)
+	})
+})
+
+describe('lastSyncedElapsedSeconds tracking', () => {
+	it('sets lastSyncedElapsedSeconds to the server elapsedSeconds after a pull', async () => {
+		const db = dbProxy.current
+		const executeSingleServerPullSync = await loadPullProgressFn()
+
+		await seedBook(db)
+		await seedProgress(db, { syncStatus: syncStatus.enum.SYNCED, elapsedSeconds: 300 })
+
+		const api = makeMockApi([
+			makeServerMedia({
+				readProgress: {
+					page: 20,
+					percentageCompleted: '0.75',
+					epubcfi: null,
+					updatedAt: NEWER_DATE,
+					elapsedSeconds: 900,
+					locator: null,
+				},
+			}),
+		])
+		await executeSingleServerPullSync(SERVER_ID, api as never)
+
+		const after = await db
+			.select()
+			.from(readProgress)
+			.where(eq(readProgress.bookId, BOOK_ID))
+			.then((r) => r[0])
+
+		expect(after).toBeTruthy()
+		expect(after!.elapsedSeconds).toBe(900)
+		expect(after!.lastSyncedElapsedSeconds).toBe(900)
+	})
+
+	it('sets lastSyncedElapsedSeconds equal to elapsedSeconds on a fresh pull with no prior record', async () => {
+		const db = dbProxy.current
+		const executeSingleServerPullSync = await loadPullProgressFn()
+
+		await seedBook(db)
+
+		const api = makeMockApi([
+			makeServerMedia({
+				readProgress: {
+					page: 1,
+					percentageCompleted: '0.1',
+					epubcfi: null,
+					updatedAt: NEWER_DATE,
+					elapsedSeconds: 120,
+					locator: null,
+				},
+			}),
+		])
+		await executeSingleServerPullSync(SERVER_ID, api as never)
+
+		const after = await db
+			.select()
+			.from(readProgress)
+			.where(eq(readProgress.bookId, BOOK_ID))
+			.then((r) => r[0])
+
+		expect(after).toBeTruthy()
+		expect(after!.lastSyncedElapsedSeconds).toBe(after!.elapsedSeconds)
+	})
+})

--- a/apps/expo/backgroundTasks/__tests__/pushLocalProgress.test.ts
+++ b/apps/expo/backgroundTasks/__tests__/pushLocalProgress.test.ts
@@ -1,0 +1,243 @@
+import { Api } from '@stump/sdk'
+import { eq } from 'drizzle-orm'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createTestDb, dbProxy, type TestDb } from '~/__tests__/utils/db'
+import { downloadedFiles, readProgress, syncStatus } from '~/db/schema'
+
+vi.mock('@stump/graphql', () => ({
+	graphql: vi.fn((q) => q),
+}))
+
+vi.mock('~/db', async () => {
+	const { createDbMock } = await import('~/__tests__/utils/db')
+	return createDbMock()
+})
+
+const loadPushProgressFn = () =>
+	import('../pushLocalProgress').then((m) => m.executePushProgressSync)
+
+const SERVER_ID = 'server-1'
+const BOOK_ID = 'book-1'
+
+async function seedBook(db: TestDb, bookId = BOOK_ID) {
+	await db.insert(downloadedFiles).values({
+		id: bookId,
+		filename: `${bookId}.epub`,
+		uri: `/books/${bookId}.epub`,
+		serverId: SERVER_ID,
+		downloadedAt: new Date(),
+	})
+}
+
+async function seedProgress(
+	db: TestDb,
+	overrides: {
+		bookId?: string
+		syncStatus?: string
+		elapsedSeconds?: number
+		lastSyncedElapsedSeconds?: number
+	} = {},
+) {
+	await db.insert(readProgress).values({
+		bookId: overrides.bookId ?? BOOK_ID,
+		serverId: SERVER_ID,
+		page: 5,
+		elapsedSeconds: overrides.elapsedSeconds ?? 300,
+		lastSyncedElapsedSeconds: overrides.lastSyncedElapsedSeconds ?? 200,
+		percentage: '0.25',
+		syncStatus: overrides.syncStatus ?? syncStatus.enum.UNSYNCED,
+		lastModified: new Date(),
+	})
+}
+
+function makeMockApi(opts: { shouldFail?: boolean } = {}) {
+	return {
+		execute: opts.shouldFail
+			? vi.fn().mockRejectedValue(new Error('network error'))
+			: vi.fn().mockResolvedValue({ updateMediaProgress: { __typename: 'MediaProgress' } }),
+	} as unknown as Api
+}
+
+beforeEach(() => {
+	vi.clearAllMocks()
+	dbProxy.current = createTestDb()
+})
+
+describe('what gets pushed', () => {
+	it('pushes UNSYNCED records and marks them SYNCED on success', async () => {
+		const db = dbProxy.current
+		const executePushProgressSync = await loadPushProgressFn()
+
+		await seedBook(db)
+		await seedProgress(db, { syncStatus: syncStatus.enum.UNSYNCED })
+
+		const api = makeMockApi()
+		const results = await executePushProgressSync({ [SERVER_ID]: api })
+
+		expect(results[SERVER_ID]!.syncedCount).toBe(1)
+		expect(results[SERVER_ID]!.failureCount).toBe(0)
+		expect(api.execute).toHaveBeenCalledOnce()
+
+		const after = await db
+			.select()
+			.from(readProgress)
+			.where(eq(readProgress.bookId, BOOK_ID))
+			.then((r) => r[0])
+		expect(after!.syncStatus).toBe(syncStatus.enum.SYNCED)
+	})
+
+	it('pushes ERROR records', async () => {
+		const db = dbProxy.current
+		const executePushProgressSync = await loadPushProgressFn()
+
+		await seedBook(db)
+		await seedProgress(db, { syncStatus: syncStatus.enum.ERROR })
+
+		const api = makeMockApi()
+		const results = await executePushProgressSync({ [SERVER_ID]: api })
+
+		expect(results[SERVER_ID]!.syncedCount).toBe(1)
+		expect(api.execute).toHaveBeenCalledOnce()
+	})
+
+	it.each([syncStatus.enum.SYNCING, syncStatus.enum.SYNCED])('skips %s records', async (status) => {
+		const db = dbProxy.current
+		const executePushProgressSync = await loadPushProgressFn()
+
+		await seedBook(db)
+		await seedProgress(db, { syncStatus: status })
+
+		const api = makeMockApi()
+		const results = await executePushProgressSync({ [SERVER_ID]: api })
+
+		expect(results[SERVER_ID]!.syncedCount).toBe(0)
+		expect(api.execute).not.toHaveBeenCalled()
+	})
+
+	it('respects ignoreBookIds and skips pushing those', async () => {
+		const db = dbProxy.current
+		const executePushProgressSync = await loadPushProgressFn()
+
+		await seedBook(db)
+		await seedProgress(db, { syncStatus: syncStatus.enum.UNSYNCED })
+
+		const api = makeMockApi()
+		const results = await executePushProgressSync({ [SERVER_ID]: api }, [BOOK_ID])
+
+		expect(results[SERVER_ID]!.syncedCount).toBe(0)
+		expect(api.execute).not.toHaveBeenCalled()
+	})
+})
+
+describe('errors', () => {
+	it('marks record as ERROR when the push call fails', async () => {
+		const db = dbProxy.current
+		const executePushProgressSync = await loadPushProgressFn()
+
+		await seedBook(db)
+		await seedProgress(db, { syncStatus: syncStatus.enum.UNSYNCED })
+
+		const api = makeMockApi({ shouldFail: true })
+		const results = await executePushProgressSync({ [SERVER_ID]: api })
+
+		expect(results[SERVER_ID]!.failureCount).toBe(1)
+		expect(results[SERVER_ID]!.syncedCount).toBe(0)
+
+		const after = await db
+			.select()
+			.from(readProgress)
+			.where(eq(readProgress.bookId, BOOK_ID))
+			.then((r) => r[0])
+		expect(after!.syncStatus).toBe(syncStatus.enum.ERROR)
+	})
+
+	it('continues to push records after a failure', async () => {
+		const db = dbProxy.current
+		const executePushProgressSync = await loadPushProgressFn()
+
+		const BOOK_ID_2 = 'book-2'
+		await seedBook(db, BOOK_ID)
+		await seedBook(db, BOOK_ID_2)
+		await seedProgress(db, { syncStatus: syncStatus.enum.UNSYNCED })
+		await seedProgress(db, { bookId: BOOK_ID_2, syncStatus: syncStatus.enum.UNSYNCED })
+
+		let callCount = 0
+		const api = {
+			execute: vi.fn().mockImplementation(() => {
+				callCount++
+				if (callCount === 1) return Promise.reject(new Error('network error'))
+				return Promise.resolve({ updateMediaProgress: { __typename: 'MediaProgress' } })
+			}),
+		} as unknown as Api
+
+		const results = await executePushProgressSync({ [SERVER_ID]: api })
+
+		expect(results[SERVER_ID]!.failureCount).toBe(1)
+		expect(results[SERVER_ID]!.syncedCount).toBe(1)
+	})
+})
+
+describe('elapsedSeconds delta', () => {
+	it('updates lastSyncedElapsedSeconds to current elapsedSeconds after a successful push', async () => {
+		const db = dbProxy.current
+		const executePushProgressSync = await loadPushProgressFn()
+
+		await seedBook(db)
+		await seedProgress(db, {
+			syncStatus: syncStatus.enum.UNSYNCED,
+			elapsedSeconds: 500,
+			lastSyncedElapsedSeconds: 200,
+		})
+
+		const api = makeMockApi()
+		await executePushProgressSync({ [SERVER_ID]: api })
+
+		const after = await db
+			.select()
+			.from(readProgress)
+			.where(eq(readProgress.bookId, BOOK_ID))
+			.then((r) => r[0])
+		expect(after!.lastSyncedElapsedSeconds).toBe(500)
+	})
+
+	it('sends a positive elapsedSecondsDelta (current minus last synced)', async () => {
+		const db = dbProxy.current
+		const executePushProgressSync = await loadPushProgressFn()
+
+		await seedBook(db)
+		await seedProgress(db, {
+			syncStatus: syncStatus.enum.UNSYNCED,
+			elapsedSeconds: 500,
+			lastSyncedElapsedSeconds: 200,
+		})
+
+		const api = makeMockApi()
+		await executePushProgressSync({ [SERVER_ID]: api })
+
+		const payload = (api.execute as ReturnType<typeof vi.fn>).mock.calls[0]![1] as {
+			input: { paged: { elapsedSecondsDelta?: number } }
+		}
+		expect(payload.input.paged.elapsedSecondsDelta).toBe(300)
+	})
+
+	it('omits elapsedSecondsDelta when elapsed has not increased', async () => {
+		const db = dbProxy.current
+		const executePushProgressSync = await loadPushProgressFn()
+
+		await seedBook(db)
+		await seedProgress(db, {
+			syncStatus: syncStatus.enum.UNSYNCED,
+			elapsedSeconds: 200,
+			lastSyncedElapsedSeconds: 200,
+		})
+
+		const api = makeMockApi()
+		await executePushProgressSync({ [SERVER_ID]: api })
+
+		const payload = (api.execute as ReturnType<typeof vi.fn>).mock.calls[0]![1] as {
+			input: { paged: { elapsedSecondsDelta?: number } }
+		}
+		expect(payload.input.paged.elapsedSecondsDelta).toBeUndefined()
+	})
+})

--- a/apps/expo/backgroundTasks/pullServerProgress.ts
+++ b/apps/expo/backgroundTasks/pullServerProgress.ts
@@ -4,6 +4,7 @@ import { Api } from '@stump/sdk'
 import { eq, inArray } from 'drizzle-orm'
 
 import { db, downloadedFiles, epubProgress, readProgress, syncStatus } from '~/db'
+import { parseGraphQLDateTime } from '~/lib/format'
 
 const query = graphql(`
 	query PullServerReadProgression($filter: MediaFilterInput!) {
@@ -57,7 +58,6 @@ export const executeSingleServerPullSync = async (
 		.select({ id: downloadedFiles.id })
 		.from(downloadedFiles)
 		.where(eq(downloadedFiles.serverId, serverId))
-		.all()
 
 	if (downloadedBooks.length === 0) {
 		return { failedBookIds: [] }
@@ -84,7 +84,6 @@ export const executeSingleServerPullSync = async (
 				serverMedia.map((m) => m.id),
 			),
 		)
-		.all()
 
 	const localProgressMap = new Map(localRecords.map((r) => [r.bookId, r]))
 	const failedBookIds: string[] = []
@@ -98,11 +97,11 @@ export const executeSingleServerPullSync = async (
 			const dateB = b.completedAt ? new Date(b.completedAt).getTime() : 0
 			return dateB - dateA // Descending order
 		})
-		const serverCompletedAt = sortedReadHistory.at(0)?.completedAt
+		const serverCompletedAt = parseGraphQLDateTime(sortedReadHistory.at(0)?.completedAt)
 
 		if (serverCompletedAt && serverCompletedAt > localUpdatedAt) {
 			try {
-				await db.delete(readProgress).where(eq(readProgress.bookId, media.id)).run()
+				await db.delete(readProgress).where(eq(readProgress.bookId, media.id))
 			} catch (error) {
 				// Note: A failure to delete local progress is not a failure to pull progress,
 				// so we log it but don't add to failedBookIds
@@ -121,6 +120,9 @@ export const executeSingleServerPullSync = async (
 
 		const serverUpdatedAt = progress.updatedAt ? new Date(progress.updatedAt) : new Date(0)
 
+		// local has unsynced writes = skip (push step will handle the conflict)
+		if (localProgress && localProgress.syncStatus !== syncStatus.enum.SYNCED) continue
+
 		// Local already ahead = skip (need to push)
 		if (localUpdatedAt >= serverUpdatedAt) continue
 
@@ -135,6 +137,7 @@ export const executeSingleServerPullSync = async (
 				serverId,
 				page: progress.page,
 				elapsedSeconds: progress.elapsedSeconds,
+				lastSyncedElapsedSeconds: progress.elapsedSeconds,
 				percentage,
 				epubProgress: isEpub
 					? epubProgress.safeParse({
@@ -147,14 +150,10 @@ export const executeSingleServerPullSync = async (
 				lastModified: serverUpdatedAt,
 			}
 
-			await db
-				.insert(readProgress)
-				.values(values)
-				.onConflictDoUpdate({
-					target: readProgress.bookId,
-					set: values,
-				})
-				.run()
+			await db.insert(readProgress).values(values).onConflictDoUpdate({
+				target: readProgress.bookId,
+				set: values,
+			})
 		} catch (error) {
 			// Fail to pull means we can't reliably push later, so mark as failed
 			console.error('Failed to pull server progress for book', {

--- a/apps/expo/backgroundTasks/pullServerProgress.ts
+++ b/apps/expo/backgroundTasks/pullServerProgress.ts
@@ -114,16 +114,18 @@ export const executeSingleServerPullSync = async (
 			continue
 		}
 
-		// No progress = skip (nothing to pull)
+		// no progress = skip (nothing to pull)
 		const progress = media.readProgress
 		if (!progress) continue
 
 		const serverUpdatedAt = progress.updatedAt ? new Date(progress.updatedAt) : new Date(0)
 
-		// local has unsynced writes = skip (push step will handle the conflict)
-		if (localProgress && localProgress.syncStatus !== syncStatus.enum.SYNCED) continue
+		if (localProgress && localProgress.syncStatus !== syncStatus.enum.SYNCED) {
+			// naive-ish last write wins
+			if (localUpdatedAt >= serverUpdatedAt) continue
+		}
 
-		// Local already ahead = skip (need to push)
+		// local already ahead or equal = skip (push handles it)
 		if (localUpdatedAt >= serverUpdatedAt) continue
 
 		try {

--- a/apps/expo/db/downloads.ts
+++ b/apps/expo/db/downloads.ts
@@ -145,6 +145,7 @@ export class DownloadRepository {
 					page: relations.existingProgression.page ?? undefined,
 					percentage: relations.existingProgression.percentageCompleted ?? undefined,
 					elapsedSeconds: relations.existingProgression.elapsedSeconds ?? undefined,
+					lastSyncedElapsedSeconds: relations.existingProgression.elapsedSeconds ?? undefined,
 					epubProgress: relations.existingProgression.locator
 						? epubProgress.safeParse(relations.existingProgression.locator).data
 						: undefined,

--- a/apps/expo/lib/hooks/sync/useProgressSync.ts
+++ b/apps/expo/lib/hooks/sync/useProgressSync.ts
@@ -3,7 +3,7 @@ import { MediaProgressInput } from '@stump/graphql'
 import { and, eq } from 'drizzle-orm'
 import { useLiveQuery } from 'drizzle-orm/expo-sqlite'
 import { useFocusEffect } from 'expo-router'
-import { useCallback, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { toast } from 'sonner-native'
 import { match, P } from 'ts-pattern'
 
@@ -135,22 +135,33 @@ export function useSyncOnlineToOfflineProgress({
 	// up to date
 	const isOfflineSyncable = Boolean(record)
 
+	const accumulatedElapsedRef = useRef<number>(record?.elapsedSeconds ?? 0)
+	useEffect(() => {
+		const dbValue = record?.elapsedSeconds ?? 0
+		// the logic here is that we want to make sure if we've made forward progress offline
+		// we don't want to overwrite that with an older value from the server
+		if (dbValue > accumulatedElapsedRef.current) {
+			accumulatedElapsedRef.current = dbValue
+		}
+	}, [record?.elapsedSeconds])
+
 	const syncProgress = useCallback(
 		async (onlineProgress: MediaProgressInput) => {
 			if (!isOfflineSyncable) return
 
-			const accumulatedElapsed =
-				(record?.elapsedSeconds ?? 0) +
-				match(onlineProgress)
-					.with(
-						{ epub: P.not(P.nullish) },
-						({ epub: { elapsedSecondsDelta } }) => elapsedSecondsDelta ?? 0,
-					)
-					.with(
-						{ paged: P.not(P.nullish) },
-						({ paged: { elapsedSecondsDelta } }) => elapsedSecondsDelta ?? 0,
-					)
-					.otherwise(() => 0)
+			const delta = match(onlineProgress)
+				.with(
+					{ epub: P.not(P.nullish) },
+					({ epub: { elapsedSecondsDelta } }) => elapsedSecondsDelta ?? 0,
+				)
+				.with(
+					{ paged: P.not(P.nullish) },
+					({ paged: { elapsedSecondsDelta } }) => elapsedSecondsDelta ?? 0,
+				)
+				.otherwise(() => 0)
+
+			const accumulatedElapsed = accumulatedElapsedRef.current + delta
+			accumulatedElapsedRef.current = accumulatedElapsed
 
 			const values = match(onlineProgress)
 				.with(
@@ -200,7 +211,6 @@ export function useSyncOnlineToOfflineProgress({
 						target: readProgress.bookId,
 						set: { ...values, lastModified: new Date() },
 					})
-					.run()
 			} catch (error) {
 				console.error('Failed to sync online progress to offline DB', {
 					onlineProgress,
@@ -212,7 +222,7 @@ export function useSyncOnlineToOfflineProgress({
 				})
 			}
 		},
-		[bookId, serverId, isOfflineSyncable, record],
+		[bookId, serverId, isOfflineSyncable],
 	)
 
 	return { syncProgress }

--- a/apps/expo/lib/hooks/sync/useProgressSync.ts
+++ b/apps/expo/lib/hooks/sync/useProgressSync.ts
@@ -13,6 +13,7 @@ import { useActiveServer } from '~/components/activeServer'
 import { db, epubProgress, readProgress, syncStatus } from '~/db'
 import { isLocalLibrary } from '~/lib/localLibrary'
 
+import { useTranslate } from '../useTranslate'
 import { useServerInstances } from './utils'
 
 export function useProgressSync() {
@@ -77,6 +78,7 @@ export function useAutoSyncActiveServer({ enabled = true }: Params = {}) {
 	const {
 		activeServer: { id: serverId },
 	} = useActiveServer()
+	const { t } = useTranslate()
 
 	const { syncProgress } = useProgressSync()
 
@@ -92,12 +94,11 @@ export function useAutoSyncActiveServer({ enabled = true }: Params = {}) {
 				try {
 					await syncProgress([serverId])
 				} catch (error) {
-					console.error('Failed to sync progress', error)
 					Sentry.captureException(error, {
 						extra: { serverId },
 					})
-					toast.error('Failed to sync offline progress', {
-						description: error instanceof Error ? error.message : 'Unknown error',
+					toast.error(t('progressSync.syncFailed'), {
+						description: error instanceof Error ? error.message : t('errors.unknown'),
 					})
 				}
 			}
@@ -108,7 +109,7 @@ export function useAutoSyncActiveServer({ enabled = true }: Params = {}) {
 			}
 			// eslint-disable-next-line react-compiler/react-compiler
 			// eslint-disable-next-line react-hooks/exhaustive-deps
-		}, [enabled, serverId]),
+		}, [enabled, serverId, t]),
 	)
 }
 

--- a/apps/expo/lib/hooks/sync/utils.ts
+++ b/apps/expo/lib/hooks/sync/utils.ts
@@ -1,4 +1,5 @@
 import { useCallback } from 'react'
+import { toast } from 'sonner-native'
 
 import { isLocalLibrary } from '~/lib/localLibrary'
 import { useSavedServers } from '~/stores'
@@ -6,9 +7,11 @@ import { useCacheStore } from '~/stores/cache'
 import { SavedServerWithConfig } from '~/stores/savedServer'
 
 import { getInstancesForServers } from '../../sdk/auth'
+import { useTranslate } from '../useTranslate'
 
 export function useServerInstances() {
 	const { savedServers, getServerConfig, saveServerToken, getServerToken } = useSavedServers()
+	const { t } = useTranslate()
 
 	const cachedInstances = useCacheStore((state) => state.sdks)
 	const onCacheInstance = useCacheStore((state) => state.addSDK)
@@ -26,40 +29,44 @@ export function useServerInstances() {
 		[savedServers, getServerConfig],
 	)
 
-	const getInstances = useCallback(
-		async (forServers?: string[]) => {
-			const actualServers = forServers?.filter((id) => !isLocalLibrary(id))
+	const getInstances = async (forServers?: string[]) => {
+		const actualServers = forServers?.filter((id) => !isLocalLibrary(id))
 
-			const servers = await Promise.all(
-				savedServers
-					.filter(
-						(server) =>
-							!isLocalLibrary(server.id) &&
-							(!actualServers?.length ||
-								server.id === actualServers.find((id) => id === server.id)),
-					)
-					.map(async (server) => {
-						const config = await getServerConfig(server.id)
-						return { ...server, config } satisfies SavedServerWithConfig
-					}),
-			)
+		const servers = await Promise.all(
+			savedServers
+				.filter(
+					(server) =>
+						!isLocalLibrary(server.id) &&
+						(!actualServers?.length || server.id === actualServers.find((id) => id === server.id)),
+				)
+				.map(async (server) => {
+					const config = await getServerConfig(server.id)
+					return { ...server, config } satisfies SavedServerWithConfig
+				}),
+		)
 
-			return getInstancesForServers(servers, {
-				getServerToken,
-				saveToken: saveServerToken,
-				getCachedInstance,
-				onCacheInstance,
-			})
-		},
-		[
-			savedServers,
+		const instances = await getInstancesForServers(servers, {
 			getServerToken,
-			saveServerToken,
-			getServerConfig,
-			onCacheInstance,
+			saveToken: saveServerToken,
 			getCachedInstance,
-		],
-	)
+			onCacheInstance,
+		})
+
+		// skipped = stump servers which cannot auto-auth
+		const skipped = servers.filter((s) => s.kind === 'stump' && !instances[s.id])
+		if (skipped.length > 0) {
+			toast.warning(
+				t(`progressSync.${skipped.length === 1 ? 'skippedOneServer' : 'skippedMultipleServers'}`, {
+					skippedCount: skipped.length,
+				}),
+				{
+					description: t('progressSync.explanation'),
+				},
+			)
+		}
+
+		return instances
+	}
 
 	return { getInstances, getFullServer, savedServers }
 }

--- a/apps/expo/lib/sdk/auth.ts
+++ b/apps/expo/lib/sdk/auth.ts
@@ -217,12 +217,7 @@ export const getInstancesForServers = async (
 ): Promise<Record<string, Api>> => {
 	const [compatibleServers, incompatibleServers] = partition(
 		servers,
-		(server) =>
-			server.kind === 'stump' &&
-			match(server.config?.auth)
-				.with({ basic: P.shape({ username: P.string, password: P.string }) }, () => true)
-				.with({ bearer: P.string }, () => true)
-				.otherwise(() => false),
+		(server) => server.kind === 'stump',
 	)
 
 	if (compatibleServers.length === 0) {

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -128,7 +128,9 @@
 	},
 	"devDependencies": {
 		"@babel/core": "^7.26.0",
+		"@types/better-sqlite3": "^7.6.13",
 		"@types/react": "^19.0.10",
+		"better-sqlite3": "^12.10.0",
 		"drizzle-kit": "^0.31.5",
 		"tsx": "^4.20.5",
 		"typescript": "~5.9.2",

--- a/docs/content/docs/apps/mobile/reading/offline.mdx
+++ b/docs/content/docs/apps/mobile/reading/offline.mdx
@@ -86,7 +86,9 @@ You may also trigger a manual sync by selecting the `Attempt Sync` option from t
 
 As mentioned above, progression sync is only supported for Stump servers. Additionally, there are some limitations primarily based on the authentication configuration:
 
-`Basic` and `Token` authentication are fully supported for progression sync. The `Login` authentication method is not supported, since it would be too annoying to implement a background operation that attempts to open a login sheet every time a sync is attempted.
+`Basic` and `Token` authentication are fully supported for auto-sync of progression. The `Login` authentication method is partially supported: if there are non-expired auth tokens available in the cache then sync will work as expected, and in the absence of valid and non-expired auth tokens, sync will be skipped for that server.
+
+The solution would be to prompt for login credentials when attempting to sync with a server of this auth configuration, however that is not currently implemented.
 
 ### Visual Indicators
 

--- a/packages/i18n/src/locales/en-US.json
+++ b/packages/i18n/src/locales/en-US.json
@@ -2855,6 +2855,9 @@
 			"value": "Value",
 			"version": "Version"
 		},
+		"errors": {
+			"unknown": "Unknown error"
+		},
 		"formatSeriesPosition": {
 			"none": {
 				"positionWithTotal": "{{position}} of {{total}} in {{seriesName}}",
@@ -2947,6 +2950,14 @@
 				"retryAll": "Retry All",
 				"dismissAll": "Dismiss All"
 			}
+		},
+		"progressSync": {
+			"skippedSync": {
+				"skippedOneServer": "Sync skipped for {{skippedCount}} server",
+				"skippedMultipleServers": "Sync skipped for {{skippedCount}} servers",
+				"explanation": "Some servers use authentication methods that cannot be automatically refreshed"
+			},
+			"syncFailed": "Failed to sync offline progress"
 		},
 		"settings": {
 			"preferences": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8140,6 +8140,13 @@
   dependencies:
     "@babel/types" "^7.28.2"
 
+"@types/better-sqlite3@^7.6.13":
+  version "7.6.13"
+  resolved "https://registry.yarnpkg.com/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz#a72387f00d2f53cab699e63f2e2c05453cf953f0"
+  integrity sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/body-parser@*":
   version "1.19.6"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.6.tgz#1859bebb8fd7dac9918a45d54c1971ab8b5af474"
@@ -8547,7 +8554,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16", "@types/react@^19.0.0", "@types/react@^19.0.10", "@types/react@^19.2.14", "@types/react@~19.2.10":
+"@types/react@*", "@types/react@>=16", "@types/react@^19.0.0", "@types/react@^19.0.10", "@types/react@^19.2.14":
   version "19.2.15"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-19.2.15.tgz#9e2c6a4251a290f5c525c3143caa872fa6e01e0d"
   integrity sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==
@@ -9216,7 +9223,12 @@
   dependencies:
     tslib "^2.6.3"
 
-"@xmldom/xmldom@>=0.8.13 <0.9.0", "@xmldom/xmldom@^0.7.5", "@xmldom/xmldom@^0.8.8":
+"@xmldom/xmldom@^0.7.5":
+  version "0.7.13"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.13.tgz#ff34942667a4e19a9f4a0996a76814daac364cf3"
+  integrity sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==
+
+"@xmldom/xmldom@^0.8.8":
   version "0.8.13"
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.13.tgz#00d1dd940b218dff2e49309d410d8bb212159225"
   integrity sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==
@@ -10093,6 +10105,14 @@ better-opn@^3.0.2, better-opn@~3.0.2:
   dependencies:
     open "^8.0.4"
 
+better-sqlite3@^12.10.0:
+  version "12.10.0"
+  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-12.10.0.tgz#bde622d14a18008583a53bc53501ae98f1a12221"
+  integrity sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==
+  dependencies:
+    bindings "^1.5.0"
+    prebuild-install "^7.1.1"
+
 big-integer@1.6.x, big-integer@^1.6.44:
   version "1.6.52"
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.52.tgz#60a887f3047614a8e1bffe5d7173490a97dc8c85"
@@ -10118,6 +10138,13 @@ binary-extensions@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
   integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
+
+bindings@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
 
 bl@^4.0.3, bl@^4.1.0:
   version "4.1.0"
@@ -11507,6 +11534,13 @@ decode-uri-component@^0.2.2:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
   integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
 
+decompress-response@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
+  integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
+  dependencies:
+    mimic-response "^3.1.0"
+
 dedent@1.5.3:
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-1.5.3.tgz#99aee19eb9bae55a67327717b6e848d0bf777e5a"
@@ -11550,6 +11584,11 @@ deep-equal@^2.0.5, deep-equal@^2.2.3:
     which-boxed-primitive "^1.0.2"
     which-collection "^1.0.1"
     which-typed-array "^1.1.13"
+
+deep-extend@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
+  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@^0.1.3:
   version "0.1.4"
@@ -11668,7 +11707,7 @@ detect-libc@^1.0.3:
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==
 
-detect-libc@^2.0.3:
+detect-libc@^2.0.0, detect-libc@^2.0.3:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
   integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
@@ -12948,6 +12987,11 @@ exit-x@^0.2.2:
   resolved "https://registry.yarnpkg.com/exit-x/-/exit-x-0.2.2.tgz#1f9052de3b8d99a696b10dad5bced9bdd5c3aa64"
   integrity sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==
 
+expand-template@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c"
+  integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
+
 expect-type@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.3.0.tgz#0d58ed361877a31bbc4dd6cf71bbfef7faf6bd68"
@@ -13508,6 +13552,11 @@ file-system-cache@2.3.0:
   dependencies:
     fs-extra "11.1.1"
     ramda "0.29.0"
+
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
 filelist@^1.0.4:
   version "1.0.4"
@@ -14122,6 +14171,11 @@ gitconfiglocal@^1.0.0:
   integrity sha512-spLUXeTAVHxDtKsJc8FkFVgFtMdEN9qPGpL23VfSHx4fP4+Ds097IXLvymbnDH8FnmxX5Nr9bPw3A+AQ6mWEaQ==
   dependencies:
     ini "^1.3.2"
+
+github-from-package@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
+  integrity sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==
 
 github-slugger@^1.0.0:
   version "1.5.0"
@@ -14988,7 +15042,7 @@ inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, i
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-ini@^1.3.2, ini@^1.3.8:
+ini@^1.3.2, ini@^1.3.8, ini@~1.3.0:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
@@ -16175,10 +16229,10 @@ jose@^5.0.0:
   resolved "https://registry.yarnpkg.com/jose/-/jose-5.10.0.tgz#c37346a099d6467c401351a9a0c2161e0f52c4be"
   integrity sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==
 
-js-cookie@>=3.0.7, js-cookie@^2.2.1:
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.7.tgz#0a53abfc459c8e89c85d7a38eb6cb68714965b8c"
-  integrity sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==
+js-cookie@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
+  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -18218,6 +18272,11 @@ mimic-function@^5.0.0:
   resolved "https://registry.yarnpkg.com/mimic-function/-/mimic-function-5.0.1.tgz#acbe2b3349f99b9deaca7fb70e48b83e94e67076"
   integrity sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==
 
+mimic-response@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
+  integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
+
 min-indent@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
@@ -18279,7 +18338,7 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
+minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
@@ -18371,7 +18430,7 @@ minizlib@^3.0.1, minizlib@^3.1.0:
   dependencies:
     minipass "^7.1.2"
 
-mkdirp-classic@^0.5.2:
+mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
   integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
@@ -18476,10 +18535,15 @@ nanoid@^3.3.11, nanoid@^3.3.8:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
   integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
 
-nanoid@^3.3.12:
+nanoid@^3.3.12, nanoid@^3.3.7:
   version "3.3.12"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.12.tgz#ab3d912e217a6d0a514f00a72a16543a28982c05"
   integrity sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==
+
+napi-build-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/napi-build-utils/-/napi-build-utils-2.0.0.tgz#13c22c0187fcfccce1461844136372a47ddc027e"
+  integrity sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==
 
 napi-postinstall@^0.3.0:
   version "0.3.4"
@@ -18562,6 +18626,13 @@ no-case@^3.0.4:
   dependencies:
     lower-case "^2.0.2"
     tslib "^2.0.3"
+
+node-abi@^3.3.0:
+  version "3.92.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.92.0.tgz#18e2214677499b8dda81ffcd095afc763d5a9802"
+  integrity sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==
+  dependencies:
+    semver "^7.3.5"
 
 node-abort-controller@^3.0.1:
   version "3.1.1"
@@ -19666,6 +19737,11 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==
 
+picocolors@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-0.2.1.tgz#570670f793646851d1ba135996962abad587859f"
+  integrity sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==
+
 picocolors@^1.0.0, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
@@ -19915,7 +19991,15 @@ postcss-value-parser@^4.0.0, postcss-value-parser@^4.1.0, postcss-value-parser@^
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^7.0.14, postcss@^7.0.32, postcss@^7.0.35, postcss@^7.0.5, postcss@^7.0.6, postcss@^8.4.23, postcss@^8.4.27, postcss@^8.4.33, postcss@^8.5.10, postcss@^8.5.14, postcss@^8.5.6, postcss@~8.4.32:
+postcss@^7.0.14, postcss@^7.0.32, postcss@^7.0.35, postcss@^7.0.5, postcss@^7.0.6:
+  version "7.0.39"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.39.tgz#9624375d965630e2e1f2c02a935c82a59cb48309"
+  integrity sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==
+  dependencies:
+    picocolors "^0.2.1"
+    source-map "^0.6.1"
+
+postcss@^8.4.23, postcss@^8.4.27, postcss@^8.4.33, postcss@^8.5.14, postcss@^8.5.6:
   version "8.5.15"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.15.tgz#d1eaf677a324e9ec02196da2d3fecf4a0b9a735c"
   integrity sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==
@@ -19923,6 +20007,33 @@ postcss@^7.0.14, postcss@^7.0.32, postcss@^7.0.35, postcss@^7.0.5, postcss@^7.0.
     nanoid "^3.3.12"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
+
+postcss@~8.4.32:
+  version "8.4.49"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.49.tgz#4ea479048ab059ab3ae61d082190fabfd994fe19"
+  integrity sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==
+  dependencies:
+    nanoid "^3.3.7"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
+
+prebuild-install@^7.1.1:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.1.3.tgz#d630abad2b147443f20a212917beae68b8092eec"
+  integrity sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==
+  dependencies:
+    detect-libc "^2.0.0"
+    expand-template "^2.0.3"
+    github-from-package "0.0.0"
+    minimist "^1.2.3"
+    mkdirp-classic "^0.5.3"
+    napi-build-utils "^2.0.0"
+    node-abi "^3.3.0"
+    pump "^3.0.0"
+    rc "^1.2.7"
+    simple-get "^4.0.0"
+    tar-fs "^2.0.0"
+    tunnel-agent "^0.6.0"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -20331,6 +20442,16 @@ raw-body@~2.5.3:
     iconv-lite "~0.4.24"
     unpipe "~1.0.0"
 
+rc@^1.2.7:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
+  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
+  dependencies:
+    deep-extend "^0.6.0"
+    ini "~1.3.0"
+    minimist "^1.2.0"
+    strip-json-comments "~2.0.1"
+
 react-colorful@^5.1.2:
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/react-colorful/-/react-colorful-5.6.1.tgz#7dc2aed2d7c72fac89694e834d179e32f3da563b"
@@ -20384,10 +20505,17 @@ react-docgen@^7.0.0:
     resolve "^1.22.1"
     strip-indent "^4.0.0"
 
-react-dom@19.2.0, react-dom@=19.2.0, react-dom@^19.0.0, react-dom@^19.2.6:
+react-dom@19.2.0, react-dom@^19.0.0:
   version "19.2.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.0.tgz#00ed1e959c365e9a9d48f8918377465466ec3af8"
   integrity sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==
+  dependencies:
+    scheduler "^0.27.0"
+
+react-dom@^19.2.6:
+  version "19.2.7"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.7.tgz#0450dc9ae9ddbff76ef196401cd8b8c7fb466ccc"
+  integrity sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==
   dependencies:
     scheduler "^0.27.0"
 
@@ -20887,10 +21015,15 @@ react-window@^1.8.11:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
 
-react@19.2.0, react@=19.2.0, react@^19.0.0, react@^19.2.0, react@^19.2.6:
+react@19.2.0, react@^19.0.0, react@^19.2.0:
   version "19.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-19.2.0.tgz#d33dd1721698f4376ae57a54098cb47fc75d93a5"
   integrity sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==
+
+react@^19.2.6:
+  version "19.2.7"
+  resolved "https://registry.yarnpkg.com/react/-/react-19.2.7.tgz#1f47a1bfc06f8ec885752c6f4af14369a9f8260b"
+  integrity sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==
 
 read-cache@^1.0.0:
   version "1.0.0"
@@ -21578,7 +21711,7 @@ safe-array-concat@^1.1.3:
     has-symbols "^1.1.0"
     isarray "^2.0.5"
 
-safe-buffer@5.2.1, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
+safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -21961,6 +22094,20 @@ sigstore@^4.0.0:
     "@sigstore/sign" "^4.0.0"
     "@sigstore/tuf" "^4.0.0"
     "@sigstore/verify" "^3.0.0"
+
+simple-concat@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
+  integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
+
+simple-get@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-4.0.1.tgz#4a39db549287c979d352112fa03fd99fd6bc3543"
+  integrity sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==
+  dependencies:
+    decompress-response "^6.0.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
 
 simple-plist@^1.1.0:
   version "1.3.1"
@@ -22397,7 +22544,16 @@ string-trim-spaces-only@^5.1.0:
   resolved "https://registry.yarnpkg.com/string-trim-spaces-only/-/string-trim-spaces-only-5.1.0.tgz#d68e328f4f11cbb96642334ae1582bf3c02582f5"
   integrity sha512-632znq4SGCNM7Vw7QITbx05oej+Xly2s7OtDxN9jvNbOoWcQuA5fq14CAS5TlpiiB04LDETzJj9fk851PnWLgg==
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -22514,7 +22670,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -22534,6 +22690,13 @@ strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.2"
@@ -22579,7 +22742,7 @@ strip-indent@^4.0.0:
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-4.1.1.tgz#aba13de189d4ad9a17f6050e76554ac27585c7af"
   integrity sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==
 
-strip-json-comments@^2.0.0:
+strip-json-comments@^2.0.0, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
@@ -22812,7 +22975,7 @@ tapable@^2.3.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.3.3.tgz#5da7c9992c46038221267985ab28421a8879f160"
   integrity sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==
 
-tar-fs@^2.1.1:
+tar-fs@^2.0.0, tar-fs@^2.1.1:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.4.tgz#800824dbf4ef06ded9afea4acafe71c67c76b930"
   integrity sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==
@@ -23269,6 +23432,13 @@ tuf-js@^4.0.0:
     "@tufjs/models" "4.0.0"
     debug "^4.4.1"
     make-fetch-happen "^15.0.0"
+
+tunnel-agent@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
+  integrity sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==
+  dependencies:
+    safe-buffer "^5.0.1"
 
 tw-animate-css@^1.4.0:
   version "1.4.0"
@@ -23856,10 +24026,15 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@>=11.1.1, uuid@^7.0.3, uuid@^9.0.0:
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
-  integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
+uuid@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
+  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
+
+uuid@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
@@ -24561,7 +24736,7 @@ workbox-window@7.4.0, workbox-window@^7.4.0:
     "@types/trusted-types" "^2.0.2"
     workbox-core "7.4.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -24574,6 +24749,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
This PR addresses a few items all related to offline-to-online progress sync:

- Fix lints related to drizzle usage (e.g., no need to run `all` since we want async)
- Add a few translation strings for sync status reporting
   - Actually spin up a message if any are skipped
- Allow `Login` auth method to sync provided a token exists (previously we just skipped it)
- Alter the sync behavior to follow a very basic last write wins, via the updated stamp (i.e., local vs remote -> newest timestamp wins)
- Fix elapsed secs delta staleness issues during sync
- Fix missing elapsed seconds when downloading in progress books
- Setup basic mocking for drizzle so I can test things better to catch these bugs in the future
   - Followed a bunch of tangled forums for this bit. There are baked in `.mock()` for some drivers but not all, and since tests run in node it made sense to just pull in `better-sqlite3` as a dev dependency and inject an in-memory db during tests instead of some kind of awfully complicated mock 