### PR TITLE
:bug: Fix finished session dedupe logic

### DIFF
--- a/apps/server/src/routers/koreader/sync.rs
+++ b/apps/server/src/routers/koreader/sync.rs
@@ -304,14 +304,8 @@ async fn put_progress(
 		},
 	}
 
-	let session = upsert_reading_session(
-		&tx,
-		&user,
-		book.id.as_ref(),
-		progression,
-		ctx.config.book_completion_dedup_timeout_secs,
-	)
-	.await?;
+	let session =
+		upsert_reading_session(&tx, &user, book.id.as_ref(), progression).await?;
 
 	if session.koreader_progress.as_deref() != Some(progress.as_str()) {
 		let mut active: reading_session::ActiveModel = session.into();

--- a/apps/server/src/routers/opds/v1_2.rs
+++ b/apps/server/src/routers/opds/v1_2.rs
@@ -874,14 +874,8 @@ async fn get_book_page(
 			..Default::default()
 		};
 
-		let reading_session = upsert_reading_session(
-			ctx.conn.as_ref(),
-			&user,
-			&id,
-			progression,
-			ctx.config.book_completion_dedup_timeout_secs,
-		)
-		.await?;
+		let reading_session =
+			upsert_reading_session(ctx.conn.as_ref(), &user, &id, progression).await?;
 		tracing::trace!(?reading_session, "Upserted active reading session");
 	}
 

--- a/apps/server/src/routers/opds/v2_0.rs
+++ b/apps/server/src/routers/opds/v2_0.rs
@@ -1392,14 +1392,7 @@ async fn update_book_progression(
 		device_id,
 	};
 
-	upsert_reading_session(
-		conn,
-		&user,
-		&id,
-		progression,
-		ctx.config.book_completion_dedup_timeout_secs,
-	)
-	.await?;
+	upsert_reading_session(conn, &user, &id, progression).await?;
 
 	Ok(axum::http::StatusCode::NO_CONTENT)
 }

--- a/apps/server/tests/reading_progress/progression_tracking.rs
+++ b/apps/server/tests/reading_progress/progression_tracking.rs
@@ -305,10 +305,10 @@ async fn test_new_readthrough_after_finished_session() {
 	assert_eq!(new_session.readthrough_number, 2); // should have incremented
 }
 
-/// if a session completes within the dedupe window, after a previous completion, it should be
-/// deduped
+/// if a progression event occurs after completion within grace, the same session should reopen
+/// instead of creating a new readthrough
 #[tokio::test]
