### PR TITLE
♻️ Config generator maintenance

### DIFF
--- a/core/src/config/stump_config.rs
+++ b/core/src/config/stump_config.rs
@@ -471,22 +471,7 @@ mod tests {
 			enable_playground: Some(false),
 			enable_koreader_sync: Some(false),
 			enable_kobo_sync: Some(false),
-			password_hash_cost: None,
-			session_ttl: None,
-			access_token_ttl: None,
-			refresh_token_ttl: None,
-			expired_session_cleanup_interval: None,
-			max_image_upload_size: None,
-			enable_upload: None,
-			max_file_upload_size: None,
-			pdf_render_dpi: None,
-			pdf_max_dimension: None,
-			pdf_render_format: None,
-			pdf_cache_pages: None,
-			pdf_prerender_range: None,
-			pdf_high_quality: None,
-			oidc: None,
-			trust_proxy_headers: None,
+			..Default::default()
 		};
 		partial_config.apply_to_config(&mut config);
 

--- a/crates/macros/stump-config-gen/src/config_vars.rs
+++ b/crates/macros/stump-config-gen/src/config_vars.rs
@@ -12,6 +12,7 @@ pub struct StumpConfigVariable {
 	pub attributes: StumpConfigVariableAttributes,
 }
 
+#[derive(Default)]
 pub struct StumpConfigVariableAttributes {
 	pub default_value: Option<Expr>,
 	pub debug_value: Option<Expr>,
@@ -55,8 +56,7 @@ pub fn get_config_variables(data_struct: &DataStruct) -> Vec<StumpConfigVariable
 			let variable_name = field.ident.as_ref().unwrap().clone();
 
 			// Parse the field's type info
-			let (variable_type, is_optional, is_vec) =
-				type_utils::parse_field_type(field);
+			let field_type = type_utils::parse_field_type(field);
 			// Parse attributes
 			let attributes = parse_config_var_attributes(field);
 
@@ -64,9 +64,9 @@ pub fn get_config_variables(data_struct: &DataStruct) -> Vec<StumpConfigVariable
 			output_vec.push(StumpConfigVariable {
 				span: variable_name.span(),
 				variable_name,
-				variable_type,
-				is_optional,
-				is_vec,
+				variable_type: field_type.inner_type_tokens,
+				is_optional: field_type.is_optional,
+				is_vec: field_type.is_vec,
 				attributes,
 			});
 		}
@@ -78,25 +78,21 @@ pub fn get_config_variables(data_struct: &DataStruct) -> Vec<StumpConfigVariable
 /// Parses the attributes on a config variable, this is where
 /// any of the #[attribute] values are unwrapped and stored
 fn parse_config_var_attributes(field: &Field) -> StumpConfigVariableAttributes {
-	let mut default_value = None;
-	let mut debug_value = None;
-	let mut required_by_new = false;
-	let mut env_key = None;
-	let mut validator = None;
 	let field_ident = field.ident.as_ref().unwrap();
 
+	let mut config_var_attributes = StumpConfigVariableAttributes::default();
 	for attr in &field.attrs {
 		// #[default_value(Expr)]
 		if attr.path().is_ident("default_value") {
 			let default_value_expr: Expr = attr.parse_args().unwrap_or_else(|e| {
 				panic!("Failed to parse default_value expression for {field_ident}: {e}")
 			});
-			default_value = Some(default_value_expr);
+			config_var_attributes.default_value = Some(default_value_expr);
 		}
 
 		// #[required_by_new]
 		if attr.path().is_ident("required_by_new") {
-			required_by_new = true;
+			config_var_attributes.required_by_new = true;
 		}
 
 		// #[env_key(Expr)]
@@ -104,7 +100,7 @@ fn parse_config_var_attributes(field: &Field) -> StumpConfigVariableAttributes {
 			let env_key_expr: Expr = attr.parse_args().unwrap_or_else(|e| {
 				panic!("Failed to parse env_key expression for {field_ident}: {e}")
 			});
-			env_key = Some(env_key_expr);
+			config_var_attributes.env_key = Some(env_key_expr);
 		}
 
 		// #[debug_value(Expr)]
@@ -112,7 +108,7 @@ fn parse_config_var_attributes(field: &Field) -> StumpConfigVariableAttributes {
 			let debug_value_expr: Expr = attr.parse_args().unwrap_or_else(|e| {
 				panic!("Failed to parse debug_value expression for {field_ident}: {e}")
 			});
-			debug_value = Some(debug_value_expr);
+			config_var_attributes.debug_value = Some(debug_value_expr);
 		}
 
 		// #[validator(fn)]
@@ -120,15 +116,9 @@ fn parse_config_var_attributes(field: &Field) -> StumpConfigVariableAttributes {
 			let validator_ident: Ident = attr.parse_args().unwrap_or_else(|e| {
 				panic!("Failed to parse validator identity for {field_ident}: {e}")
 			});
-			validator = Some(validator_ident);
+			config_var_attributes.validator = Some(validator_ident);
 		}
 	}
 
-	StumpConfigVariableAttributes {
-		default_value,
-		debug_value,
-		required_by_new,
-		env_key,
-		validator,
-	}
+	config_var_attributes
 }

