### PR TITLE
:bug: Fix 500 error for KOReader progression fetch

### DIFF
--- a/apps/server/src/routers/koreader/sync.rs
+++ b/apps/server/src/routers/koreader/sync.rs
@@ -124,7 +124,7 @@ async fn get_progress(
 	let user = req.user();
 	let document_cpy = document.clone();
 
-	let latest_query = reading_session::Entity::find()
+	let latest_query = reading_session::ModelWithDevice::find()
 		.inner_join(media::Entity)
 		.filter(reading_session::Column::UserId.eq(user.id.clone()))
 		.filter(media::Column::KoreaderHash.eq(document_cpy.clone()))

--- a/apps/server/tests/api_tests.rs
+++ b/apps/server/tests/api_tests.rs
@@ -1,4 +1,5 @@
 mod common;
+mod koreader;
 mod opds;
 mod reading_progress;
 

--- a/apps/server/tests/common/api_key.rs
+++ b/apps/server/tests/common/api_key.rs
@@ -1,0 +1,36 @@
+use models::{
+	entity::{api_key, user},
+	shared::api_key::{APIKeyPermissions, InheritPermissionValue},
+};
+use sea_orm::{ActiveModelTrait, ActiveValue::Set};
+use stump_core::api_key::create_prefixed_key;
+
+use crate::common::TestApp;
+
+pub async fn create_api_key_for_user(
+	app: &TestApp,
+	user: &user::Model,
+	permissions: Option<APIKeyPermissions>,
+) -> (String, api_key::Model) {
+	let conn = app.conn();
+
+	let (prefixed_key, hash) = create_prefixed_key().expect("failed to create API key");
+	let api_key_string = prefixed_key.to_string();
+
+	let api_key_model = api_key::ActiveModel {
+		user_id: Set(user.id.clone()),
+		name: Set("test-api-key".to_string()),
+		short_token: Set(prefixed_key.short_token().to_string()),
+		long_token_hash: Set(hash),
+		permissions: Set(permissions
+			.unwrap_or(APIKeyPermissions::Inherit(InheritPermissionValue::Inherit))),
+		..Default::default()
+	};
+
+	let inserted_api_key = api_key_model
+		.insert(conn)
+		.await
+		.expect("failed to insert API key");
+
+	(api_key_string, inserted_api_key)
+}

--- a/apps/server/tests/common/mod.rs
+++ b/apps/server/tests/common/mod.rs
@@ -1,4 +1,5 @@
 pub mod account;
+pub mod api_key;
 pub mod book;
 pub mod series;
 

--- a/apps/server/tests/koreader/mod.rs
+++ b/apps/server/tests/koreader/mod.rs
@@ -1,0 +1,1 @@
+mod progress;

--- a/apps/server/tests/koreader/progress.rs
+++ b/apps/server/tests/koreader/progress.rs
@@ -1,0 +1,156 @@
+use crate::common::{
+	api_key::create_api_key_for_user, series::setup_single_series_with_n_books, TestApp,
+};
+use models::{
+	entity::{media, user},
+	shared::{
+		api_key::APIKeyPermissions,
+		enums::{ReadingStatus, UserPermission},
+	},
+};
+use sea_orm::{ActiveModelTrait, ActiveValue::Set, IntoActiveModel};
+use tests::fake_data;
+
+async fn setup() -> (TestApp, String, media::Model, user::Model) {
+	let app = TestApp::new().await;
+	let db = app.conn();
+
+	let user = fake_data::User::new("koreader").insert(db).await;
+
+	let (token, _) = create_api_key_for_user(
+		&app,
+		&user,
+		Some(APIKeyPermissions::Custom(vec![
+			UserPermission::AccessKoreaderSync,
+		])),
+	)
+	.await;
+
+	let image = fake_data::Library {
+		id: Some("image".to_string()),
+		name: Some("Image".to_string()),
+		..Default::default()
+	}
+	.insert(db)
+	.await;
+
+	let (_, books) = setup_single_series_with_n_books(
+		&app,
+		fake_data::Series {
+			id: Some("black_science".to_string()),
+			name: Some("Black Science".to_string()),
+			library_id: Some(image.id.clone()),
+			..Default::default()
+		},
+		1,
+	)
+	.await;
+
+	let koreader_hash = "abc123".to_string();
+	let mut active_book = books
+		.into_iter()
+		.next()
+		.expect("should have at least one book")
+		.into_active_model();
+	active_book.koreader_hash = Set(Some(koreader_hash.clone()));
+
+	let media = active_book
+		.update(db)
+		.await
+		.expect("failed to update media with koreader_hash");
+
+	(app, token, media, user)
+}
+
+#[tokio::test]
+async fn test_get_progress_no_session_exists() {
+	let (app, api_key, media, _) = setup().await;
+
+	let koreader_hash = media.koreader_hash.clone().expect("should be set");
+	let path = format!("/koreader/{}/syncs/progress/{}", api_key, koreader_hash);
+
+	let response = app.server.get(&path).await;
+
+	response.assert_status_ok();
+
+	let body: serde_json::Value = response.json();
+
+	assert_eq!(
+		body["document"].as_str().expect("should be set"),
+		koreader_hash.as_str()
+	);
+	assert!(body["percentage"].is_null());
+	assert!(body["progress"].is_null());
+}
+
+#[tokio::test]
+async fn test_get_progress_active_session() {
+	let (app, api_key, media, user) = setup().await;
+	let db = app.conn();
+
+	fake_data::ReadingSession {
+		media_id: media.id.clone(),
+		user_id: user.id.clone(),
+		end_percentage: 0.42,
+		status: ReadingStatus::Reading,
+		..Default::default()
+	}
+	.insert(db)
+	.await;
+
+	let koreader_hash = media.koreader_hash.clone().expect("should be set");
+	let path = format!("/koreader/{}/syncs/progress/{}", api_key, koreader_hash);
+
+	let response = app.server.get(&path).await;
+
+	response.assert_status_ok();
+
+	let body: serde_json::Value = response.json();
+
+	assert_eq!(
+		body["document"].as_str().expect("should be set"),
+		koreader_hash.as_str()
+	);
+	assert_eq!(
+		body["percentage"].as_f64().unwrap(),
+		0.42,
+		"expected 42% progress"
+	);
+	assert!(body["timestamp"].is_number(), "timestamp should be set");
+}
+
+#[tokio::test]
+async fn test_get_progress_completed_session() {
+	let (app, api_key, media, user) = setup().await;
+	let db = app.conn();
+
+	fake_data::ReadingSession {
+		media_id: media.id.clone(),
+		user_id: user.id.clone(),
+		end_percentage: 1.0,
+		status: ReadingStatus::Finished,
+		..Default::default()
+	}
+	.insert(db)
+	.await;
+
+	let koreader_hash = media.koreader_hash.clone().expect("should be set");
+	let path = format!("/koreader/{}/syncs/progress/{}", api_key, koreader_hash);
+
+	let response = app.server.get(&path).await;
+
+	response.assert_status_ok();
+
+	let body: serde_json::Value = response.json();
+
+	assert_eq!(
+		body["document"].as_str().expect("should be set"),
+		koreader_hash.as_str()
+	);
+	assert_eq!(
+		body["percentage"].as_f64().unwrap(),
+		1.0,
+		"expected 100% completion"
+	);
+	assert!(body["timestamp"].is_number(), "timestamp should be set");
+}

--- a/core/src/config/stump_config.rs
+++ b/core/src/config/stump_config.rs
@@ -185,6 +185,7 @@ pub struct StumpConfig {
 	/// Indicates if the KoReader sync feature should be enabled.
 	#[default_value(false)]
 	#[env_key(ENABLE_KOREADER_SYNC_KEY)]
+	#[debug_value(true)]
 	pub enable_koreader_sync: bool,
 
 	/// Indicates if the Kobo sync feature should be enabled.

--- a/crates/models/src/entity/api_key.rs
+++ b/crates/models/src/entity/api_key.rs
@@ -1,5 +1,8 @@
 use async_graphql::SimpleObject;
-use sea_orm::{entity::prelude::*, FromQueryResult, JoinType, QuerySelect};
+use sea_orm::{
+	entity::prelude::{async_trait::async_trait, *},
+	ActiveValue, FromQueryResult, JoinType, QuerySelect,
+};
 
 use crate::{
 	prefixer::{parse_query_to_model, Prefixer},
@@ -27,10 +30,7 @@ pub struct Model {
 	#[sea_orm(column_type = "Json", nullable)]
 	#[graphql(skip)]
 	pub permissions: APIKeyPermissions,
-	#[sea_orm(
-		column_type = "custom(\"DATETIME\")",
-		default_value = "CURRENT_TIMESTAMP"
-	)]
+	#[sea_orm(column_type = "custom(\"DATETIME\")")]
 	pub created_at: DateTimeWithTimeZone,
 	#[sea_orm(column_type = "custom(\"DATETIME\")", nullable)]
 	pub last_used_at: Option<DateTimeWithTimeZone>,
@@ -111,4 +111,15 @@ impl Related<super::user::Entity> for Entity {
 	}
 }
 
-impl ActiveModelBehavior for ActiveModel {}
+#[async_trait]
+impl ActiveModelBehavior for ActiveModel {
+	async fn before_save<C>(mut self, _db: &C, insert: bool) -> Result<Self, DbErr>
+	where
+		C: ConnectionTrait,
+	{
+		if insert {
+			self.created_at = ActiveValue::Set(chrono::Utc::now().into());
+		}
+		Ok(self)
+	}
+}

--- a/crates/models/src/entity/reading_session.rs
+++ b/crates/models/src/entity/reading_session.rs
@@ -118,7 +118,7 @@ impl ModelWithDevice {
 			*/
 			// which _works_ but the former condition is redundant and will never actually match anything,
 			// but sea-orm seems to always imbue the join with that default predicate...
-			.join_rev(
+			.join(
 				JoinType::LeftJoin,
 				Entity::belongs_to(reading_device::Entity)
 					.from(Column::DeviceIds)

--- a/crates/tests/src/db.rs
+++ b/crates/tests/src/db.rs
@@ -1,8 +1,8 @@
 use models::entity::{
-	age_restriction, kobo_sync_session, library, library_config, library_exclusion,
-	media, media_analysis, media_metadata, media_tag, reading_device, reading_session,
-	refresh_token, series, series_metadata, server_config, session, tag, user,
-	user_preferences,
+	age_restriction, api_key, kobo_sync_session, library, library_config,
+	library_exclusion, media, media_analysis, media_metadata, media_tag, reading_device,
+	reading_session, refresh_token, series, series_metadata, server_config, session, tag,
+	user, user_preferences,
 };
 use sea_orm::{ConnectionTrait, Database, DbBackend, DbConn, DbErr, Schema};
 pub async fn test_database() -> DbConn {
@@ -21,6 +21,7 @@ pub async fn create_database_tables(db: &DbConn) -> Result<(), DbErr> {
 	let schema = Schema::new(DbBackend::Sqlite);
 
 	let tables = [
+		schema.create_table_from_entity(api_key::Entity),
 		schema.create_table_from_entity(media::Entity),
 		schema.create_table_from_entity(media_metadata::Entity),
 		schema.create_table_from_entity(media_analysis::Entity),


### PR DESCRIPTION
Fixes #1279

## Description

- Update selection to fix query error (the existing `ModelWithDevice` abstraction over the plain model)
- Add tests to assert fix

I have not tested on an actual koreader device, but the tests to assert the change corrects the 500 (just revert sync.rs and observe the 500s)

## Stump Contributor License Agreement

By contributing to Stump, you agree that your contributions will be licensed under the following licenses (where applicable):

- The [expo application](https://github.com/stumpapp/stump/blob/main/apps/expo/LICENSE) is licensed under [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.html)
- All other code in the repository is licensed under [MIT License](https://www.tldrlegal.com/license/mit-license)
