### PR TITLE
📝 Fix references to "Windows Service" in the documentation.

### DIFF
--- a/docs/content/docs/getting-started/installation/binaries.mdx
+++ b/docs/content/docs/getting-started/installation/binaries.mdx
@@ -100,13 +100,9 @@ sudo chmod +x stump_server
 
 ## Additional guides
 
-### Setup a Windows service
+### Setup a systemd service
 
-<Callout type="info">
-  This section is only relevant for Windows users
-</Callout>
-
-You can optionally setup a Windows service to run Stump in the background. Here's an example of a Windows service file (provided by [@KrautByte](https://github.com/KrautByte)):
+You can optionally setup a systemd unit to run Stump in the background. Here's an example of a systemd unit file (provided by [@KrautByte](https://github.com/KrautByte)):
 
 ```ini copy
 [Unit]


### PR DESCRIPTION
Closes #1287 

## Description

Updates documentation to refer to a systemd unit file instead of a windows service - the code example given is a systemd unit file.

## Ready?

Please read each item and check the boxes:

- [x] I read the [contributing guidelines](https://github.com/stumpapp/stump/blob/main/.github/CONTRIBUTING.md)
- [x] I searched for existing issues or pull requests that may be related to my contribution
- [x] This PR is based into `nightly` and not `main`
- [x] I added tests and/or documentation for my changes if applicable

## Stump Contributor License Agreement

By contributing to Stump, you agree that your contributions will be licensed under the following licenses (where applicable):

- The [expo application](https://github.com/stumpapp/stump/blob/main/apps/expo/LICENSE) is licensed under [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.html)
- All other code in the repository is licensed under [MIT License](https://www.tldrlegal.com/license/mit-license)
