### PR TITLE
:memo: Add justRead to OPDS 1.2 tested clients

### DIFF
--- a/docs/content/docs/guides/features/opds.mdx
+++ b/docs/content/docs/guides/features/opds.mdx
@@ -29,6 +29,7 @@ The following clients have been tested with Stump:
 | iOS & Android |                              [Stump](/docs/apps/mobile)                               |             ✅ |                                                                               ✨ |
 | iOS           |                             [Panels](https://panels.app/)                              |             ✅ |                                                                               ✨ |
 | iOS           |     [Chunky Reader](https://apps.apple.com/us/app/chunky-comic-reader/id663567628)     |             ✅ |                                                                                  |
+| iOS           |     [justRead](https://apps.apple.com/us/app/epub-reader-justread-app/id6757948605)     |             ❌ |                                    General EPUB/PDF/audiobook reader, not comic-focused; no page-streaming support |
 | Android       | [Moon+ Reader](https://play.google.com/store/apps/details?id=com.flyersoft.moonreader) |             ❌ |                                                       Users report OK experience |
 | Android       |                         [KyBook 3](http://kybook-reader.com/)                          |             ❌ |                                                          No testing at this time |
 | Android       |    [Librera](https://play.google.com/store/apps/details?id=com.foobnix.pdf.reader)     |             ❌ | Supports covers, categories, and downloads, but shows file names not book titles |


### PR DESCRIPTION
justRead is a native iOS/iPadOS EPUB, PDF, and audiobook reader with a custom OPDS server field, so it can browse and download from a Stump server's OPDS 1.2 catalog. I haven't run it against page-streaming specifically (it's a general reader, not a comic-focused client), so I've marked that column No rather than claim untested behavior. Happy to update with real findings if I get a chance to test more thoroughly.

App Store: https://apps.apple.com/us/app/epub-reader-justread-app/id6757948605
Website: https://justread.app