### PR TITLE
add PKCE support and remove duplicate openid scope

### DIFF
--- a/apps/server/src/config/oidc.rs
+++ b/apps/server/src/config/oidc.rs
@@ -8,8 +8,8 @@ use openidconnect::{
 	},
 	AuthorizationCode, Client, ClientId, ClientSecret, CsrfToken, EmptyAdditionalClaims,
 	EndpointMaybeSet, EndpointNotSet, EndpointSet, IssuerUrl, Nonce, OAuth2TokenResponse,
-	PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, Scope,
-	StandardErrorResponse, TokenResponse,
+	PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, Scope, StandardErrorResponse,
+	TokenResponse,
 };
 use serde::{Deserialize, Serialize};
 use stump_core::config::OidcConfig;
@@ -138,13 +138,10 @@ pub async fn exchange_code_for_claims(
 	if let Some(verifier) = pkce_verifier {
 		request = request.set_pkce_verifier(verifier);
 	}
-	let token_response = request
-		.request_async(http_client)
-		.await
-		.map_err(|error| {
-			tracing::error!(?error, "Token exchange failed");
-			APIError::OIDCTokenExchangeFailed(error.to_string())
-		})?;
+	let token_response = request.request_async(http_client).await.map_err(|error| {
+		tracing::error!(?error, "Token exchange failed");
+		APIError::OIDCTokenExchangeFailed(error.to_string())
+	})?;
 
 	let id_token = token_response
 		.id_token()

--- a/apps/server/src/config/oidc.rs
+++ b/apps/server/src/config/oidc.rs
@@ -8,7 +8,8 @@ use openidconnect::{
 	},
 	AuthorizationCode, Client, ClientId, ClientSecret, CsrfToken, EmptyAdditionalClaims,
 	EndpointMaybeSet, EndpointNotSet, EndpointSet, IssuerUrl, Nonce, OAuth2TokenResponse,
-	RedirectUrl, Scope, StandardErrorResponse, TokenResponse,
+	PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, Scope,
+	StandardErrorResponse, TokenResponse,
 };
 use serde::{Deserialize, Serialize};
 use stump_core::config::OidcConfig;
@@ -89,19 +90,24 @@ pub fn get_oidc_authorize_url(
 	client: &StumpOidcClient,
 	scopes: &[String],
 	state: &str,
+	pkce_challenge: Option<PkceCodeChallenge>,
 ) -> String {
 	let scope_vec: Vec<Scope> = scopes.iter().map(|s| Scope::new(s.clone())).collect();
 	let state_owned = state.to_string();
 
-	let (authorize_url, _, _) = client
+	let mut auth_request = client
 		.authorize_url(
 			CoreAuthenticationFlow::AuthorizationCode,
 			move || CsrfToken::new(state_owned),
 			Nonce::new_random,
 		)
-		.add_scopes(scope_vec)
-		.url();
+		.add_scopes(scope_vec);
 
+	if let Some(challenge) = pkce_challenge {
+		auth_request = auth_request.set_pkce_challenge(challenge);
+	}
+
+	let (authorize_url, _, _) = auth_request.url();
 	authorize_url.to_string()
 }
 
