### PR TITLE
:bug: Fix `host` resolve logic for Kobo sync

### DIFF
--- a/apps/server/src/middleware/host.rs
+++ b/apps/server/src/middleware/host.rs
@@ -67,10 +67,12 @@ where
 			"http".to_string()
 		});
 
-		Ok(HostExtractor(HostDetails {
-			host: host.0,
-			scheme,
-		}))
+		let via_proxy = trust_proxy_headers
+			&& (parts.headers.contains_key(X_FORWARDED_PROTO_HEADER_KEY)
+				|| parts.headers.contains_key(FORWARDED));
+		let host = resolve_host(host.0, &scheme, app_state.config.port, via_proxy);
+
+		Ok(HostExtractor(HostDetails { host, scheme }))
 	}
 }
 
@@ -117,6 +119,29 @@ fn parse_forwarded(headers: &HeaderMap) -> Option<&str> {
 			.eq_ignore_ascii_case("proto")
 			.then(|| value.trim().trim_matches('"'))
 	})
+}
+
+/// resolves the ideal host to use for URL generation based on the incoming request and server config,
+/// appending a port manually when:
+/// - the incoming `Host` header doesn't include a port (e.g., from Kobo devices,
+///   see https://github.com/stumpapp/stump/issues/1228)
+/// - the connection is direct (not via a trusted reverse proxy, which should handle port mapping on its own)
+/// - the configured port is not the default for the scheme (80 for http, 443 for https)
+fn resolve_host(host: String, scheme: &str, port: u16, via_proxy: bool) -> String {
+	// if already contains a port or is pulled from proxy header, return as-is
+	if host.contains(':') || via_proxy {
+		return host;
+	}
+
+	// is a bit naive but feels safe
+	let is_default =
+		(scheme == "http" && port == 80) || (scheme == "https" && port == 443);
+
+	if is_default {
+		host
+	} else {
+		format!("{}:{}", host, port)
+	}
 }
 
 /// Extracts the client IP from headers in the following priority order:
@@ -275,5 +300,49 @@ mod tests {
 		let ip = extract_client_ip(&headers, &extensions, false);
 
 		assert_eq!(ip, Some("192.0.2.1".parse().unwrap())); // connect info used, not headers
+	}
+
+	#[test]
+	fn test_append_port_direct_non_standard() {
+		let result = resolve_host("192.168.0.62".to_string(), "http", 10801, false);
+		assert_eq!(result, "192.168.0.62:10801");
+	}
+
+	#[test]
+	fn test_append_port_direct_https_non_standard() {
+		let result = resolve_host("192.168.0.62".to_string(), "https", 10801, false);
+		assert_eq!(result, "192.168.0.62:10801");
+	}
+
+	#[test]
+	fn test_no_append_port_http_default() {
+		let result = resolve_host("192.168.0.62".to_string(), "http", 80, false);
+		assert_eq!(result, "192.168.0.62");
+	}
+
+	#[test]
+	fn test_no_append_port_https_default() {
+		let result = resolve_host("myserver.com".to_string(), "https", 443, false);
+		assert_eq!(result, "myserver.com");
+	}
+
+	#[test]
+	fn test_no_append_port_already_has_port() {
+		let result = resolve_host("192.168.0.62:10801".to_string(), "http", 10801, false);
+		assert_eq!(result, "192.168.0.62:10801");
+	}
+
+	#[test]
+	fn test_no_append_port_via_proxy() {
+		// e.g., reverse proxy myserver.com:443 -> internal:10801
+		// assuming host header is myserver.com
+		let result = resolve_host("myserver.com".to_string(), "https", 10801, true);
+		assert_eq!(result, "myserver.com");
+	}
+
+	#[test]
+	fn test_no_append_port_via_proxy_non_standard_public_port() {
+		let result = resolve_host("myserver.com:8443".to_string(), "https", 10801, true);
+		assert_eq!(result, "myserver.com:8443");
 	}
 }

--- a/apps/server/src/routers/kobo/mod.rs
+++ b/apps/server/src/routers/kobo/mod.rs
@@ -1,11 +1,38 @@
-use axum::Router;
+use axum::{
+	extract::State, http::StatusCode, middleware, routing::delete, Extension, Router,
+};
+use graphql::data::AuthContext;
+use models::entity::kobo_sync_session;
+use sea_orm::prelude::*;
 
