### PR TITLE
Remove unused cargo command in yarn run setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 	"scripts": {
 		"prepare": "husky",
 		"postinstall": "patch-package",
-		"setup": "yarn && yarn web build && cargo codegen",
+		"setup": "yarn && yarn web build",
 		"lint": "lerna run lint --stream --parallel && yarn check-types",
 		"check-types": "lerna run check-types  --stream --parallel --ignore @stump/expo",
 		"test": "lerna run test",


### PR DESCRIPTION
## Description

The `yarn run setup` task was including a now deprecated use of a tool (`cargo codegen`) which is missing and thus exiting with an error when first setting up the repo for development.

## Ready?

Please read each item and check the boxes:

- [X] I read the [contributing guidelines](https://github.com/stumpapp/stump/blob/main/.github/CONTRIBUTING.md)
- [X] I searched for existing issues or pull requests that may be related to my contribution
- [X] This PR is based into `nightly` and not `main`
- [X] I added tests and/or documentation for my changes if applicable

## Stump Contributor License Agreement

By contributing to Stump, you agree that your contributions will be licensed under the following licenses (where applicable):

- The [expo application](https://github.com/stumpapp/stump/blob/main/apps/expo/LICENSE) is licensed under [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.html)
- All other code in the repository is licensed under [MIT License](https://www.tldrlegal.com/license/mit-license)
