### PR TITLE
:bug: Fix kobo unauthroized error regression

### DIFF
--- a/apps/server/src/routers/kobo/mod.rs
+++ b/apps/server/src/routers/kobo/mod.rs
@@ -14,13 +14,21 @@ mod sync;
 mod sync_token;
 
 pub(crate) fn mount(app_state: AppState) -> Router<AppState> {
-	Router::new()
-		.nest("/kobo", router::mount(app_state.clone()))
+	let session_route = Router::new()
 		.route(
 			"/api/v2/kobo/sync-sessions",
 			delete(delete_kobo_sync_sessions),
 		)
-		.layer(middleware::from_fn_with_state(app_state, auth_middleware))
+		.layer(middleware::from_fn_with_state(
+			app_state.clone(),
+			auth_middleware,
+		));
+
+	// the session route is separate from the main /kobo router because auth mechanisms
+	// are different (session cookie / jwt vs api-key in URL)
+	Router::new()
+		.nest("/kobo", router::mount(app_state))
+		.merge(session_route)
 }
 
 /// Delete all Kobo sync sessions for the current user, forcing a full re-sync

--- a/apps/server/tests/api_tests.rs
+++ b/apps/server/tests/api_tests.rs
@@ -1,4 +1,5 @@
 mod common;
+mod kobo;
 mod koreader;
 mod opds;
 mod reading_progress;

--- a/apps/server/tests/common/app.rs
+++ b/apps/server/tests/common/app.rs
@@ -125,6 +125,14 @@ impl TestApp {
 		response
 	}
 
+	/// issue a DELETE request to the specified path with auth headers, returning the response directly
+	pub async fn delete(&self, path: &str) -> TestResponse {
+		self.server
+			.delete(path)
+			.add_header("Authorization", self.auth_header().await)
+			.await
+	}
+
 	/// issue a PUT request to the specified path with auth headers and a JSON body, returning the response directly
 	pub async fn put(&self, path: &str, body: &Value) -> TestResponse {
 		let response = self

--- a/apps/server/tests/kobo/auth.rs
+++ b/apps/server/tests/kobo/auth.rs
@@ -1,0 +1,46 @@
+use axum::http::StatusCode;
+use tests::fake_data;
+
+use crate::common::{api_key::create_api_key_for_user, TestApp};
+
+async fn setup() -> (TestApp, String) {
+	let app = TestApp::new().await;
+	let user = fake_data::User::new("kobo").insert(app.conn()).await;
+	let (api_key, _) = create_api_key_for_user(&app, &user, None).await;
+	(app, api_key)
+}
+
+/// routes explicitly part of the kobo sync api are authed via api key, not session / jwt auth
+#[tokio::test]
+async fn test_kobo_device_route_authenticates_with_api_key() {
+	let (app, api_key) = setup().await;
+
+	// invalid api key = 401
+	app.server
+		.post("/kobo/invalid_api_key/v1/auth/device")
+		.await
+		.assert_status(StatusCode::UNAUTHORIZED);
+
+	// valid api key = ok
+	app.server
+		.post(&format!("/kobo/{}/v1/auth/device", api_key))
+		.await
+		.assert_status_ok();
+}
+
+/// routes part of internal api, not part of the kobo sync api, are authed via session / jwt auth
+#[tokio::test]
+async fn test_delete_sync_sessions_requires_session_auth() {
+	let app = TestApp::new_with_default_user().await;
+
+	// no auth at all = 401
+	app.server
+		.delete("/api/v2/kobo/sync-sessions")
+		.await
+		.assert_status(StatusCode::UNAUTHORIZED);
+
+	// authed = 204
+	app.delete("/api/v2/kobo/sync-sessions")
+		.await
+		.assert_status(StatusCode::NO_CONTENT);
+}

--- a/apps/server/tests/kobo/mod.rs
+++ b/apps/server/tests/kobo/mod.rs
@@ -1,0 +1,3 @@
+mod auth;
+
+// TODO(kobo): add tests for actual kobo sync ops

--- a/core/src/config/stump_config.rs
+++ b/core/src/config/stump_config.rs
@@ -191,6 +191,7 @@ pub struct StumpConfig {
 	/// Indicates if the Kobo sync feature should be enabled.
 	#[default_value(false)]
 	#[env_key(ENABLE_KOBO_SYNC_KEY)]
+	#[debug_value(true)]
 	pub enable_kobo_sync: bool,
 
 	/// Indicates if OPDS page access should automatically track reading progression.


### PR DESCRIPTION
Resolves an [issue reported on Discord](https://discord.com/channels/972593831172272148/1527997934514475118)

## Description

A regression was introduced in https://github.com/stumpapp/stump/commit/f22db74bd which did not layer the auth middleware at the correct spot, thus running the sync router through session/jwt guards instead of the more specific api-key-in-URL guard

- Isolate internal API kobo router and sync router
- Add server tests to assert fix

## Stump Contributor License Agreement

By contributing to Stump, you agree that your contributions will be licensed under the following licenses (where applicable):

- The [expo application](https://github.com/stumpapp/stump/blob/main/apps/expo/LICENSE) is licensed under [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.html)
- All other code in the repository is licensed under [MIT License](https://www.tldrlegal.com/license/mit-license)