--- a/crates/macros/stump-config-gen/src/gen_config_impls.rs
+++ b/crates/macros/stump-config-gen/src/gen_config_impls.rs
@@ -12,7 +12,7 @@ pub fn gen_stump_config_impls(
 	let new_impl = gen_new_impl(config_vars);
 	let debug_impl = gen_debug_impl(config_vars);
 
-	let partial_struct_name = format_ident!("Partial{}", struct_ident);
+	let partial_struct_name = format_ident!("Partial{struct_ident}");
 	let with_file_impl = gen_with_file_impl(&partial_struct_name, input_attrs);
 	let with_env_impl = gen_with_env_impl(&partial_struct_name, config_vars);
 
@@ -29,8 +29,8 @@ pub fn gen_stump_config_impls(
 }
 
 fn gen_new_impl(config_vars: &[StumpConfigVariable]) -> TokenStream {
-	let mut setters: Vec<TokenStream> = Vec::new();
-	let mut args: Vec<TokenStream> = Vec::new();
+	let mut setters = Vec::new();
+	let mut args = Vec::new();
 
 	for var in config_vars {
 		let name = &var.variable_name;
@@ -63,7 +63,7 @@ fn gen_new_impl(config_vars: &[StumpConfigVariable]) -> TokenStream {
 }
 
 fn gen_debug_impl(config_vars: &[StumpConfigVariable]) -> TokenStream {
-	let mut setters: Vec<TokenStream> = Vec::new();
+	let mut setters = Vec::new();
 
 	for var in config_vars {
 		let name = &var.variable_name;
@@ -106,7 +106,7 @@ fn gen_with_file_impl(
 			let toml_content_str = std::fs::read_to_string(config_toml)?;
 			let toml_configs = toml::from_str::<#partial_struct_name>(&toml_content_str)
 				.map_err(|e| {
-					eprintln!("Failed to parse Stump config file: {}", e);
+					eprintln!("Failed to parse Stump config file: {e}");
 					crate::CoreError::InitializationError(e.to_string())
 				})?;
 

--- a/crates/macros/stump-config-gen/src/gen_partial_config.rs
+++ b/crates/macros/stump-config-gen/src/gen_partial_config.rs
@@ -7,7 +7,7 @@ use crate::config_vars::StumpConfigVariable;
 pub fn gen_partial_stump_config(
 	struct_ident: &Ident,
 	config_vars: &[StumpConfigVariable],
-) -> proc_macro2::TokenStream {
+) -> TokenStream {
 	let mut struct_defs = Vec::new();
 	let mut empty_setters = Vec::new();
 

--- a/crates/macros/stump-config-gen/src/gen_partial_config.rs
+++ b/crates/macros/stump-config-gen/src/gen_partial_config.rs
@@ -21,10 +21,10 @@ pub fn gen_partial_stump_config(
 
 	let empty_fn_impl = gen_empty_impl(&empty_setters);
 	let apply_fn_impl = gen_apply_impl(struct_ident, config_vars);
-	let partial_struct_name = format_ident!("Partial{}", struct_ident);
+	let partial_struct_name = format_ident!("Partial{struct_ident}");
 
 	quote! {
-		#[derive(serde::Deserialize, Debug, Clone, PartialEq)]
+		#[derive(serde::Deserialize, Debug, Default, Clone, PartialEq)]
 		struct #partial_struct_name {
 			#(#struct_defs),*
 		}
@@ -69,7 +69,7 @@ fn config_var_to_setter(var: &StumpConfigVariable) -> TokenStream {
 			var.error("The config macro doesn't support Option<Vec<T>> config variables.")
 		},
 		(true, false) => {
-			let orig_var_name = format_ident!("orig_{}", var_name);
+			let orig_var_name = format_ident!("orig_{var_name}");
 
 			quote! {
 			let #orig_var_name = config.#var_name.clone();

--- a/crates/macros/stump-config-gen/src/lib.rs
+++ b/crates/macros/stump-config-gen/src/lib.rs
@@ -35,21 +35,21 @@ use gen_partial_config::gen_partial_stump_config;
 ///
 /// This attribute indicates that a field of the input will be a required parameter of the
 /// `new` function constructed by the macro. Using `required_by_new` will override any
-/// `default_value` set, using the `new` function parameter's value instead.
+/// `default_value` set, instead using the `new` function parameter's value.
 ///
 /// ### `#[env_key(Expr)]`
 ///
 /// This attribute indicates the environment variable from which the field it is applied to
 /// is derived using the `with_environment` function. Inputs can be a `str` value or `const`
-/// (or, indeed, any expression). Variables without this annotation will not be included in
-/// the `with_environment` function at all.
+/// (or any expression). Variables without this annotation will not be included in the
+/// `with_environment` function at all.
 ///
 /// ### `#[validator(Fn)]`
 ///
 /// This attribute optionally allows a validation function to be defined which will run before  
 /// any value of type `T` is written to the struct when running `with_environment` or
 /// `with_config_file`. The function must have the signature `Fn(T) -> bool`, with a `true`
-/// result causing the variable to be written, and a `false` result causing it not to be written.
+/// result causing the variable to be written and a `false` result causing it not to be written.
 ///
 /// ### `#[config_file_location(Expr)]`
 ///

--- a/crates/macros/stump-config-gen/src/type_utils.rs
+++ b/crates/macros/stump-config-gen/src/type_utils.rs
@@ -1,33 +1,53 @@
 use proc_macro2::TokenStream;
 use syn::{Field, Type, TypePath};
 
-pub fn parse_field_type(field: &Field) -> (TokenStream, bool, bool) {
+pub struct FieldType {
+	pub inner_type_tokens: TokenStream,
+	pub is_optional: bool,
+	pub is_vec: bool,
+}
+
+pub fn parse_field_type(field: &Field) -> FieldType {
 	match &field.ty {
 		Type::Path(type_path) => {
 			let type_name = type_path.path.segments.last().unwrap().ident.to_string();
 			let is_optional = type_name == "Option";
 
 			// If it's an Option get the inner type name
-			let (type_tokens, is_vec) = if is_optional {
+			let inner_type = if is_optional {
 				parse_option_inner_type(type_path)
 			}
 			// If it's a Vec<T> we want both Vec and T.
 			else if type_name == "Vec" {
-				let vector_type = get_vector_type(type_path);
-				(vector_type, true)
+				InnerType {
+					inner_type_tokens: get_vector_type(type_path),
+					is_vec: true,
+				}
 			} else {
 				let non_vector_type = type_name.parse::<TokenStream>().unwrap();
-				(non_vector_type, false)
+				InnerType {
+					inner_type_tokens: non_vector_type,
+					is_vec: false,
+				}
 			};
 
-			(type_tokens, is_optional, is_vec)
+			FieldType {
+				inner_type_tokens: inner_type.inner_type_tokens,
+				is_optional,
+				is_vec: inner_type.is_vec,
+			}
 		},
 		_ => panic!("Unsupported type"),
 	}
 }
 
-pub fn parse_option_inner_type(type_path: &TypePath) -> (TokenStream, bool) {
-	// Unravel the Option<T>
+pub struct InnerType {
+	inner_type_tokens: TokenStream,
+	is_vec: bool,
+}
+
+pub fn parse_option_inner_type(type_path: &TypePath) -> InnerType {
+	// Unravel the Option<T> or Vec<T>
 	match &type_path.path.segments.last().unwrap().arguments {
 		// Match on angle bracketed arguments only
 		syn::PathArguments::AngleBracketed(args) => {
@@ -46,13 +66,18 @@ pub fn parse_option_inner_type(type_path: &TypePath) -> (TokenStream, bool) {
 
 				// If T is a Vec then we need to do more processing
 				if inner_path_name == "Vec" {
-					let vector_type = get_vector_type(inner_type_path);
-					(vector_type, true)
+					InnerType {
+						inner_type_tokens: get_vector_type(inner_type_path),
+						is_vec: true,
+					}
 				}
 				// Otherwise we can just parse and return it
 				else {
 					let non_vector_type = inner_path_name.parse::<TokenStream>().unwrap();
-					(non_vector_type, false)
+					InnerType {
+						inner_type_tokens: non_vector_type,
+						is_vec: false,
+					}
 				}
 			}
 			// This shouldn't happen, but would occur if there were empty angle brackets

--- a/crates/macros/stump-config-gen/tests/basic_tests.rs
+++ b/crates/macros/stump-config-gen/tests/basic_tests.rs
@@ -47,6 +47,11 @@ struct BasicConfig {
 }
 
 #[test]
+fn test_empty_config() {
+	let _ = EmptyConfig::new();
+}
+
+#[test]
 fn test_create_new() {
 	let config = BasicConfig::new();
 


### PR DESCRIPTION
## Description

Two main changes here:
- General code cleanup in the stump-config-gen macro.
- Implement `Default` on the partial config struct generated by the macro.

The config generator macro is a couple of years old and it seems like it has been working well. I gave it a review and made a few changes to improve the ease of reading the code and eliminate what would be some clippy warnings if clippy worked on procedural macro crates. I also fixed some grammatical issues in the macro's documentation comments.

I think a shortcoming of the way config is approached is that the tests have to be updated in a lot of places whenever a new variable is added. Some of that is probably good since it forces verifying that, e.g., a fresh start will have the value that you expect. But I would also guess it feels tedious. To try and reduce that a _little_ I changed the part of the macro that generates the `PartialStumpConfig` struct so that it derives `Default`. That allowed one of the big structs in the `stump_config::test` module to end with `..Default::default()` which will eliminate the need to add new fields there in the future. 

I wonder if there are other QOL improvements that could be made to the testing approach - open to suggestions.

## Stump Contributor License Agreement

By contributing to Stump, you agree that your contributions will be licensed under the following licenses (where applicable):

- The [expo application](./apps/expo/LICENSE) is licensed under [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.html)
- All other code in the repository is licensed under [MIT License](https://www.tldrlegal.com/license/mit-license)
