### PR TITLE
:adhesive_bandage: Auto-append port for non-IP origins

### DIFF
--- a/apps/server/src/middleware/host.rs
+++ b/apps/server/src/middleware/host.rs
@@ -133,14 +133,16 @@ fn resolve_host(host: String, scheme: &str, port: u16, via_proxy: bool) -> Strin
 		return host;
 	}
 
+	let is_ip_address = host.parse::<std::net::IpAddr>().is_ok();
+
 	// is a bit naive but feels safe
 	let is_default =
 		(scheme == "http" && port == 80) || (scheme == "https" && port == 443);
 
-	if is_default {
-		host
-	} else {
+	if !is_default && is_ip_address {
 		format!("{}:{}", host, port)
+	} else {
+		host
 	}
 }
 
@@ -344,5 +346,30 @@ mod tests {
 	fn test_no_append_port_via_proxy_non_standard_public_port() {
 		let result = resolve_host("myserver.com:8443".to_string(), "https", 10801, true);
 		assert_eq!(result, "myserver.com:8443");
+	}
+
+	#[test]
+	fn test_no_append_port_domain_non_standard() {
+		let result = resolve_host("stump.example.com".to_string(), "https", 10801, false);
+		assert_eq!(result, "stump.example.com");
+	}
+
+	#[test]
+	fn test_no_append_port_domain_with_subdomain() {
+		let result =
+			resolve_host("my.stump.example.com".to_string(), "https", 10801, false);
+		assert_eq!(result, "my.stump.example.com");
+	}
+
+	#[test]
+	fn test_append_port_ipv4_non_standard() {
+		let result = resolve_host("192.168.1.100".to_string(), "https", 10801, false);
+		assert_eq!(result, "192.168.1.100:10801");
+	}
+
+	#[test]
+	fn test_no_append_port_ipv4_default() {
+		let result = resolve_host("192.168.1.100".to_string(), "https", 443, false);
+		assert_eq!(result, "192.168.1.100");
 	}
 }

--- a/docs/content/docs/guides/access-control/oidc.mdx
+++ b/docs/content/docs/guides/access-control/oidc.mdx
@@ -118,6 +118,10 @@ services:
 
 OIDC can be configured using either environment variables or the TOML configuration file. See [server configuration](/docs/guides/configuration/server-config) for more details.
 
+<Callout type="info">
+	**Running behind a reverse proxy?** You might need to set `STUMP_TRUST_PROXY_HEADERS=true` (or `trust_proxy_headers = true` in `Stump.toml`). Without it, Stump ignores forwarded headers and may generate incorrect URLs (like the OIDC redirect callbacks). See [`STUMP_TRUST_PROXY_HEADERS`](/docs/guides/configuration/server-config#stump_trust_proxy_headers) for details.
+</Callout>
+
 <Callout type="warning">
 	When using the `Stump.toml` configuration file, OIDC settings must be placed under an `[oidc]`
 	table section, **not** as flat keys with an `oidc_` prefix. See the [TOML example](#toml-example)

--- a/docs/content/docs/guides/configuration/server-config.mdx
+++ b/docs/content/docs/guides/configuration/server-config.mdx
@@ -71,6 +71,8 @@ Stored as a valid array in the configuration file.
 
 Whether or not to trust proxy headers like `X-Forwarded-For` and `X-Real-IP` for determining the client's IP address. This should only be set to `true` if Stump is running behind a reverse proxy that is properly configured to set these headers, since it increases the risk of IP spoofing.
 
+Without this config enabled, Stump will ignore these headers entirely and rely only on raw connect info. This means that if you're running Stump behind a reverse proxy, some generated URLs may be built incorrectly.
+
 | Type    | Default Value | TOML Key              |
 | ------- | ------------- | --------------------- |
 | Boolean | `false`       | `trust_proxy_headers` |


### PR DESCRIPTION
Relates to #1224

## Description

A clear and concise description of the PR.

- As described in https://github.com/stumpapp/stump/issues/1224#issuecomment-5017274720

## Stump Contributor License Agreement

By contributing to Stump, you agree that your contributions will be licensed under the following licenses (where applicable):

- The [expo application](https://github.com/stumpapp/stump/blob/main/apps/expo/LICENSE) is licensed under [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.html)
- All other code in the repository is licensed under [MIT License](https://www.tldrlegal.com/license/mit-license)
