### PR TITLE
💄 (expo): Update DownloadRowItem selection animation

### DIFF
--- a/apps/expo/app/(tabs)/library/index.tsx
+++ b/apps/expo/app/(tabs)/library/index.tsx
@@ -161,7 +161,7 @@ export default function Screen() {
 				paddingVertical: 16,
 			}}
 			contentInsetAdjustmentBehavior="always"
-			ItemSeparatorComponent={() => <View className="h-6" />}
+			ItemSeparatorComponent={() => <View className="h-4" />}
 			ListHeaderComponent={
 				<>
 					<ListHeaderComponent isEmptyState={data?.length === 0} />

--- a/apps/expo/components/localLibrary/DownloadRowItem.tsx
+++ b/apps/expo/components/localLibrary/DownloadRowItem.tsx
@@ -1,5 +1,7 @@
-import { Host, Image } from '@expo/ui/swift-ui'
+import { clone, getColor, mix } from 'colorjs.io/fn'
 import { useRouter } from 'expo-router'
+import { SymbolView } from 'expo-symbols'
+import medium from 'expo-symbols/androidWeights/medium'
 import { CheckCircle2, Trash } from 'lucide-react-native'
 import { useCallback, useEffect, useMemo } from 'react'
 import { Alert, Platform, View } from 'react-native'
@@ -7,15 +9,16 @@ import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-na
 import { useShallow } from 'zustand/react/shallow'
 
 import { epubProgress, imageMeta, syncStatus } from '~/db'
-import { useColors } from '~/lib/constants'
+import { COLORS, toHex } from '~/lib/constants'
 import { formatBytes } from '~/lib/format'
 import { useDownload, useTranslate } from '~/lib/hooks'
+import { useColorScheme } from '~/lib/useColorScheme'
+import { usePreferencesStore } from '~/stores'
 import { useSelectionStore } from '~/stores/selection'
 
 import { ThumbnailImage } from '../image'
 import { Heading, Progress, Text } from '../ui'
 import { ContextMenu } from '../ui/context-menu/context-menu'
-import { Icon } from '../ui/icon'
 import { SyncIcon } from './sync-icon/SyncIcon'
 import { DownloadedFile } from './types'
 import { useDownloadRowItemSize } from './useDownloadRowItemSize'
@@ -48,9 +51,8 @@ export default function DownloadRowItem({ downloadedFile }: Props) {
 	const totalPages = downloadedFile.pages
 	const size = downloadedFile.size ? formatBytes(downloadedFile.size) : null
 
-	const colors = useColors()
-
 	const { width, height } = useDownloadRowItemSize()
+	const { backgroundColor, iconColor } = useSelectionColors()
 
 	const selectionStore = useSelectionStore(
 		useShallow((state) => ({
@@ -66,22 +68,53 @@ export default function DownloadRowItem({ downloadedFile }: Props) {
 		[selectionStore],
 	)
 
-	const iconOpacity = useSharedValue(1)
-	const overlayOpacity = useSharedValue(0)
+	const scale = useSharedValue(1)
+	const opacity = useSharedValue(1)
+	const bgOpacity = useSharedValue(0)
+	const bgScale = useSharedValue(0)
 
 	useEffect(() => {
-		iconOpacity.value = withTiming(selectionStore.isSelected ? 0.6 : 1, { duration: 200 })
-		overlayOpacity.value = withTiming(selectionStore.isSelected ? 1 : 0, { duration: 150 })
-	}, [selectionStore.isSelected, iconOpacity, overlayOpacity])
+		// three different modes (selected, not selected, and not in selection mode)
+		if (selectionStore.isSelectionMode) {
+			if (selectionStore.isSelected) {
+				scale.value = withTiming(0.95, { duration: 250 })
+				opacity.value = withTiming(1, { duration: 250 })
+				bgOpacity.value = withTiming(1, { duration: 250 })
+				bgScale.value = withTiming(1, { duration: 250 })
+			} else {
+				scale.value = withTiming(0.9, { duration: 250 })
+				opacity.value = withTiming(0.5, { duration: 250 })
+				bgOpacity.value = withTiming(0, { duration: 250 })
+				bgScale.value = withTiming(0.85, { duration: 250 })
+			}
+		} else {
+			scale.value = withTiming(1, { duration: 250 })
+			opacity.value = withTiming(1, { duration: 250 })
+			bgOpacity.value = withTiming(0, { duration: 250 })
+			bgScale.value = withTiming(1, { duration: 250 })
+		}
+	}, [selectionStore, scale, opacity, bgOpacity, bgScale])
 
-	const syncIconStyle = useAnimatedStyle(() => ({
-		opacity: iconOpacity.value,
-	}))
-	const overlayStyle = useAnimatedStyle(() => ({
-		backgroundColor: colors.foreground.brand + '33',
-		borderColor: colors.foreground.brand,
-		opacity: overlayOpacity.value,
-	}))
+	const itemStyle = useAnimatedStyle(() => {
+		return {
+			transform: [{ scale: scale.value }],
+			opacity: opacity.value,
+		}
+	})
+
+	const backgroundStyle = useAnimatedStyle(() => {
+		return {
+			opacity: bgOpacity.value,
+			transform: [{ scale: bgScale.value }],
+		}
+	})
+
+	const overlayStyle = useAnimatedStyle(() => {
+		return {
+			opacity: bgOpacity.value,
+			transform: [{ scale: bgScale.value }],
+		}
+	})
 
 	const onPress = useCallback(
 		() =>
@@ -168,7 +201,12 @@ export default function DownloadRowItem({ downloadedFile }: Props) {
 					},
 				]}
 			>
-				<View className="mx-4 gap-4 relative flex-row" style={{ height }}>
+				<Animated.View
+					className="squircle left-3 right-3 -top-1 -bottom-1 absolute rounded-3xl"
+					style={[backgroundStyle, { backgroundColor: backgroundColor }]}
+				/>
+
+				<Animated.View className="mx-4 gap-4 relative flex-row" style={[{ height }, itemStyle]}>
 					{/* TODO: Use file icons when no thumbnail is available? */}
 					<ThumbnailImage
 						source={{
@@ -187,7 +225,7 @@ export default function DownloadRowItem({ downloadedFile }: Props) {
 							</Heading>
 
 							{status && (
-								<Animated.View className="mt-1 shrink-0" style={syncIconStyle}>
+								<Animated.View className="mt-1 shrink-0">
 									<SyncIcon status={status} />
 								</Animated.View>
 							)}
@@ -195,7 +233,7 @@ export default function DownloadRowItem({ downloadedFile }: Props) {
 
 						<View className="gap-2 flex-row items-center">
 							{currentPage && (
-								<View className="squircle px-2.5 py-0.5 flex-row items-end rounded-full bg-background-surface-secondary">
+								<View className="squircle px-2.5 py-0.5 bg-black/5 dark:bg-white/10 flex-row items-end rounded-full">
 									<Text size="sm">{`${t('common.page')} ${currentPage}`}</Text>
 									<Text
 										size="xs"
@@ -205,7 +243,7 @@ export default function DownloadRowItem({ downloadedFile }: Props) {
 							)}
 
 							{size && (
-								<View className="squircle px-2.5 py-0.5 rounded-full bg-background-surface-secondary">
+								<View className="squircle px-2.5 py-0.5 bg-black/5 dark:bg-white/10 rounded-full">
 									<Text size="sm" className="text-foreground-muted">
 										{size}
 									</Text>
@@ -217,34 +255,78 @@ export default function DownloadRowItem({ downloadedFile }: Props) {
 							<View className="gap-3 flex-row items-center">
 								<Progress
 									className="shrink"
+									trackClassName="bg-black/5 dark:bg-white/10"
 									value={getProgress()}
 									style={{ height: 6, borderRadius: 3 }}
 								/>
 
-								<Text size="sm" className="shrink-0 text-foreground-muted">
+								<Text size="sm" className="text-foreground-muted shrink-0">
 									{(getProgress() || 0).toFixed(0)}%
 								</Text>
 							</View>
 						)}
 					</View>
+				</Animated.View>
 
-					<Animated.View
-						className="squircle inset-0 -m-1 rounded-lg absolute z-10 border-2"
-						style={overlayStyle}
-					>
-						<View className="flex flex-1 items-center justify-center">{CheckIcon}</View>
-					</Animated.View>
-				</View>
+				<Animated.View
+					// absolute and symmetrical so it translates from the same origin as the background style, plus move the icon up and left
+					className="left-2 right-2 -top-2.5 -bottom-2.5 absolute"
+					style={overlayStyle}
+				>
+					<CheckIcon color={iconColor} />
+				</Animated.View>
 			</ContextMenu>
 		</>
 	)
 }
 
-const CheckIcon = Platform.select({
-	ios: (
-		<Host matchContents>
-			<Image systemName="checkmark.circle.fill" size={32} />
-		</Host>
-	),
-	android: <Icon as={CheckCircle2} size={32} className="shadow text-fill-brand" />,
-})
+function useSelectionColors() {
+	const { isDarkColorScheme } = useColorScheme()
+	const accentColor =
+		usePreferencesStore((state) => state.accentColor) ?? COLORS.light.fill.brand.DEFAULT
+
+	const color = getColor(accentColor)
+
+	const c1 = clone(color)
+	c1.alpha = 0.2
+	const backgroundColor = toHex(c1)
+
+	const iconColor = toHex(
+		mix(color, isDarkColorScheme ? 'black' : 'white', isDarkColorScheme ? 0.3 : 0.25, {
+			space: 'oklch',
+		}),
+	)
+
+	return { backgroundColor, iconColor }
+}
+
+function CheckIcon({ color }: { color: string }) {
+	return Platform.select({
+		ios: (
+			<SymbolView
+				name={{ ios: 'checkmark.circle.fill' }}
+				// @ts-expect-error android should not be required
+				weight={{ ios: 'medium' }}
+				size={30}
+				type="palette"
+				colors={['white', color]}
+			/>
+		),
+		android: (
+			<View
+				className="squircle h-7 w-7 items-center justify-center rounded-full"
+				style={{ backgroundColor: color }}
+			>
+				<SymbolView
+					name={{ android: 'check' }}
+					// @ts-expect-error ios should not be required
+					weight={{ android: medium }}
+					size={18}
+					tintColor={'white'}
+					// this makes it line up with ios, because the ios icon has some kind of padding, because of course it does
+					style={{ inset: 3 }}
+				/>
+			</View>
+		),
+	})
+}

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -81,6 +81,7 @@
 		"expo-splash-screen": "~55.0.21",
 		"expo-sqlite": "~55.0.16",
 		"expo-status-bar": "~55.0.6",
+		"expo-symbols": "^56.0.6",
 		"expo-system-ui": "~55.0.18",
 		"fast-xml-parser": "^5.8.0",
 		"image-size": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13270,6 +13270,14 @@ expo-symbols@^55.0.8:
     "@expo-google-fonts/material-symbols" "^0.4.1"
     sf-symbols-typescript "^2.0.0"
 
+expo-symbols@^56.0.6:
+  version "56.0.6"
+  resolved "https://registry.yarnpkg.com/expo-symbols/-/expo-symbols-56.0.6.tgz#02e5f6154e0a7445981ea3634d8069cfe3148fb1"
+  integrity sha512-BrA81DjcNafdj7gXVhdrExb9LtUiSVyOf/NavyMmDAHgHMY1GqeR5cnn1PSAZeYKnSgQhee/H89XUpAxtog5hg==
+  dependencies:
+    "@expo-google-fonts/material-symbols" "^0.4.1"
+    sf-symbols-typescript "^2.0.0"
+
 expo-system-ui@~55.0.18:
   version "55.0.18"
   resolved "https://registry.yarnpkg.com/expo-system-ui/-/expo-system-ui-55.0.18.tgz#dabd6c872e4c71d12e6ba512733be8f5387a2028"


### PR DESCRIPTION
## Description

A small update to the download row items, to make the selections look a bit nicer

## Screenshots

<details>
<summary> Screenshots </summary>

<table>
<thead>
<tr>
<th align="center"><strong>No Selected Items</strong></th>
<th align="center"><strong>Selected Items</strong></th>
</tr>
</thead>
<tbody>
<tr>
<td align="center">
<img width="526" height="1079" alt="x1" src="https://github.com/user-attachments/assets/6bc60a56-384d-4edd-ba5f-3520e242dc6c" />
</td>
<td align="center"> 
<img width="526" height="1079" alt="x2" src="https://github.com/user-attachments/assets/b22fda38-2862-4a97-b041-74b79ddbd0ca" />
</td>
</tr>
</tbody>
</table>

</details>

## Stump Contributor License Agreement

By contributing to Stump, you agree that your contributions will be licensed under the following licenses (where applicable):

- The [expo application](./apps/expo/LICENSE) is licensed under [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.html)
- All other code in the repository is licensed under [MIT License](https://www.tldrlegal.com/license/mit-license)
