### PR TITLE
🐛 (expo): Fix language key in epub reader menu

### DIFF
--- a/apps/expo/components/book/reader/epub/ReadiumFooter.tsx
+++ b/apps/expo/components/book/reader/epub/ReadiumFooter.tsx
@@ -145,7 +145,7 @@ export default function ReadiumFooter() {
 					<MenuItem
 						show={showMenu}
 						delay={50}
-						label={t('epubMenu.appearance')}
+						label={t('epubMenu.bookmarksAndAnnotations')}
 						icon={Palette}
 						onPress={() => {
 							openSheet('settings')

--- a/apps/expo/components/book/reader/epub/ReadiumFooter.tsx
+++ b/apps/expo/components/book/reader/epub/ReadiumFooter.tsx
@@ -134,7 +134,7 @@ export default function ReadiumFooter() {
 					<MenuItem
 						show={showMenu}
 						delay={100}
-						label={t('epubMenu.annotations')}
+						label={t('epubMenu.bookmarksAndAnnotations')}
 						icon={PencilLine}
 						onPress={() => {
 							openSheet('annotations')
@@ -145,7 +145,7 @@ export default function ReadiumFooter() {
 					<MenuItem
 						show={showMenu}
 						delay={50}
-						label={t('epubMenu.bookmarksAndAnnotations')}
+						label={t('epubMenu.appearance')}
 						icon={Palette}
 						onPress={() => {
 							openSheet('settings')


### PR DESCRIPTION
## Description

The new EPUB menu added is showing its language key for the 'annotations and bookmarks', due to mislabelling of the language key. It now references the correct language key.

## Ready?

Please read each item and check the boxes:

- [X] I read the [contributing guidelines](https://github.com/stumpapp/stump/blob/main/.github/CONTRIBUTING.md)
- [X] I searched for existing issues or pull requests that may be related to my contribution
- [X] This PR is based into `nightly` and not `main`
- [X] I added tests and/or documentation for my changes if applicable

## Stump Contributor License Agreement

By contributing to Stump, you agree that your contributions will be licensed under the following licenses (where applicable):

- The [expo application](https://github.com/stumpapp/stump/blob/main/apps/expo/LICENSE) is licensed under [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.html)
- All other code in the repository is licensed under [MIT License](https://www.tldrlegal.com/license/mit-license)
