### PR TITLE
fix(i18n): improve Korean preferences translations

### DIFF
--- a/packages/browser/src/scenes/settings/app/preferences/AppearanceSettingsScene.tsx
+++ b/packages/browser/src/scenes/settings/app/preferences/AppearanceSettingsScene.tsx
@@ -88,8 +88,8 @@ export default function AppearanceSettingsScene() {
 					</NewCard>
 
 					<NewCard
-						label="Display and spacing"
-						description="Preferences related to the presentation of content and information"
+						label={t(getKey('displayAndSpacing.label'))}
+						description={t(getKey('displayAndSpacing.description'))}
 					>
 						<DisplaySpacingPreference />
 						<MaxWidthPreference />
@@ -106,25 +106,24 @@ export default function AppearanceSettingsScene() {
 						</p>
 					</div>
 
-					{/* TODO: localize after finalizing groups */}
 					<NewCard
-						label="Content browsing"
-						description="Preferences that affect browsing and navigating content lists"
+						label={t(getKey('contentBrowsing.label'))}
+						description={t(getKey('contentBrowsing.description'))}
 					>
 						<EnableAlphabetFiltering />
 					</NewCard>
 
 					<NewCard
-						label="Motion and animation"
-						description="Visual presentation and movement preferences"
+						label={t(getKey('motionAndAnimation.label'))}
+						description={t(getKey('motionAndAnimation.description'))}
 					>
 						<EnableFancyAnimations />
 						<HideScrollbarToggle />
 					</NewCard>
 
 					<NewCard
-						label="Activity and status"
-						description="Indicators, overlays, or functionality related to background activity"
+						label={t(getKey('activityAndStatus.label'))}
+						description={t(getKey('activityAndStatus.description'))}
 					>
 						<QueryIndicatorToggle />
 						<LiveRefetchToggle />

--- a/packages/browser/src/scenes/settings/app/preferences/InterfaceRoundnessPreference.tsx
+++ b/packages/browser/src/scenes/settings/app/preferences/InterfaceRoundnessPreference.tsx
@@ -1,12 +1,13 @@
 import { NewCard } from '@stump/components'
 import { InterfaceRoundness } from '@stump/graphql'
+import { useLocaleContext } from '@stump/i18n'
 
 import { usePreferences } from '@/hooks'
 
 import RadioTileGroup from './RadioTileGroup'
 
-// TODO(i18n): add key/values
 export default function InterfaceRoundnessPreference() {
+	const { t } = useLocaleContext()
 	const {
 		preferences: { interfaceRoundness },
 		update,
@@ -23,32 +24,29 @@ export default function InterfaceRoundnessPreference() {
 	}
 
 	return (
-		<NewCard.Row
-			label="Interface roundness"
-			description="How rounded the corners are for UI elements"
-		>
+		<NewCard.Row label={t(getKey('label'))} description={t(getKey('description'))}>
 			<RadioTileGroup
 				value={interfaceRoundness || InterfaceRoundness.Normal}
 				onChange={handleChange}
 				columns={4}
 				options={[
 					{
-						label: 'None',
+						label: t(getKey('options.none')),
 						value: InterfaceRoundness.None,
 						preview: <RoundnessPreview value={InterfaceRoundness.None} />,
 					},
 					{
-						label: 'Normal',
+						label: t(getKey('options.normal')),
 						value: InterfaceRoundness.Normal,
 						preview: <RoundnessPreview value={InterfaceRoundness.Normal} />,
 					},
 					{
-						label: 'Rounded',
+						label: t(getKey('options.rounded')),
 						value: InterfaceRoundness.Rounded,
 						preview: <RoundnessPreview value={InterfaceRoundness.Rounded} />,
 					},
 					{
-						label: 'Pill',
+						label: t(getKey('options.pill')),
 						value: InterfaceRoundness.Pill,
 						preview: <RoundnessPreview value={InterfaceRoundness.Pill} />,
 					},
@@ -57,6 +55,9 @@ export default function InterfaceRoundnessPreference() {
 		</NewCard.Row>
 	)
 }
+
+const LOCALE_BASE = 'settingsScene.app/preferences.sections.interfaceRoundness'
+const getKey = (key: string) => `${LOCALE_BASE}.${key}`
 
 const ROUNDNESS_PREVIEW_RADIUS: Record<InterfaceRoundness, number> = {
 	[InterfaceRoundness.None]: 0,

--- a/packages/i18n/src/locales/en-US.json
+++ b/packages/i18n/src/locales/en-US.json
@@ -1476,6 +1476,16 @@
 					"label": "Font",
 					"description": "Customize the font used in the application"
 				},
+				"interfaceRoundness": {
+					"label": "Interface roundness",
+					"description": "How rounded the corners are for UI elements",
+					"options": {
+						"none": "None",
+						"normal": "Normal",
+						"rounded": "Rounded",
+						"pill": "Pill"
+					}
+				},
 				"thumbnailPreview": {
 					"label": "Preview",
 					"description": "This is how thumbnails will look with the current settings"
@@ -1575,9 +1585,25 @@
 						"noLimit": "No limit"
 					}
 				},
+				"displayAndSpacing": {
+					"label": "Display and spacing",
+					"description": "Preferences related to the presentation of content and information"
+				},
 				"additionalPreferences": {
 					"label": "Additional preferences",
 					"description": "Customize the appearance and behavior of Stump with these additional settings"
+				},
+				"contentBrowsing": {
+					"label": "Content browsing",
+					"description": "Preferences that affect browsing and navigating content lists"
+				},
+				"motionAndAnimation": {
+					"label": "Motion and animation",
+					"description": "Visual presentation and movement preferences"
+				},
+				"activityAndStatus": {
+					"label": "Activity and status",
+					"description": "Indicators, overlays, or functionality related to background activity"
 				},
 				"hideScrollbarToggle": {
 					"label": "Hide scrollbar",

--- a/packages/i18n/src/locales/ko-KR.json
+++ b/packages/i18n/src/locales/ko-KR.json
@@ -1433,187 +1433,213 @@
 			}
 		},
 		"app/preferences": {
-			"helmet": "Appearance",
-			"title": "Appearance",
-			"description": "Customize the look and feel of the application",
+			"helmet": "환경설정",
+			"title": "환경설정",
+			"description": "애플리케이션의 모양과 사용감을 사용자화합니다",
 			"sections": {
 				"themeAndAppearance": {
-					"label": "Theme and appearance",
-					"description": "The basic look and feel options for Stump"
+					"label": "테마와 모양",
+					"description": "Stump의 기본적인 모양과 느낌 옵션"
 				},
 				"interface": {
-					"title": "Interface",
-					"description": "Primary UI surfaces and interaction elements"
+					"title": "인터페이스",
+					"description": "주요 UI 화면과 상호작용 요소"
 				},
 				"thumbnails": {
-					"title": "Thumbnails",
-					"description": "Display options for thumbnail images"
+					"title": "썸네일",
+					"description": "썸네일 이미지 표시 옵션"
 				},
 				"themeSelect": {
 					"label": "테마",
 					"description": [
-						"If you're interested in creating your own custom theme, check out the",
-						"documentation"
+						"직접 커스텀 테마를 만들고 싶다면",
+						"문서"
 					],
 					"options": {
-						"system": "System",
-						"light": "Light",
-						"dark": "Dark",
-						"bronze": "Bronze light",
-						"ocean": "Ocean",
-						"autumn": "Autumn",
-						"cosmic": "Cosmic",
-						"pumpkin": "Pumpkin",
+						"system": "시스템",
+						"light": "라이트",
+						"dark": "다크",
+						"bronze": "브론즈 라이트",
+						"ocean": "오션",
+						"autumn": "어텀",
+						"cosmic": "코스믹",
+						"pumpkin": "펌킨",
 						"midnight": "Midnight",
 						"matrix": "Matrix"
 					}
 				},
 				"gradientToggle": {
-					"label": "Enable gradients",
-					"description": "Some themes optionally support gradients for a more dynamic look"
+					"label": "그라데이션 사용",
+					"description": "일부 테마는 더 동적인 느낌을 위해 그라데이션을 지원합니다"
 				},
 				"fontSelect": {
-					"label": "Font",
-					"description": "Customize the font used in the application"
+					"label": "글꼴",
+					"description": "애플리케이션에서 사용할 글꼴을 설정합니다"
+				},
+				"interfaceRoundness": {
+					"label": "인터페이스 둥글기",
+					"description": "UI 요소의 모서리를 얼마나 둥글게 표시할지 설정합니다",
+					"options": {
+						"none": "없음",
+						"normal": "보통",
+						"rounded": "둥글게",
+						"pill": "알약형"
+					}
 				},
 				"thumbnailPreview": {
-					"label": "Preview",
-					"description": "This is how thumbnails will look with the current settings"
+					"label": "미리보기",
+					"description": "현재 설정에서 썸네일이 이렇게 표시됩니다"
 				},
 				"thumbnailRatioSelect": {
-					"label": "Thumbnail Ratio",
-					"description": "The aspect ratio to use for thumbnails",
-					"defaultSuffix": "Default"
+					"label": "썸네일 비율",
+					"description": "썸네일에 사용할 가로세로 비율",
+					"defaultSuffix": "기본값"
 				},
 				"thumbnailPlaceholder": {
-					"label": "Thumbnail placeholder",
-					"description": "The style to use for thumbnail placeholders",
+					"label": "썸네일 플레이스홀더",
+					"description": "썸네일 플레이스홀더에 사용할 스타일",
 					"options": {
-						"grayscale": "Grayscale",
-						"averageColor": "Average color",
-						"colorful": "Colorful",
+						"grayscale": "회색조",
+						"averageColor": "평균 색상",
+						"colorful": "컬러풀",
 						"thumbhash": "Thumbhash"
 					}
 				},
 				"thumbnailRoundness": {
-					"label": "Thumbnail roundness",
-					"description": "How rounded the corners of thumbnail images should be",
+					"label": "썸네일 둥글기",
+					"description": "썸네일 이미지의 모서리를 얼마나 둥글게 표시할지 설정합니다",
 					"options": {
-						"none": "None",
-						"normal": "Normal",
-						"rounded": "Rounded",
-						"large": "Large"
+						"none": "없음",
+						"normal": "보통",
+						"rounded": "둥글게",
+						"large": "크게"
 					}
 				},
 				"navigation": {
-					"title": "Navigation",
-					"description": "Customize the navigation elements of the app"
+					"title": "내비게이션",
+					"description": "앱의 내비게이션 요소를 사용자화합니다"
 				},
 				"layoutAndArrangement": {
-					"label": "Layout and arrangement",
-					"description": "Customize how Stump displays information and organizes content"
+					"label": "레이아웃과 배치",
+					"description": "Stump가 정보를 표시하고 콘텐츠를 구성하는 방식을 사용자화합니다"
 				},
 				"primaryNavigation": {
-					"label": "Primary navigation",
-					"description": "Choose between a minimal sidebar or a topbar navigation",
+					"label": "기본 내비게이션",
+					"description": "간단한 사이드바와 상단바 내비게이션 중 선택합니다",
 					"options": {
-						"sidebar": "Sidebar",
-						"topbar": "Topbar"
+						"sidebar": "사이드바",
+						"topbar": "상단바"
 					},
-					"disclaimer": "* Settings for the unselected option will be disabled or hidden"
+					"disclaimer": "* 선택하지 않은 옵션의 설정은 비활성화되거나 숨겨집니다"
 				},
 				"doubleSidebar": {
-					"label": "Settings sidebar",
-					"description": "Enables sidebar navigation for the settings pages"
+					"label": "설정 사이드바",
+					"description": "설정 페이지에서 사이드바 내비게이션을 사용합니다"
 				},
 				"replacePrimarySidebar": {
-					"label": "Replace primary sidebar",
-					"description": "Any instance of a secondary sidebar will replace the primary sidebar instead of stacking them",
+					"label": "기본 사이드바 대체",
+					"description": "보조 사이드바가 기본 사이드바 위에 쌓이지 않고 기본 사이드바를 대체합니다",
 					"tooltips": {
-						"doubleSidebar": "This setting requires the settings sidebar to be enabled",
-						"topbar": "This setting is not currently supported when the primary navigation is set to top bar"
+						"doubleSidebar": "이 설정을 사용하려면 설정 사이드바가 활성화되어야 합니다",
+						"topbar": "기본 내비게이션이 상단바일 때는 현재 이 설정을 지원하지 않습니다"
 					}
 				},
 				"navigationArrangement": {
-					"label": "Navigation arrangement",
-					"description": "Rearrange or tweak the navigation items in your primary navigation",
-					"isLocked": "Arrangement is locked",
-					"lock": "Lock arrangement",
-					"unlock": "Unlock arrangement",
+					"label": "내비게이션 배치",
+					"description": "기본 내비게이션 항목을 재배치하거나 조정합니다",
+					"isLocked": "배치가 잠겨 있습니다",
+					"lock": "배치 잠금",
+					"unlock": "배치 잠금 해제",
 					"options": {
-						"HOME": "Home",
-						"EXPLORE": "Explore",
-						"LIBRARIES": "Libraries",
-						"BOOK_CLUBS": "Book clubs",
-						"SMART_LISTS": "Smart lists"
+						"HOME": "홈",
+						"EXPLORE": "탐색",
+						"LIBRARIES": "라이브러리",
+						"BOOK_CLUBS": "북클럽",
+						"SMART_LISTS": "스마트 목록"
 					},
 					"entityOptions": {
 						"createAction": {
-							"label": "Show create action",
-							"help": "Show the create action in the navigation"
+							"label": "생성 액션 표시",
+							"help": "내비게이션에 생성 액션을 표시합니다"
 						},
 						"linkToAll": {
-							"label": "See all link",
-							"help": "A link to a page dedicated to viewing all items of this type"
+							"label": "전체 보기 링크",
+							"help": "이 유형의 모든 항목을 보는 전용 페이지 링크"
 						}
 					}
 				},
 				"displaySpacing": {
-					"label": "Display spacing",
-					"description": "Adjusts the overall spacing between elements throughout the app",
+					"label": "표시 간격",
+					"description": "앱 전체 요소 사이의 전반적인 간격을 조정합니다",
 					"options": {
-						"default": "Default",
-						"compact": "Compact"
+						"default": "기본값",
+						"compact": "압축"
 					},
-					"disclaimer": "* Compact display mode is not implemented yet"
+					"disclaimer": "* 압축 표시 모드는 아직 구현되지 않았습니다"
 				},
 				"maxWidthPreference": {
-					"label": "Adjusted width",
-					"description": "Stump applies a max-width to the viewport. This setting allows you to adjust or remove this limit",
-					"tooltip": "This setting is not currently supported when the primary navigation is set to sidebar",
+					"label": "화면 너비",
+					"description": "Stump는 화면 영역에 최대 너비를 적용합니다. 이 설정으로 제한을 조정하거나 제거할 수 있습니다",
+					"tooltip": "기본 내비게이션이 사이드바일 때는 현재 이 설정을 지원하지 않습니다",
 					"options": {
-						"noLimit": "No limit"
+						"noLimit": "제한 없음"
 					}
 				},
+				"displayAndSpacing": {
+					"label": "표시와 간격",
+					"description": "콘텐츠와 정보 표시 방식 관련 설정"
+				},
 				"additionalPreferences": {
-					"label": "Additional preferences",
-					"description": "Customize the appearance and behavior of Stump with these additional settings"
+					"label": "추가 환경설정",
+					"description": "추가 설정으로 Stump의 모양과 동작을 사용자화합니다"
+				},
+				"contentBrowsing": {
+					"label": "콘텐츠 탐색",
+					"description": "콘텐츠 목록을 탐색하고 이동하는 방식에 영향을 주는 설정"
+				},
+				"motionAndAnimation": {
+					"label": "모션과 애니메이션",
+					"description": "시각적 움직임과 애니메이션 관련 설정"
+				},
+				"activityAndStatus": {
+					"label": "활동 및 상태",
+					"description": "백그라운드 활동과 관련된 표시, 오버레이, 기능 설정"
 				},
 				"hideScrollbarToggle": {
-					"label": "Hide scrollbar",
-					"description": "Some pages simply look better without a scrollbar, this setting will hide it when possible",
+					"label": "스크롤바 숨기기",
+					"description": "일부 페이지는 스크롤바가 없을 때 더 보기 좋습니다. 가능한 경우 스크롤바를 숨깁니다",
 					"tooltips": {
-						"enabled": "This setting will hide the scrollbar on some pages",
-						"disabled": "This setting will show the scrollbar on some pages"
+						"enabled": "일부 페이지에서 스크롤바를 숨깁니다",
+						"disabled": "일부 페이지에서 스크롤바를 표시합니다"
 					}
 				},
 				"enableAlphabetFiltering": {
-					"label": "Alphabet filtering",
-					"description": "Show an alphabet filter when applicable"
+					"label": "알파벳 필터",
+					"description": "사용 가능한 곳에 알파벳 필터를 표시합니다"
 				},
 				"enableFancyAnimations": {
-					"label": "Fancy animations",
-					"description": "A broad opt-in for fancier animations throughout the app"
+					"label": "화려한 애니메이션",
+					"description": "앱 전반에서 더 화려한 애니메이션을 사용합니다"
 				},
 				"queryIndicatorToggle": {
-					"label": "Background fetch indicator",
-					"description": "Show a loading indicator whenever a query is running in the background"
+					"label": "백그라운드 가져오기 표시기",
+					"description": "백그라운드에서 쿼리가 실행 중일 때마다 로딩 표시기를 표시합니다"
 				},
 				"liveRefetchToggle": {
-					"label": "Live refetch",
-					"description": "Refetch queries on the fly to hydrate the UI with new data as it comes in. This can be resource intensive"
+					"label": "실시간 다시 가져오기",
+					"description": "새 데이터가 들어오는 즉시 쿼리를 다시 가져와 UI를 갱신합니다. 리소스를 많이 사용할 수 있습니다"
 				},
 				"enableJobOverlayToggle": {
-					"label": "Job overlay",
-					"description": "Show a floating overlay while a job is running"
+					"label": "작업 오버레이",
+					"description": "작업이 실행 중일 때 떠 있는 오버레이를 표시합니다"
 				},
 				"dayResetHourOffset": {
-					"label": "Reading day reset offset",
-					"description": "Shift when a reading day resets, in hours from midnight"
+					"label": "독서일 초기화 오프셋",
+					"description": "독서일이 초기화되는 시간을 자정 기준 시간 단위로 조정합니다"
 				},
 				"readingSessionGracePeriod": {
-					"label": "Reading session grace period",
-					"description": "If no activity is detected within this time frame, in seconds, the next update will start a new session"
+					"label": "독서 세션 유예 시간",
+					"description": "이 시간(초) 동안 활동이 없으면 다음 업데이트가 새 세션을 시작합니다"
 				}
 			}
 		},
@@ -2645,7 +2671,7 @@
 			"tooManyFiles": "You have selected too many files",
 			"noValidFiles": "No valid files were selected"
 		},
-		"unknownError": "An unknown error occurred"
+		"unknownError": "알 수 없는 오류가 발생했습니다"
 	},
 	"userPermissions": {
 		"ACCESS_API_KEYS": {
@@ -2837,17 +2863,17 @@
 			"markAsRead": {
 				"label": "Mark as Read",
 				"confirmation": "Are you sure you want to mark {{bookTitle}} as read?",
-				"failure": "Failed to mark book as read"
+				"failure": "책을 읽음으로 표시하지 못했습니다"
 			},
 			"clearProgress": {
 				"label": "Clear Progress",
 				"confirmation": "Are you sure you want to clear your progress for {{bookTitle}}?",
-				"failure": "Failed to delete current progress"
+				"failure": "현재 진행률을 삭제하지 못했습니다"
 			},
 			"deleteReadHistory": {
 				"label": "Delete Read History",
 				"confirmation": "Are you sure you want to delete your read history for {{bookTitle}}?",
-				"failure": "Failed to delete read history"
+				"failure": "읽기 기록을 삭제하지 못했습니다"
 			},
 			"deleteBook": {
 				"label": "Delete Book",


### PR DESCRIPTION
## Description

This PR improves Korean localization coverage for the app Preferences screen.

- Replaces remaining hardcoded Preferences card labels/descriptions with i18n keys.
- Localizes the interface roundness preference label, description, and tile options.
- Adds the corresponding `en-US` source locale keys.
- Updates `ko-KR` Preferences translations and fills missing `common.unknownError` / mobile book action failure keys.

How to contribute: https://github.com/stumpapp/stump/blob/main/.github/CONTRIBUTING.md

Validation performed:

- `ko-KR` locale parity check: `en keys 1844 ko keys 1844 missing in ko 0 extra in ko 0`
- `git diff --check`
- `corepack yarn prettier --config prettier.config.js --check packages/browser/src/scenes/settings/app/preferences/AppearanceSettingsScene.tsx packages/browser/src/scenes/settings/app/preferences/InterfaceRoundnessPreference.tsx packages/i18n/src/locales/en-US.json packages/i18n/src/locales/ko-KR.json`
- `corepack yarn workspace @stump/i18n check-types`
- `corepack yarn workspace @stump/browser check-types`
- `corepack yarn workspace @stump/browser lint` exited 0 with existing warnings

## Screenshots

Not included. This PR updates localization coverage and i18n wiring for existing UI text.

## Ready?

Please read each item and check the boxes:

- [x] I read the [contributing guidelines](https://github.com/stumpapp/stump/blob/main/.github/CONTRIBUTING.md)
- [x] I searched for existing issues or pull requests that may be related to my contribution
- [x] This PR is based into `nightly` and not `main`
- [x] I added tests and/or documentation for my changes if applicable

## Stump Contributor License Agreement

By contributing to Stump, you agree that your contributions will be licensed under the following licenses (where applicable):

- The [expo application](https://github.com/stumpapp/stump/blob/main/apps/expo/LICENSE) is licensed under [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.html)
- All other code in the repository is licensed under [MIT License](https://www.tldrlegal.com/license/mit-license)
