### PR TITLE
🐛 (expo): OPDS v1.2 fixes

### DIFF
--- a/apps/expo/app/opds-legacy/[id]/read.tsx
+++ b/apps/expo/app/opds-legacy/[id]/read.tsx
@@ -15,8 +15,9 @@ import { db, downloadedFiles, readProgress, syncStatus } from '~/db'
 import { useReaderStore } from '~/stores'
 import { useBookPreferences, useBookTimer } from '~/stores/reader'
 
-type Params = Omit<OPDSLegacyStreamingContextValue, 'pageCount'> & {
+type Params = Omit<OPDSLegacyStreamingContextValue, 'pageCount' | 'serverLastRead'> & {
 	pageCount: string // conform to Route params, reqs being a string
+	serverLastRead?: string
 }
 
 export default function Screen() {
@@ -28,6 +29,7 @@ export default function Screen() {
 		() => ({
 			...params,
 			pageCount: getValidNumber(params.pageCount),
+			serverLastRead: getPositiveNumber(params.serverLastRead),
 		}),
 		[params],
 	)
@@ -92,6 +94,8 @@ export default function Screen() {
 		preferences: { trackElapsedTime },
 	} = useBookPreferences({ book })
 
+	const initialPage = contextValue.serverLastRead ?? 1
+
 	const timer = useBookTimer(contextValue.entryId, { enabled: trackElapsedTime })
 
 	const onPageChanged = useCallback(
@@ -155,7 +159,7 @@ export default function Screen() {
 	return (
 		<ImageBasedReader
 			serverId={serverId}
-			initialPage={1}
+			initialPage={initialPage}
 			book={book}
 			pageURL={getStreamURLForPage}
 			requestHeaders={requestHeaders}
@@ -169,4 +173,10 @@ export default function Screen() {
 const getValidNumber = (value: string) => {
 	const parsed = parseInt(value, 10)
 	return isNaN(parsed) ? -1 : parsed
+}
+
+const getPositiveNumber = (value: string | undefined): number | undefined => {
+	if (value == null) return undefined
+	const parsed = parseInt(value, 10)
+	return isNaN(parsed) || parsed <= 0 ? undefined : parsed
 }

--- a/apps/expo/context/opdsLegacy.ts
+++ b/apps/expo/context/opdsLegacy.ts
@@ -50,10 +50,10 @@ export type OPDSLegacyStreamingContextValue = {
 	entryContent: string
 	streamingURL: string
 	pageCount: number
-	// TODO: I _could_ use this for resuming, but is that the best way?
-	// It doesn't necessarily sync back as you progress, depends on server,
-	// sooooo
-	// currentPage?: number
+	/**
+	 * the last-read page reported by the server via pse:lastRead (1-indexed)
+	 */
+	serverLastRead?: number
 }
 
 export const OPDSLegacyStreamingContext = createContext<OPDSLegacyStreamingContextValue | null>(
@@ -85,11 +85,14 @@ export const getLegacyStreamingContextValue = (
 	const pageCount = pageCountLink['pse:count']
 	if (pageCount == null) return null
 
+	const serverLastRead = pageCountLink['pse:lastRead'] ?? undefined
+
 	return {
 		entryId: entry.id,
 		entryTitle: entry.title,
 		entryContent: entry.content || '',
 		streamingURL,
 		pageCount,
+		serverLastRead,
 	}
 }

--- a/packages/sdk/src/types/__tests__/opds-legacy.test.ts
+++ b/packages/sdk/src/types/__tests__/opds-legacy.test.ts
@@ -1,0 +1,27 @@
+import { legacyFeed } from '../opds-legacy'
+
+// note these tests are for the zod schema, not actual api (that would be xml)
+
+test('numeric text nodes (author name, entry/feed title) are coerced to strings', () => {
+	const raw = {
+		id: 'id',
+		title: 2099,
+		author: { name: 1942 },
+		link: [],
+		entry: [
+			{
+				id: 1,
+				title: 2099,
+				author: { name: 1942 },
+				link: [],
+			},
+		],
+	}
+
+	const feed = legacyFeed.parse(raw)
+
+	expect(feed.title).toBe('2099')
+	expect(feed.author?.name).toBe('1942')
+	expect(feed.entries[0]?.title).toBe('2099')
+	expect(feed.entries[0]?.authors[0]?.name).toBe('1942')
+})

--- a/packages/sdk/src/types/opds-legacy.ts
+++ b/packages/sdk/src/types/opds-legacy.ts
@@ -46,6 +46,10 @@ const linkRel = z
 export const isPseStreamLink = (link: OPDSLegacyLink) =>
 	link.rel === 'http://vaemendis.net/opds-pse/stream'
 
+// fast-xml-parser coerces all-digit text to numbers, so this will allow either
+// and coerce into string for us
+const coercedString = z.union([z.string(), z.number()]).transform(String)
+
 const intoValidNumber = (value: string | number) => {
 	if (typeof value === 'number') return value
 	const parsed = parseInt(value, 10)
@@ -68,7 +72,7 @@ const resolveCountFromLink = (
 const linkSchema = z
 	.object({
 		href: z.string(),
-		title: z.string().nullish(),
+		title: coercedString.nullish(),
 		type: linkType.nullish(),
 		rel: linkRel.nullish(),
 		'pse:count': z.union([z.string(), z.number()]).nullish(),
@@ -87,7 +91,7 @@ const linkSchema = z
 export type OPDSLegacyLink = z.infer<typeof linkSchema>
 
 const entryAuthor = z.object({
-	name: z.string(),
+	name: coercedString,
 	uri: z.string().nullish(),
 })
 export type OPDSLegacyEntryAuthor = z.infer<typeof entryAuthor>
@@ -102,12 +106,12 @@ const contentSchema = z
 	])
 	.transform((val) => (typeof val === 'string' ? val : val['#text']))
 
-const idSchema = z.union([z.string(), z.number()]).transform((val) => val.toString())
+const idSchema = coercedString
 
 const entry = z
 	.object({
 		id: idSchema,
-		title: z.string(),
+		title: coercedString,
 		updated: z.string().nullish(),
 		content: contentSchema.nullish(),
 		link: z.union([linkSchema, z.array(linkSchema)]).default([]),
@@ -121,15 +125,15 @@ const entry = z
 export type OPDSLegacyEntry = z.infer<typeof entry>
 
 const feedAuthor = z.object({
-	name: z.string(),
+	name: coercedString,
 	uri: z.string().nullish(),
 })
 export type OPDSLegacyFeedAuthor = z.infer<typeof feedAuthor>
 
 export const legacyFeed = z
 	.object({
-		id: z.string(),
-		title: z.string(),
+		id: coercedString,
+		title: coercedString,
 		author: feedAuthor.nullish(),
 		link: z.union([linkSchema, z.array(linkSchema)]).default([]),
 		entry: z.union([entry, z.array(entry)]).default([]),


### PR DESCRIPTION
Resolves two issues reported outside of GitHub:

1. [OPDS 1.2 + PSE Stump doesn't remember progress](https://discord.com/channels/972593831172272148/1517038975666225340)
2. [OPDS 1.2 (legacy) feed rejected — numeric <author><name> coerced to a number fails z.string()](https://discord.com/channels/972593831172272148/1517038270645669979)

## Description

This PR addresses the aforementioned issues

## Stump Contributor License Agreement

By contributing to Stump, you agree that your contributions will be licensed under the following licenses (where applicable):

- The [expo application](./apps/expo/LICENSE) is licensed under [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.html)
- All other code in the repository is licensed under [MIT License](https://www.tldrlegal.com/license/mit-license)