-use crate::config::state::AppState;
+use crate::{
+	config::state::AppState, errors::APIResult, middleware::auth::auth_middleware,
+};
 
 mod router;
 mod sync;
 mod sync_token;
 
 pub(crate) fn mount(app_state: AppState) -> Router<AppState> {
-	Router::new().nest("/kobo", router::mount(app_state))
+	Router::new()
+		.nest("/kobo", router::mount(app_state.clone()))
+		.route(
+			"/api/v2/kobo/sync-sessions",
+			delete(delete_kobo_sync_sessions),
+		)
+		.layer(middleware::from_fn_with_state(app_state, auth_middleware))
+}
+
+/// Delete all Kobo sync sessions for the current user, forcing a full re-sync
+/// on the next connection
+async fn delete_kobo_sync_sessions(
+	Extension(req): Extension<AuthContext>,
+	State(ctx): State<AppState>,
+) -> APIResult<StatusCode> {
+	let user = req.user();
+	kobo_sync_session::Entity::delete_many()
+		.filter(kobo_sync_session::Column::UserId.eq(user.id.clone()))
+		.exec(ctx.conn.as_ref())
+		.await?;
+	Ok(StatusCode::NO_CONTENT)
 }

--- a/apps/server/src/routers/kobo/router.rs
+++ b/apps/server/src/routers/kobo/router.rs
@@ -140,7 +140,7 @@ async fn initialization(
 ) -> APIResult<impl IntoResponse> {
 	let base_url = host.url();
 	let template = format!(
-		"{}/kobo/{}/v1/books/{{ImageId}}/thumbnail/{{Width}}/{{Height}}/image.jpg",
+		"{}/kobo/{}/v1/books/{{ImageId}}/thumbnail/{{Width}}/{{Height}}/{{IsGreyscale}}/image.jpg",
 		base_url, api_key
 	);
 	let quality_template = format!(
@@ -148,8 +148,19 @@ async fn initialization(
 		base_url, api_key
 	);
 
-	Ok(Json(
-		json![{ "image_url_quality_template": quality_template, "image_url_template": template,	}],
+	let mut headers = HeaderMap::new();
+	// Note: i couldn't find reference to _why_ this is needed, but Komga includes the header. it should be
+	// harmless, as e30= is just a base64 of "{}"
+	headers.insert("x-kobo-apitoken", HeaderValue::from_static("e30="));
+
+	Ok((
+		headers,
+		Json(json![{
+			"Resources": {
+				"image_url_quality_template": quality_template,
+				"image_url_template": template,
+			}
+		}]),
 	))
 }
 

--- a/docs/content/docs/guides/integrations/kobo.mdx
+++ b/docs/content/docs/guides/integrations/kobo.mdx
@@ -15,7 +15,6 @@ You can automatically sync books to your Kobo device with Stump.
 
 You can configure your Kobo to retrieve books from Stump, rather than from the Kobo store.
 
-
 ## Setup
 
 To set up Kobo sync with Stump, you need to:
@@ -70,6 +69,21 @@ api_endpoint=http://192.168.4.100:10801/kobo/98765432109876543210876543210987
 </Step>
 
 </Steps>
+
+## Force sync
+
+If your Kobo becomes out of sync with Stump, you can reset the server-side sync state so the next sync starts from scratch:
+
+```http
+DELETE /api/v2/kobo/sync-sessions
+Authorization: Bearer <your-token>
+```
+
+This deletes all stored sync sessions for your account, which should force a full re-sync the next time your Kobo connects.
+
+<Callout>
+	After calling this endpoint you may also need to trigger a fresh sync from the Kobo itself. If the device still skips the library sync step, you may need to restore `.kobo/Kobo/Kobo eReader.conf` back to defaults, trigger a sync, then edit it again to point to Stump and trigger another sync.
+</Callout>
 
 ## Future improvements
 


### PR DESCRIPTION
Fixes #1228

## Description

A few fixes at once:

- A little smarter host parsing logic to account missing ports (if needed)
- Wrap Kobo initialization response in `Resources` envelope
- Add "force re-sync" endpoint to delete existing sync tokens
- Add dummy `x-kobo-apitoken` header for Kobo initialization response

## Stump Contributor License Agreement

By contributing to Stump, you agree that your contributions will be licensed under the following licenses (where applicable):

- The [expo application](./apps/expo/LICENSE) is licensed under [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.html)
- All other code in the repository is licensed under [MIT License](https://www.tldrlegal.com/license/mit-license)