@@ -126,9 +132,13 @@ pub async fn exchange_code_for_claims(
 	client: &StumpOidcClient,
 	code: String,
 	extra_audiences: Vec<String>,
+	pkce_verifier: Option<PkceCodeVerifier>,
 ) -> Result<OidcClaims, APIError> {
-	let token_response = client
-		.exchange_code(AuthorizationCode::new(code))?
+	let mut request = client.exchange_code(AuthorizationCode::new(code))?;
+	if let Some(verifier) = pkce_verifier {
+		request = request.set_pkce_verifier(verifier);
+	}
+	let token_response = request
 		.request_async(http_client)
 		.await
 		.map_err(|error| {

--- a/apps/server/src/routers/api/v2/oidc.rs
+++ b/apps/server/src/routers/api/v2/oidc.rs
@@ -81,7 +81,7 @@ pub struct AuthorizeQuery {
 
 /// The OIDC state parameter passed through the authorization flow.
 /// Contains both the original query params and the PKCE code verifier.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Default)]
 struct OidcState {
 	#[serde(flatten)]
 	query: AuthorizeQuery,
@@ -119,6 +119,7 @@ async fn authorize(
 
 	let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
 
+	let generate_token = query.generate_token;
 	let state = OidcState {
 		query,
 		pkce_verifier: pkce_verifier.secret().to_string(),
@@ -129,6 +130,7 @@ async fn authorize(
 		APIError::InternalServerError("Failed to encode state".to_string())
 	})?;
 
+	let pkce_challenge_code = pkce_challenge.as_str().to_owned();
 	let redirect_to = get_oidc_authorize_url(
 		&client,
 		&oidc_config.get_scopes(),
@@ -137,7 +139,8 @@ async fn authorize(
 	);
 
 	tracing::debug!(
-		pkce = true,
+		%generate_token,
+		pkce_challenge_code,
 		?redirect_to,
 		"Redirecting to OIDC provider",
 	);
@@ -169,10 +172,7 @@ impl axum::response::IntoResponse for OidcCallbackResponse {
 fn parse_state(state: Option<&str>) -> OidcState {
 	state
 		.and_then(|s| serde_json::from_str::<OidcState>(s).ok())
-		.unwrap_or_else(|| OidcState {
-			query: AuthorizeQuery::default(),
-			pkce_verifier: String::new(),
-		})
+		.unwrap_or_default()
 }
 
 /// The handler for the OIDC callback (code exchange + user creation/login)

--- a/apps/server/src/routers/api/v2/oidc.rs
+++ b/apps/server/src/routers/api/v2/oidc.rs
@@ -12,6 +12,8 @@ use sea_orm::{
 use serde::{Deserialize, Serialize};
 use tower_sessions::Session;
 
+use openidconnect::PkceCodeChallenge;
+
 use crate::{
 	config::{
 		jwt::{create_jwt_auth, JwtTokenPair},
@@ -77,6 +79,15 @@ pub struct AuthorizeQuery {
 	pub redirect_uri: Option<String>,
 }
 
+/// The OIDC state parameter passed through the authorization flow.
+/// Contains both the original query params and the PKCE code verifier.
+#[derive(Debug, Serialize, Deserialize)]
+struct OidcState {
+	#[serde(flatten)]
+	query: AuthorizeQuery,
+	pkce_verifier: String,
+}
+
 /// Initiate OIDC authorization
 /// The frontend(s) redirects to this endpoint so the backend can generate the auth URL
 /// and then redirect the user again to the provider
@@ -106,16 +117,27 @@ async fn authorize(
 			APIError::InternalServerError("Failed to initialize OIDC".to_string())
 		})?;
 
-	let state_value = serde_json::to_string(&query).map_err(|error| {
+	let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
+
+	let state = OidcState {
+		query,
+		pkce_verifier: pkce_verifier.secret().to_string(),
+	};
+
+	let state_value = serde_json::to_string(&state).map_err(|error| {
 		tracing::error!(?error, "Failed to encode state parameter");
 		APIError::InternalServerError("Failed to encode state".to_string())
 	})?;
 
-	let redirect_to =
-		get_oidc_authorize_url(&client, &oidc_config.get_scopes(), &state_value);
+	let redirect_to = get_oidc_authorize_url(
+		&client,
+		&oidc_config.get_scopes(),
+		&state_value,
+		Some(pkce_challenge),
+	);
 
 	tracing::debug!(
-		generate_token = %query.generate_token,
+		pkce = true,
 		?redirect_to,
 		"Redirecting to OIDC provider",
 	);
@@ -144,10 +166,13 @@ impl axum::response::IntoResponse for OidcCallbackResponse {
 	}
 }
 
-fn parse_state(state: Option<&str>) -> AuthorizeQuery {
+fn parse_state(state: Option<&str>) -> OidcState {
 	state
-		.and_then(|s| serde_json::from_str::<AuthorizeQuery>(s).ok())
-		.unwrap_or_default()
+		.and_then(|s| serde_json::from_str::<OidcState>(s).ok())
+		.unwrap_or_else(|| OidcState {
+			query: AuthorizeQuery::default(),
+			pkce_verifier: String::new(),
+		})
 }
 
 /// The handler for the OIDC callback (code exchange + user creation/login)
@@ -160,8 +185,8 @@ async fn callback(
 ) -> Result<OidcCallbackResponse, APIError> {
 	let config = &*ctx.config;
 
-	let authorize_query = parse_state(query.state.as_deref());
-	let generate_token = authorize_query.generate_token;
+	let oidc_state = parse_state(query.state.as_deref());
+	let generate_token = oidc_state.query.generate_token;
 
 	let oidc_config = config
 		.oidc
@@ -183,13 +208,21 @@ async fn callback(
 		})?;
 
 	let extra_audiences = oidc_config.get_extra_audiences();
-	let claims =
-		exchange_code_for_claims(&http_client, &client, query.code, extra_audiences)
-			.await
-			.map_err(|e| {
-				tracing::error!("Failed to exchange code for claims: {:?}", e);
-				APIError::Unauthorized
-			})?;
+	let pkce_verifier = (!oidc_state.pkce_verifier.is_empty())
+		.then(|| openidconnect::PkceCodeVerifier::new(oidc_state.pkce_verifier));
+
+	let claims = exchange_code_for_claims(
+		&http_client,
+		&client,
+		query.code,
+		extra_audiences,
+		pkce_verifier,
+	)
+	.await
+	.map_err(|e| {
+		tracing::error!("Failed to exchange code for claims: {:?}", e);
+		APIError::Unauthorized
+	})?;
 
 	tracing::debug!(subject = %claims.subject, email = ?claims.email, "OIDC claims received");
 
@@ -326,7 +359,7 @@ async fn callback(
 		let token = create_jwt_auth(&user_model.id, &ctx.conn, &ctx.config).await?;
 		tracing::debug!(user_id = %user_model.id, "Generated JWT tokens for OIDC user");
 
-		if let Some(redirect_uri) = authorize_query.redirect_uri {
+		if let Some(redirect_uri) = oidc_state.query.redirect_uri {
 			let redirect_url = format!(
 				"{}?access_token={}&refresh_token={}&expires_at={}",
 				redirect_uri,

--- a/core/src/config/oidc_config.rs
+++ b/core/src/config/oidc_config.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use super::env_keys::*;
 
-const REQUIRED_SCOPES: &str = "openid,email";
+const REQUIRED_SCOPES: &str = "email";
 
 /// Configuration for OpenID Connect (OIDC) authentication
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, SimpleObject)]


### PR DESCRIPTION
I wanted to use Stump with Rauthy, which is a bit stricter than other SSO solutions, so it requires PKCE support and complain if a scope is duplicated.


- Remove openid from REQUIRED_SCOPES; the openidconnect crate already adds it automatically on authorize_url(), causing duplicate scopes
- Add PKCE (S256) support for authorization code flow, required by providers like Rauthy that enforce RFC 7636
- Pass PKCE code verifier through the OAuth state parameter instead of the session store, which rejects records without a user_id