-async fn test_completion_dedupe_suppresses_immediate_second_readthrough_finish() {
+async fn test_reopen_recent_finished_session_within_grace() {
 	let (app, book) = setup().await;
 
 	let conn = app.conn();
@@ -337,12 +337,12 @@ async fn test_completion_dedupe_suppresses_immediate_second_readthrough_finish()
 	)
 	.await;
 
-	// start second readthrough right away
+	// regress progress
 	update_progress(
 		&app,
 		&book.id,
 		MediaProgressInput::Paged(PagedProgressInput {
-			page: 1,
+			page: 99,
 			elapsed_seconds_delta: Some(120),
 			..Default::default()
 		}),
@@ -356,10 +356,17 @@ async fn test_completion_dedupe_suppresses_immediate_second_readthrough_finish()
 		.await
 		.expect("could not query reading sessions")
 		.expect("no session found");
-	assert_eq!(latest_before_finish.readthrough_number, 2);
+	assert_eq!(latest_before_finish.readthrough_number, 1);
 	assert_eq!(latest_before_finish.status, ReadingStatus::Reading);
 
-	// complete second readthrough
+	let sessions_after_reopen = reading_session::Entity::find()
+		.filter(reading_session::Column::MediaId.eq(book.id.clone()))
+		.all(conn)
+		.await
+		.expect("could not query reading sessions");
+	assert_eq!(sessions_after_reopen.len(), 1);
+
+	// finish again
 	update_progress(
 		&app,
 		&book.id,
@@ -377,11 +384,11 @@ async fn test_completion_dedupe_suppresses_immediate_second_readthrough_finish()
 		.all(conn)
 		.await
 		.expect("could not query reading sessions");
-	assert_eq!(all_sessions.len(), 2);
+	assert_eq!(all_sessions.len(), 1);
 
 	let latest_after_finish = all_sessions.last().expect("no session found");
-	assert_eq!(latest_after_finish.readthrough_number, 2);
-	assert_eq!(latest_after_finish.status, ReadingStatus::Reading);
+	assert_eq!(latest_after_finish.readthrough_number, 1);
+	assert_eq!(latest_after_finish.status, ReadingStatus::Finished);
 
 	let finished_count = all_sessions
 		.iter()

--- a/apps/server/tests/reading_progress/progression_tracking.rs
+++ b/apps/server/tests/reading_progress/progression_tracking.rs
@@ -305,6 +305,91 @@ async fn test_new_readthrough_after_finished_session() {
 	assert_eq!(new_session.readthrough_number, 2); // should have incremented
 }
 
+/// if a session completes within the dedupe window, after a previous completion, it should be
+/// deduped
+#[tokio::test]
+async fn test_completion_dedupe_suppresses_immediate_second_readthrough_finish() {
+	let (app, book) = setup().await;
+
+	let conn = app.conn();
+
+	// first readthrough start
+	update_progress(
+		&app,
+		&book.id,
+		MediaProgressInput::Paged(PagedProgressInput {
+			page: 10,
+			elapsed_seconds_delta: Some(300),
+			..Default::default()
+		}),
+	)
+	.await;
+
+	// first readthrough finish
+	update_progress(
+		&app,
+		&book.id,
+		MediaProgressInput::Paged(PagedProgressInput {
+			page: 100,
+			elapsed_seconds_delta: Some(300),
+			..Default::default()
+		}),
+	)
+	.await;
+
+	// start second readthrough right away
+	update_progress(
+		&app,
+		&book.id,
+		MediaProgressInput::Paged(PagedProgressInput {
+			page: 1,
+			elapsed_seconds_delta: Some(120),
+			..Default::default()
+		}),
+	)
+	.await;
+
+	let latest_before_finish = reading_session::Entity::find()
+		.filter(reading_session::Column::MediaId.eq(book.id.clone()))
+		.order_by_desc(reading_session::Column::CreatedAt)
+		.one(conn)
+		.await
+		.expect("could not query reading sessions")
+		.expect("no session found");
+	assert_eq!(latest_before_finish.readthrough_number, 2);
+	assert_eq!(latest_before_finish.status, ReadingStatus::Reading);
+
+	// complete second readthrough
+	update_progress(
+		&app,
+		&book.id,
+		MediaProgressInput::Paged(PagedProgressInput {
+			page: 100,
+			elapsed_seconds_delta: Some(180),
+			..Default::default()
+		}),
+	)
+	.await;
+
+	let all_sessions = reading_session::Entity::find()
+		.filter(reading_session::Column::MediaId.eq(book.id.clone()))
+		.order_by_asc(reading_session::Column::CreatedAt)
+		.all(conn)
+		.await
+		.expect("could not query reading sessions");
+	assert_eq!(all_sessions.len(), 2);
+
+	let latest_after_finish = all_sessions.last().expect("no session found");
+	assert_eq!(latest_after_finish.readthrough_number, 2);
+	assert_eq!(latest_after_finish.status, ReadingStatus::Reading);
+
+	let finished_count = all_sessions
+		.iter()
+		.filter(|s| s.status == ReadingStatus::Finished)
+		.count();
+	assert_eq!(finished_count, 1);
+}
+
 /// if the user finishes an ebook, the session should be marked as such
 #[tokio::test]
 async fn test_detect_finishing_session_for_ebook() {

--- a/apps/server/tests/reading_progress/stats.rs
+++ b/apps/server/tests/reading_progress/stats.rs
@@ -1,5 +1,11 @@
+use models::entity::reading_session;
+use sea_orm::{prelude::*, EntityTrait};
+
 use crate::common::{
-	book::{create_nth_readthrough, update_progress},
+	book::{
+		active_session_for_book, create_nth_readthrough, fudge_session_time,
+		update_progress,
+	},
 	TestApp,
 };
 
@@ -211,4 +217,134 @@ async fn test_library_stats() {
 	assert_eq!(stats["completedBooks"], 1);
 	assert_eq!(stats["inProgressBooks"], 2);
 	assert_eq!(stats["totalReadingTimeSeconds"], 2700); // 1200 from black science, 1500 from invincible
+}
+
+// if a book has multiple sessions within a (finished) readthrough it should count as completed not in-progress
+#[tokio::test]
+async fn test_series_stats_historical_reading_not_counted_as_in_progress() {
+	let app = setup().await;
+	let conn = app.conn();
+
+	// starts the book
+	update_progress(
+		&app,
+		"black_science_1",
+		MediaProgressInput::Paged(PagedProgressInput {
+			page: 10,
+			elapsed_seconds_delta: Some(300),
+			..Default::default()
+		}),
+	)
+	.await;
+
+	let reading_session = active_session_for_book(&app, "black_science_1").await;
+	fudge_session_time(&reading_session, conn).await;
+
+	// finishes the book in diff session
+	update_progress(
+		&app,
+		"black_science_1",
+		MediaProgressInput::Paged(PagedProgressInput {
+			page: 100,
+			elapsed_seconds_delta: Some(300),
+			..Default::default()
+		}),
+	)
+	.await;
+
+	let session_count = reading_session::Entity::find()
+		.filter(reading_session::Column::MediaId.eq("black_science_1"))
+		.count(conn)
+		.await
+		.expect("db error");
+	assert_eq!(session_count, 2);
+
+	let stats = fetch_series_stats(&app, "black_science").await;
+
+	assert_eq!(stats["bookCount"], 5);
+	assert_eq!(stats["completedBooks"], 1);
+	assert_eq!(stats["inProgressBooks"], 0); // the crux of the test
+	assert_eq!(stats["totalReadingTimeSeconds"], 600);
+}
+
+// same as above but at the library level
+#[tokio::test]
+async fn test_library_stats_historical_reading_not_counted_as_in_progress() {
+	let app = setup().await;
+	let conn = app.conn();
+
+	// starts the book
+	update_progress(
+		&app,
+		"black_science_1",
+		MediaProgressInput::Paged(PagedProgressInput {
+			page: 10,
+			elapsed_seconds_delta: Some(300),
+			..Default::default()
+		}),
+	)
+	.await;
+
+	let reading_session = active_session_for_book(&app, "black_science_1").await;
+	fudge_session_time(&reading_session, conn).await;
+
+	// finishes the book in diff session
+	update_progress(
+		&app,
+		"black_science_1",
+		MediaProgressInput::Paged(PagedProgressInput {
+			page: 100,
+			elapsed_seconds_delta: Some(300),
+			..Default::default()
+		}),
+	)
+	.await;
+
+	// starts another book
+	update_progress(
+		&app,
+		"invincible_1",
+		MediaProgressInput::Paged(PagedProgressInput {
+			page: 50,
+			elapsed_seconds_delta: Some(1500),
+			..Default::default()
+		}),
+	)
+	.await;
+
+	let stats = fetch_library_stats(&app, "image").await;
+
+	assert_eq!(stats["bookCount"], 10);
+	assert_eq!(stats["seriesCount"], 2);
+	assert_eq!(stats["completedBooks"], 1);
+	assert_eq!(stats["inProgressBooks"], 1); // the crux of the test
+	assert_eq!(stats["totalReadingTimeSeconds"], 2100);
+}
+
+// a book already finished but actively being read should report in both completed and in-progress
+// states
+#[tokio::test]
+async fn test_series_stats_second_readthrough() {
+	let app = setup().await;
+
+	create_nth_readthrough(&app, "black_science_1", 1).await;
+
+	// start re-reading
+	update_progress(
+		&app,
+		"black_science_1",
+		MediaProgressInput::Paged(PagedProgressInput {
+			page: 10,
+			elapsed_seconds_delta: Some(300),
+			..Default::default()
+		}),
+	)
+	.await;
+
+	let stats = fetch_series_stats(&app, "black_science").await;
+
+	assert_eq!(stats["bookCount"], 5);
+	assert_eq!(stats["completedBooks"], 1); // crux 1 of test
+	assert_eq!(stats["inProgressBooks"], 1); // crux 2 of test
+	assert_eq!(stats["totalReadingTimeSeconds"], 900);
 }

--- a/core/src/config/stump_config.rs
+++ b/core/src/config/stump_config.rs
@@ -57,8 +57,6 @@ pub mod env_keys {
 	pub const OIDC_ALLOW_REGISTRATION_KEY: &str = "STUMP_OIDC_ALLOW_REGISTRATION";
 	pub const OIDC_DISABLE_LOCAL_AUTH_KEY: &str = "STUMP_OIDC_DISABLE_LOCAL_AUTH";
 	pub const OIDC_EXTRA_AUDIENCES_KEY: &str = "STUMP_OIDC_EXTRA_AUDIENCES";
-	pub const BOOK_COMPLETION_DEDUP_TIMEOUT_SECS_KEY: &str =
-		"STUMP_BOOK_COMPLETION_DEDUP_TIMEOUT_SECS";
 	pub const TRUST_PROXY_HEADERS_KEY: &str = "STUMP_TRUST_PROXY_HEADERS";
 }
 use env_keys::*;
@@ -291,11 +289,6 @@ pub struct StumpConfig {
 	#[default_value(None)]
 	pub oidc: Option<OidcConfig>,
 
-	/// The number of seconds after which a book can be re-completed
-	#[default_value(DEFAULT_BOOK_COMPLETION_DEDUP_TIMEOUT_SECS)]
-	#[env_key(BOOK_COMPLETION_DEDUP_TIMEOUT_SECS_KEY)]
-	pub book_completion_dedup_timeout_secs: i64,
-
 	/// Whether to trust proxy headers for determining client IP and scheme (e.g., X-Forwarded-For)
 	#[default_value(false)]
 	#[env_key(TRUST_PROXY_HEADERS_KEY)]
@@ -497,7 +490,6 @@ mod tests {
 			pdf_prerender_range: None,
 			pdf_high_quality: None,
 			oidc: None,
-			book_completion_dedup_timeout_secs: None,
 			trust_proxy_headers: None,
 		};
 		partial_config.apply_to_config(&mut config);
@@ -551,9 +543,6 @@ mod tests {
 				pdf_prerender_range: Some(DEFAULT_PDF_PRERENDER_RANGE),
 				pdf_high_quality: Some(DEFAULT_PDF_HIGH_QUALITY),
 				oidc: None,
-				book_completion_dedup_timeout_secs: Some(
-					DEFAULT_BOOK_COMPLETION_DEDUP_TIMEOUT_SECS
-				),
 				trust_proxy_headers: Some(false),
 			}
 		);
@@ -622,8 +611,6 @@ mod tests {
 						pdf_prerender_range: DEFAULT_PDF_PRERENDER_RANGE,
 						pdf_high_quality: DEFAULT_PDF_HIGH_QUALITY,
 						oidc: None,
-						book_completion_dedup_timeout_secs:
-							DEFAULT_BOOK_COMPLETION_DEDUP_TIMEOUT_SECS,
 						trust_proxy_headers: false,
 					}
 				);

--- a/crates/graphql/schema.graphql
+++ b/crates/graphql/schema.graphql
@@ -3255,8 +3255,6 @@ type StumpConfig {
 	pdfPrerenderRange: Int!
 	"Whether to enable high-quality rendering with smoothing (slower but better quality)."
 	pdfHighQuality: Boolean!
-	"The number of seconds after which a book can be re-completed"
-	bookCompletionDedupTimeoutSecs: Int!
 	"Whether to trust proxy headers for determining client IP and scheme (e.g., X-Forwarded-For)"
 	trustProxyHeaders: Boolean!
 }

--- a/crates/graphql/src/mutation/reading_progress.rs
+++ b/crates/graphql/src/mutation/reading_progress.rs
@@ -71,16 +71,10 @@ impl ReadProgressMutation {
 			},
 		};
 
-		upsert_reading_session(
-			conn,
-			user,
-			id.as_ref(),
-			progression,
-			core.config.book_completion_dedup_timeout_secs,
-		)
-		.await
-		.map(ReadingSession::from)
-		.map_err(Into::into)
+		upsert_reading_session(conn, user, id.as_ref(), progression)
+			.await
+			.map(ReadingSession::from)
+			.map_err(Into::into)
 	}
 
 	/// trashes current readthrough, if there is one

--- a/crates/graphql/src/object/stats.rs
+++ b/crates/graphql/src/object/stats.rs
@@ -51,22 +51,65 @@ impl LibraryStats {
 						(SELECT COUNT(*) FROM series WHERE ($1 IS NULL OR series.library_id = $1)) AS series_count
 					FROM library_media
 				),
-				readthrough_stats AS (
+				filtered_sessions AS (
+					SELECT *
+					FROM reading_sessions
+					WHERE media_id IN (SELECT id FROM library_media)
+						AND ($2 IS TRUE OR user_id = $3)
+				),
+				latest_readthrough_sessions AS (
 					SELECT
 						frs.media_id,
+						frs.user_id,
 						frs.readthrough_number,
-						MAX(CASE WHEN frs.status = 'FINISHED' THEN 1 ELSE 0 END) AS has_finished,
-						MAX(CASE WHEN frs.status = 'READING' THEN 1 ELSE 0 END) AS has_reading,
+						frs.status
+					FROM filtered_sessions frs
+					WHERE NOT EXISTS (
+							SELECT 1
+							FROM filtered_sessions rs2
+							WHERE rs2.user_id = frs.user_id
+								AND rs2.media_id = frs.media_id
+								AND rs2.readthrough_number = frs.readthrough_number
+								AND (
+									IFNULL(rs2.updated_at, rs2.created_at) > IFNULL(frs.updated_at, frs.created_at)
+									OR (
+										IFNULL(rs2.updated_at, rs2.created_at) = IFNULL(frs.updated_at, frs.created_at)
+										AND rs2.created_at > frs.created_at
+									)
+									OR (
+										IFNULL(rs2.updated_at, rs2.created_at) = IFNULL(frs.updated_at, frs.created_at)
+										AND rs2.created_at = frs.created_at
+										AND rs2.id > frs.id
+									)
+								)
+						)
+				),
+				readthrough_elapsed AS (
+					SELECT
+						frs.media_id,
+						frs.user_id,
+						frs.readthrough_number,
 						IFNULL(SUM(frs.elapsed_seconds), 0) AS readthrough_elapsed_seconds
-					FROM reading_sessions frs
-					WHERE frs.media_id IN (SELECT id FROM library_media)
-						AND ($2 IS TRUE OR frs.user_id = $3)
-					GROUP BY frs.media_id, frs.readthrough_number
+					FROM filtered_sessions frs
+					GROUP BY frs.media_id, frs.user_id, frs.readthrough_number
+				),
+				readthrough_stats AS (
+					SELECT
+						lrs.media_id,
+						MAX(CASE WHEN lrs.status = 'FINISHED' THEN 1 ELSE 0 END) AS has_finished,
+						MAX(CASE WHEN lrs.status = 'READING' THEN 1 ELSE 0 END) AS has_reading,
+						IFNULL(SUM(rte.readthrough_elapsed_seconds), 0) AS readthrough_elapsed_seconds
+					FROM latest_readthrough_sessions lrs
+					INNER JOIN readthrough_elapsed rte
+						ON rte.media_id = lrs.media_id
+						AND rte.user_id = lrs.user_id
+						AND rte.readthrough_number = lrs.readthrough_number
+					GROUP BY lrs.media_id
 				),
 				session_stats AS (
 					SELECT
-						COUNT(DISTINCT CASE WHEN has_finished = 1 THEN media_id END) AS completed_books,
-						COUNT(DISTINCT CASE WHEN has_reading = 1 THEN media_id END) AS in_progress_books,
+						COUNT(CASE WHEN has_finished = 1 THEN media_id END) AS completed_books,
+						COUNT(CASE WHEN has_reading = 1 THEN media_id END) AS in_progress_books,
 						IFNULL(SUM(readthrough_elapsed_seconds), 0) AS total_reading_time_seconds
 					FROM readthrough_stats
 				)
@@ -118,22 +161,65 @@ impl SeriesStats {
 					FROM media
 					WHERE media.series_id = $1
 				),
-				readthrough_stats AS (
+				filtered_sessions AS (
+					SELECT *
+					FROM reading_sessions
+					WHERE media_id IN (SELECT id FROM media WHERE series_id = $1)
+						AND ($2 IS TRUE OR user_id = $3)
+				),
+				latest_readthrough_sessions AS (
 					SELECT
 						frs.media_id,
+						frs.user_id,
 						frs.readthrough_number,
-						MAX(CASE WHEN frs.status = 'FINISHED' THEN 1 ELSE 0 END) AS has_finished,
-						MAX(CASE WHEN frs.status = 'READING' THEN 1 ELSE 0 END) AS has_reading,
+						frs.status
+					FROM filtered_sessions frs
+					WHERE NOT EXISTS (
+							SELECT 1
+							FROM filtered_sessions rs2
+							WHERE rs2.user_id = frs.user_id
+								AND rs2.media_id = frs.media_id
+								AND rs2.readthrough_number = frs.readthrough_number
+								AND (
+									IFNULL(rs2.updated_at, rs2.created_at) > IFNULL(frs.updated_at, frs.created_at)
+									OR (
+										IFNULL(rs2.updated_at, rs2.created_at) = IFNULL(frs.updated_at, frs.created_at)
+										AND rs2.created_at > frs.created_at
+									)
+									OR (
+										IFNULL(rs2.updated_at, rs2.created_at) = IFNULL(frs.updated_at, frs.created_at)
+										AND rs2.created_at = frs.created_at
+										AND rs2.id > frs.id
+									)
+								)
+						)
+				),
+				readthrough_elapsed AS (
+					SELECT
+						frs.media_id,
+						frs.user_id,
+						frs.readthrough_number,
 						IFNULL(SUM(frs.elapsed_seconds), 0) AS readthrough_elapsed_seconds
-					FROM reading_sessions frs
-					WHERE frs.media_id IN (SELECT id FROM media WHERE series_id = $1)
-						AND ($2 IS TRUE OR frs.user_id = $3)
-					GROUP BY frs.media_id, frs.readthrough_number
+					FROM filtered_sessions frs
+					GROUP BY frs.media_id, frs.user_id, frs.readthrough_number
+				),
+				readthrough_stats AS (
+					SELECT
+						lrs.media_id,
+						MAX(CASE WHEN lrs.status = 'FINISHED' THEN 1 ELSE 0 END) AS has_finished,
+						MAX(CASE WHEN lrs.status = 'READING' THEN 1 ELSE 0 END) AS has_reading,
+						IFNULL(SUM(rte.readthrough_elapsed_seconds), 0) AS readthrough_elapsed_seconds
+					FROM latest_readthrough_sessions lrs
+					INNER JOIN readthrough_elapsed rte
+						ON rte.media_id = lrs.media_id
+						AND rte.user_id = lrs.user_id
+						AND rte.readthrough_number = lrs.readthrough_number
+					GROUP BY lrs.media_id
 				),
 				session_stats AS (
 					SELECT
-						COUNT(DISTINCT CASE WHEN has_finished = 1 THEN media_id END) AS completed_books,
-						COUNT(DISTINCT CASE WHEN has_reading = 1 THEN media_id END) AS in_progress_books,
+						COUNT(CASE WHEN has_finished = 1 THEN media_id END) AS completed_books,
+						COUNT(CASE WHEN has_reading = 1 THEN media_id END) AS in_progress_books,
 						IFNULL(SUM(readthrough_elapsed_seconds), 0) AS total_reading_time_seconds
 					FROM readthrough_stats
 				)

--- a/crates/models/src/domain/reading_progress.rs
+++ b/crates/models/src/domain/reading_progress.rs
@@ -138,6 +138,18 @@ mod tests {
 	}
 
 	#[test]
+	fn test_is_within_grace_period_recent_update() {
+		let session = make_session(false, Some(10)); // within grace
+		assert!(is_within_grace_period(&session, 60));
+	}
+
+	#[test]
+	fn test_is_within_grace_period_expired_update() {
+		let session = make_session(false, Some(700)); // past grace
+		assert!(!is_within_grace_period(&session, 60));
+	}
+
+	#[test]
 	fn test_should_extend_not_completed_within_grace() {
 		let session = make_session(false, Some(300)); // 5 min ago
 		assert!(should_extend_session(&session, 600));
@@ -152,6 +164,12 @@ mod tests {
 	#[test]
 	fn test_should_extend_completed_session() {
 		let session = make_session(true, Some(10)); // recently updated but complete
+		assert!(should_extend_session(&session, 600));
+	}
+
+	#[test]
+	fn test_should_not_extend_completed_session_after_grace() {
+		let session = make_session(true, Some(700)); // updated a while ago and complete
 		assert!(!should_extend_session(&session, 600));
 	}
 

--- a/crates/models/src/domain/reading_progress.rs
+++ b/crates/models/src/domain/reading_progress.rs
@@ -1,25 +1,17 @@
 use chrono::{DateTime, Duration, NaiveDate, Utc};
 use sea_orm::sqlx::types::Decimal;
 
-use crate::entity::reading_session;
+use crate::{entity::reading_session, shared::enums::ReadingStatus};
 
 pub fn calculate_logical_date(now: DateTime<Utc>, offset_hours: i32) -> NaiveDate {
 	(now - Duration::hours(offset_hours as i64)).date_naive()
 }
 
-/// returns true if the given session should be extended rather than a new one created.
-///
-/// a session is extendable when:
-/// - the book was not completed during it (`did_complete` is false)
-/// - the time since the last update is within the user's configured grace period
-pub fn should_extend_session(
+/// returns true if `session` was updated within the last `grace_period_secs` seconds
+fn is_within_grace_period(
 	session: &reading_session::Model,
 	grace_period_secs: i64,
 ) -> bool {
-	if session.is_finalized() {
-		return false;
-	}
-
 	let secs_since_update = session
 		.updated_at
 		.map(|t| {
@@ -29,6 +21,24 @@ pub fn should_extend_session(
 		.unwrap_or(0);
 
 	secs_since_update <= grace_period_secs
+}
+
+/// returns true if the given session should be extended rather than a new one created
+///
+/// a session is extendable when:
+/// - the session is still within the grace period
+/// - the status is not Abandoned
+///
+/// if a completed session is within the grace period, that is accepted as an extension
+pub fn should_extend_session(
+	session: &reading_session::Model,
+	grace_period_secs: i64,
+) -> bool {
+	if session.status == ReadingStatus::Abandoned {
+		false
+	} else {
+		is_within_grace_period(session, grace_period_secs)
+	}
 }
 
 /// returns true if `session` was completed within `timeout_secs` of now

--- a/crates/models/src/services/reading_progress.rs
+++ b/crates/models/src/services/reading_progress.rs
@@ -5,9 +5,7 @@ use sea_orm::{
 };
 
 use crate::{
-	domain::reading_progress::{
-		calculate_logical_date, is_recent_completion, should_extend_session,
-	},
+	domain::reading_progress::{calculate_logical_date, should_extend_session},
 	entity::{media, reading_session, user::AuthUser},
 	shared::{enums::ReadingStatus, readium::ReadiumLocator},
 };
@@ -163,27 +161,4 @@ pub async fn get_book_pages(
 			sea_orm::DbErr::RecordNotFound(format!("Media with id {} not found", book_id))
 		})?;
 	Ok(pages)
-}
-
-// note this makes certain assumptions that feel incorrect but i only use it when
-// gated by input.is_complete so it's fine
-async fn should_enforce_completion_dedupe(
-	session: &reading_session::Model,
-	timeout_secs: i64,
-	conn: &impl ConnectionTrait,
-) -> Result<bool, sea_orm::DbErr> {
-	let latest_completed = reading_session::Entity::find()
-		.filter(
-			reading_session::Column::UserId
-				.eq(&session.user_id)
-				.and(reading_session::Column::MediaId.eq(&session.media_id)),
-		)
-		.filter(reading_session::Column::Status.eq(ReadingStatus::Finished))
-		.order_by_desc(reading_session::Column::UpdatedAt)
-		.one(conn)
-		.await?;
-
-	Ok(latest_completed
-		.filter(|s| is_recent_completion(s, timeout_secs))
-		.is_some())
 }

--- a/crates/models/src/services/reading_progress.rs
+++ b/crates/models/src/services/reading_progress.rs
@@ -55,6 +55,8 @@ pub async fn upsert_reading_session(
 		// 2. mutate the finished session as incomplete if within the dedupe window to be active instead
 		// the first was easier which is why i did it, however second might be better. need to properly review
 		// how it would impact the tracking though so will come back when i have more time.
+		// other suggestion from another:
+		// replace dedupe timout with grace period (simplifies in that now there is just one number to control session lifetimes)
 		Some(ref session)
 			if input.did_complete
 				&& should_enforce_completion_dedupe(

--- a/crates/models/src/services/reading_progress.rs
+++ b/crates/models/src/services/reading_progress.rs
@@ -46,9 +46,23 @@ pub async fn upsert_reading_session(
 		.await?;
 
 	match latest {
+		// TODO(reading-sessions): this presents an interesting ux smell imo. once you finish a session,
+		// the next progression tracking event (e.g., jumping back 10 pages before the end) will create
+		// a new session and increment the readthrough number. it will not let you finish that readthrough
+		// until you mark as complete or the deduplication window passes (e.g., 1 day by default). im thinking
+		// one of two things would be better:
+		// 1. increment the readthrough to continue tracking progress (the current fix in this branch)
+		// 2. mutate the finished session as incomplete if within the dedupe window to be active instead
+		// the first was easier which is why i did it, however second might be better. need to properly review
+		// how it would impact the tracking though so will come back when i have more time.
 		Some(ref session)
 			if input.did_complete
-				&& is_recent_completion(session, completion_dedup_timeout_secs) =>
+				&& should_enforce_completion_dedupe(
+					session,
+					completion_dedup_timeout_secs,
+					db,
+				)
+				.await? =>
 		{
 			Ok(latest.unwrap())
 		},
@@ -158,4 +172,27 @@ pub async fn get_book_pages(
 			sea_orm::DbErr::RecordNotFound(format!("Media with id {} not found", book_id))
 		})?;
 	Ok(pages)
+}
+
+// note this makes certain assumptions that feel incorrect but i only use it when
+// gated by input.is_complete so it's fine
+async fn should_enforce_completion_dedupe(
+	session: &reading_session::Model,
+	timeout_secs: i64,
+	conn: &impl ConnectionTrait,
+) -> Result<bool, sea_orm::DbErr> {
+	let latest_completed = reading_session::Entity::find()
+		.filter(
+			reading_session::Column::UserId
+				.eq(&session.user_id)
+				.and(reading_session::Column::MediaId.eq(&session.media_id)),
+		)
+		.filter(reading_session::Column::Status.eq(ReadingStatus::Finished))
+		.order_by_desc(reading_session::Column::UpdatedAt)
+		.one(conn)
+		.await?;
+
+	Ok(latest_completed
+		.filter(|s| is_recent_completion(s, timeout_secs))
+		.is_some())
 }

--- a/crates/models/src/services/reading_progress.rs
+++ b/crates/models/src/services/reading_progress.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use sea_orm::{
 	prelude::Decimal, ActiveModelTrait, ActiveValue::Set, ColumnTrait, ConnectionTrait,
-	EntityTrait, QueryFilter, QueryOrder, QuerySelect,
+	EntityTrait, IntoActiveModel, QueryFilter, QueryOrder, QuerySelect,
 };
 
 use crate::{
@@ -24,6 +24,42 @@ pub struct NormalizedProgression {
 	pub device_id: Option<String>,
 }
 
+impl NormalizedProgression {
+	fn apply(&self, session: reading_session::Model) -> reading_session::ActiveModel {
+		let new_elapsed = session.elapsed_seconds.unwrap_or(0)
+			+ self.elapsed_seconds_delta.unwrap_or(0).max(0);
+
+		let mut active = session.into_active_model();
+
+		active.epubcfi = Set(self.epubcfi.clone());
+		active.end_page = Set(self.page);
+		active.end_locator = Set(self.locator.clone());
+		active.end_percentage = Set(self.percentage);
+		if self.did_complete {
+			active.status = Set(ReadingStatus::Finished);
+		} else {
+			active.status = Set(ReadingStatus::Reading);
+		}
+		active.elapsed_seconds = Set(Some(new_elapsed));
+		if let Some(incoming) = &self.device_id {
+			let current = match &active.device_ids {
+				sea_orm::ActiveValue::Set(v) | sea_orm::ActiveValue::Unchanged(v) => {
+					v.as_ref()
+				},
+				sea_orm::ActiveValue::NotSet => None,
+			};
+			let mut ids = current
+				.map(|reading_session::DeviceIds(v)| v.clone())
+				.unwrap_or_default();
+			if !ids.contains(incoming) {
+				ids.push(incoming.clone());
+				active.device_ids = Set(Some(reading_session::DeviceIds(ids)));
+			}
+		}
+		active
+	}
+}
+
 /// creates a [`reading_session`] record or extends the most recent one if it falls within
 /// the same logical day and the grace period has not elapsed
 pub async fn upsert_reading_session(
@@ -31,7 +67,6 @@ pub async fn upsert_reading_session(
 	user: &AuthUser,
 	media_id: &str,
 	input: NormalizedProgression,
-	completion_dedup_timeout_secs: i64,
 ) -> Result<reading_session::Model, sea_orm::DbErr> {
 	let (grace_period, day_reset_offset) = user
 		.preferences
@@ -46,59 +81,13 @@ pub async fn upsert_reading_session(
 		.await?;
 
 	match latest {
-		// TODO(reading-sessions): this presents an interesting ux smell imo. once you finish a session,
-		// the next progression tracking event (e.g., jumping back 10 pages before the end) will create
-		// a new session and increment the readthrough number. it will not let you finish that readthrough
-		// until you mark as complete or the deduplication window passes (e.g., 1 day by default). im thinking
-		// one of two things would be better:
-		// 1. increment the readthrough to continue tracking progress (the current fix in this branch)
-		// 2. mutate the finished session as incomplete if within the dedupe window to be active instead
-		// the first was easier which is why i did it, however second might be better. need to properly review
-		// how it would impact the tracking though so will come back when i have more time.
-		// other suggestion from another:
-		// replace dedupe timout with grace period (simplifies in that now there is just one number to control session lifetimes)
-		Some(ref session)
-			if input.did_complete
-				&& should_enforce_completion_dedupe(
-					session,
-					completion_dedup_timeout_secs,
-					db,
-				)
-				.await? =>
-		{
-			Ok(latest.unwrap())
-		},
+		// so long as the status is no dnf, progression within grace period will extend the existing session.
+		// this might re-open the session if it was previously marked as finished
 		Some(session)
 			if session.session_date == logical_today
 				&& should_extend_session(&session, grace_period) =>
 		{
-			let new_elapsed = session.elapsed_seconds.unwrap_or(0)
-				+ input.elapsed_seconds_delta.unwrap_or(0).max(0);
-
-			let mut active: reading_session::ActiveModel = session.into();
-			active.epubcfi = Set(input.epubcfi);
-			active.end_page = Set(input.page);
-			active.end_locator = Set(input.locator);
-			active.end_percentage = Set(input.percentage);
-			active.elapsed_seconds = Set(Some(new_elapsed));
-			if input.did_complete {
-				active.status = Set(ReadingStatus::Finished);
-			}
-			if let Some(incoming) = input.device_id {
-				let current = match &active.device_ids {
-					sea_orm::ActiveValue::Set(v) | sea_orm::ActiveValue::Unchanged(v) => {
-						v.as_ref()
-					},
-					sea_orm::ActiveValue::NotSet => None,
-				};
-				let mut ids = current
-					.map(|reading_session::DeviceIds(v)| v.clone())
-					.unwrap_or_default();
-				if !ids.contains(&incoming) {
-					ids.push(incoming);
-					active.device_ids = Set(Some(reading_session::DeviceIds(ids)));
-				}
-			}
+			let active = input.apply(session);
 			active.update(db).await
 		},
 		_ => {

--- a/crates/models/src/services/reading_progress.rs
+++ b/crates/models/src/services/reading_progress.rs
@@ -99,7 +99,7 @@ pub async fn upsert_reading_session(
 				end_page: Set(input.page),
 				start_locator: Set(input.locator.clone()),
 				end_locator: Set(input.locator),
-				start_percentage: Set(input.percentage),
+				start_percentage: Set(input.percentage.or(Some(Decimal::new(0, 2)))),
 				end_percentage: Set(input.percentage),
 				// set bc there's no existing session to extend
 				elapsed_seconds: Set(Some(

--- a/packages/graphql/src/client/graphql.ts
+++ b/packages/graphql/src/client/graphql.ts
@@ -4372,8 +4372,6 @@ export type StumpConfig = {
   accessTokenTtl: Scalars['Int']['output'];
   /** A list of origins for CORS. */
   allowedOrigins: Array<Scalars['String']['output']>;
-  /** The number of seconds after which a book can be re-completed */
-  bookCompletionDedupTimeoutSecs: Scalars['Int']['output'];
   /** The client directory. */
   clientDir: Scalars['String']['output'];
   /** Whether or not to include ANSI color codes in log files. */


### PR DESCRIPTION
This PR changes the behavior of finished session deduplication:

- The control mechanism is now exclusively through the grace window user preference, rather than a config var specific to only deduplication
- If you are within the grace window after finishing, e.g. you got back 10 pages after reading the end, it will re-open the session

I still have a little testing to do but will merge after