### PR TITLE
:bug: Fix `ambiguous column name` error for `keep_reading` query

### DIFF
--- a/crates/graphql/src/query/media.rs
+++ b/crates/graphql/src/query/media.rs
@@ -399,7 +399,7 @@ impl MediaQuery {
 				let count = query.clone().count(conn).await?;
 
 				let models = query
-					.find_also_related(media_metadata::Entity)
+					.select_also(media_metadata::Entity)
 					.offset(info.offset())
 					.limit(info.limit())
 					.all(conn)
@@ -418,7 +418,7 @@ impl MediaQuery {
 			},
 			Pagination::None(_) => {
 				let models = query
-					.find_also_related(media_metadata::Entity)
+					.select_also(media_metadata::Entity)
 					.all(conn)
 					.await?
 					.into_iter()


### PR DESCRIPTION
Fixes a regression from c759318cd28c1b060fc6dd89e3aa61028a2adb74

## Stump Contributor License Agreement

By contributing to Stump, you agree that your contributions will be licensed under the following licenses (where applicable):

- The [expo application](https://github.com/stumpapp/stump/blob/main/apps/expo/LICENSE) is licensed under [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.html)
- All other code in the repository is licensed under [MIT License](https://www.tldrlegal.com/license/mit-license)
