### PR TITLE
A collection of fixes for `nightly`

### DIFF
--- a/apps/expo/components/book/overview/BookMenu.tsx
+++ b/apps/expo/components/book/overview/BookMenu.tsx
@@ -118,6 +118,13 @@ export default function BookMenu({ data }: Props) {
 			client.refetchQueries({ queryKey: ['onDeck'], exact: false }),
 			client.refetchQueries({ queryKey: ['recentlyAddedBooks'], exact: false }),
 			client.refetchQueries({ queryKey: ['recentlyAddedSeries'], exact: false }),
+			// TODO: would be better to have a little bit smarter cache invalidation here,
+			// im casting a wide net because i don't want to have to figure out where i am
+			// in the router (e.g., did i come from books? a series? etc)
+			client.invalidateQueries({ queryKey: ['seriesById', book.series.id], exact: false }), // stats
+			client.invalidateQueries({ queryKey: ['seriesBooks', book.series.id], exact: false }),
+			client.invalidateQueries({ queryKey: ['booksStats', serverID], exact: false }), // stats
+			client.invalidateQueries({ queryKey: ['books', serverID], exact: false }), // server books
 		])
 	}
 

--- a/apps/expo/components/listLayout/grid/GridImageItem.tsx
+++ b/apps/expo/components/listLayout/grid/GridImageItem.tsx
@@ -91,37 +91,36 @@ export default function GridImageItem({
 						)}
 
 						{hasCompleted && (
-							<BlurView
-								blurTarget={blurTargetRef}
-								blurMethod="dimezisBlurView"
+							<View
 								className={cn(
 									'right-2 bottom-2 squircle absolute z-30 rounded-full',
 									isReading && 'bottom-5',
 								)}
-								intensity={4}
 							>
-								<View className="bg-white/30 flex flex-row items-center justify-center">
-									{showNumber && (
-										<Text
-											className="font-bold ml-2 shadow tablet:text-base"
-											style={{
-												color: '#f5f3ef',
-											}}
-										>
-											{numberOfReads}
-										</Text>
-									)}
+								<BlurView blurTarget={blurTargetRef} blurMethod="dimezisBlurView" intensity={4}>
+									<View className="bg-white/30 flex flex-row items-center justify-center">
+										{showNumber && (
+											<Text
+												className="font-bold ml-2 shadow tablet:text-base"
+												style={{
+													color: '#f5f3ef',
+												}}
+											>
+												{numberOfReads}
+											</Text>
+										)}
 
-									<Icon
-										as={Check}
-										// This icon looks optically off center so I've adjusted it down a bit
-										className="shadow m-1 top-[0.7]"
-										size={20}
-										color="#f5f3ef"
-										strokeWidth={2.5}
-									/>
-								</View>
-							</BlurView>
+										<Icon
+											as={Check}
+											// This icon looks optically off center so I've adjusted it down a bit
+											className="shadow m-1 top-[0.7] z-50"
+											size={20}
+											color="#f5f3ef"
+											strokeWidth={2.5}
+										/>
+									</View>
+								</BlurView>
+							</View>
 						)}
 					</View>
 

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -62,7 +62,7 @@
 		"expo-application": "~56.0.3",
 		"expo-asset": "~56.0.17",
 		"expo-auth-session": "~56.0.14",
-		"expo-blur": "~56.0.3",
+		"expo-blur": "~56.0.4",
 		"expo-brightness": "~56.0.5",
 		"expo-build-properties": "~56.0.19",
 		"expo-constants": "~56.0.18",

--- a/apps/server/src/errors.rs
+++ b/apps/server/src/errors.rs
@@ -324,7 +324,9 @@ impl IntoResponse for APIErrorResponse {
 
 		let mut builder = Response::builder()
 			.status(self.status)
-			.header("Content-Type", "application/json");
+			.header("Content-Type", "application/json")
+			// do not cache error responses
+			.header("Cache-Control", "no-store");
 
 		// if the status is 401, we want to encourage the client to delete their
 		// session cookie

--- a/apps/server/src/http_server.rs
+++ b/apps/server/src/http_server.rs
@@ -57,8 +57,8 @@ pub async fn run_http_server(config: StumpConfig) -> ServerResult<()> {
 		.await
 		.map_err(|e| ServerError::ServerStartError(e.to_string()))?;
 
-	// Initialize the scheduler
-	core.init_scheduler()
+	let _scheduler = core
+		.init_scheduler()
 		.await
 		.map_err(|e| ServerError::ServerStartError(e.to_string()))?;
 

--- a/core/src/job/scheduler.rs
+++ b/core/src/job/scheduler.rs
@@ -12,6 +12,7 @@ use crate::job::stump_job::StumpJob;
 use crate::{CoreError, CoreResult, Ctx};
 
 /// A scheduler that loads cron-based jobs and spawns them accordingly
+#[must_use = "dropping the JobScheduler aborts all scheduled job loops"]
 pub struct JobScheduler {
 	handles: Vec<tokio::task::JoinHandle<()>>,
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -293,10 +293,10 @@ impl StumpCore {
 		}
 	}
 
-	pub async fn init_scheduler(&self) -> Result<Arc<JobScheduler>, CoreError> {
+	pub async fn init_scheduler(&self) -> Result<JobScheduler, CoreError> {
 		let ctx = self.ctx.arced();
 		let scheduler = JobScheduler::init(ctx).await?;
-		Ok(Arc::new(scheduler))
+		Ok(scheduler)
 	}
 
 	pub async fn init_library_watcher(&self) -> CoreResult<()> {

--- a/crates/graphql/src/filter/keyword.rs
+++ b/crates/graphql/src/filter/keyword.rs
@@ -1,0 +1,60 @@
+//! LIKE-pattern escaping helpers for string filters
+
+use sea_orm::sea_query::LikeExpr;
+
+/// The escape character paired with every generated `LIKE` pattern
+const LIKE_ESCAPE_CHAR: char = '\\';
+
+/// Escapes the LIKE metacharacters `%` and `_`, plus the escape character
+/// itself, so e.g., a search for `50%` is correctly understood to be literal
+/// and not a pattern
+pub fn escape_like_fragment(input: &str) -> String {
+	let mut escaped = String::with_capacity(input.len());
+	for ch in input.chars() {
+		if ch == LIKE_ESCAPE_CHAR || ch == '%' || ch == '_' {
+			escaped.push(LIKE_ESCAPE_CHAR);
+		}
+		escaped.push(ch);
+	}
+	escaped
+}
+
+/// `%value%`, with `value` lowercased and escaped
+pub(crate) fn like_contains(value: &str) -> LikeExpr {
+	LikeExpr::new(format!("%{}%", escape_like_fragment(&value.to_lowercase())))
+		.escape(LIKE_ESCAPE_CHAR)
+}
+
+/// `value%`, with `value` lowercased and escaped
+pub(crate) fn like_starts_with(value: &str) -> LikeExpr {
+	LikeExpr::new(format!("{}%", escape_like_fragment(&value.to_lowercase())))
+		.escape(LIKE_ESCAPE_CHAR)
+}
+
+/// `%value`, with `value` lowercased and escaped
+pub(crate) fn like_ends_with(value: &str) -> LikeExpr {
+	LikeExpr::new(format!("%{}", escape_like_fragment(&value.to_lowercase())))
+		.escape(LIKE_ESCAPE_CHAR)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn escape_like_fragment_handles_wildcards() {
+		assert_eq!(escape_like_fragment("50%"), r"50\%");
+		assert_eq!(escape_like_fragment("file_name"), r"file\_name");
+		assert_eq!(escape_like_fragment("100% true"), r"100\% true");
+		assert_eq!(
+			escape_like_fragment(r"already\escaped"),
+			r"already\\escaped"
+		);
+	}
+
+	#[test]
+	fn escape_like_fragment_noop_for_safe_strings() {
+		assert_eq!(escape_like_fragment("normal"), "normal");
+		assert_eq!(escape_like_fragment("with spaces"), "with spaces");
+	}
+}

--- a/crates/graphql/src/filter/mod.rs
+++ b/crates/graphql/src/filter/mod.rs
@@ -8,12 +8,15 @@ use sea_orm::{
 };
 use serde::{Deserialize, Serialize};
 
+pub mod keyword;
 pub mod library;
 pub mod log;
 pub mod media;
 pub mod media_metadata;
 pub mod series;
 pub mod series_metadata;
+
+use keyword::{like_contains, like_ends_with, like_starts_with};
 
 // TODO: This probably needs a rewrite to make it more compatible with async-graphql. The big issue is generics
 // with input objects. Look at and yoink from seaography for how they are doing things
@@ -77,28 +80,28 @@ where
 			let v: String = value.into();
 			Condition::all().add(
 				QExpr::expr(Func::lower(QExpr::col(column.as_column_ref())))
-					.like(format!("%{}%", v.to_lowercase())),
+					.like(like_contains(&v)),
 			)
 		},
 		StringLikeFilter::Excludes(value) => {
 			let v: String = value.into();
 			Condition::all().add(
 				QExpr::expr(Func::lower(QExpr::col(column.as_column_ref())))
-					.not_like(format!("%{}%", v.to_lowercase())),
+					.not_like(like_contains(&v)),
 			)
 		},
 		StringLikeFilter::StartsWith(value) => {
 			let v: String = value.into();
 			Condition::all().add(
 				QExpr::expr(Func::lower(QExpr::col(column.as_column_ref())))
-					.like(format!("{}%", v.to_lowercase())),
+					.like(like_starts_with(&v)),
 			)
 		},
 		StringLikeFilter::EndsWith(value) => {
 			let v: String = value.into();
 			Condition::all().add(
 				QExpr::expr(Func::lower(QExpr::col(column.as_column_ref())))
-					.like(format!("%{}", v.to_lowercase())),
+					.like(like_ends_with(&v)),
 			)
 		},
 		StringLikeFilter::LikeAnyOf(values) => {
@@ -106,7 +109,7 @@ where
 				let v: String = value.into();
 				acc.add(
 					QExpr::expr(Func::lower(QExpr::col(column.as_column_ref())))
-						.like(format!("%{}%", v.to_lowercase())),
+						.like(like_contains(&v)),
 				)
 			})
 		},
@@ -116,7 +119,7 @@ where
 				let v: String = value.into();
 				acc.add(
 					QExpr::expr(Func::lower(QExpr::col(column.as_column_ref())))
-						.like(format!("%{}%", v.to_lowercase())),
+						.like(like_contains(&v)),
 				)
 			})
 			.not(),
@@ -226,7 +229,7 @@ mod tests {
 
 		assert_eq!(
 			sql,
-			r#"SELECT  FROM "media" WHERE LOWER("media"."name") LIKE '%test%' OR LOWER("media"."name") LIKE '%example%'"#
+			r#"SELECT  FROM "media" WHERE LOWER("media"."name") LIKE '%test%' ESCAPE '\' OR LOWER("media"."name") LIKE '%example%' ESCAPE '\'"#
 		);
 	}
 
@@ -243,7 +246,70 @@ mod tests {
 
 		assert_eq!(
 			sql,
-			r#"SELECT  FROM "media" WHERE NOT (LOWER("media"."name") LIKE '%test%' OR LOWER("media"."name") LIKE '%example%')"#
+			r#"SELECT  FROM "media" WHERE NOT (LOWER("media"."name") LIKE '%test%' ESCAPE '\' OR LOWER("media"."name") LIKE '%example%' ESCAPE '\')"#
+		);
+	}
+
+	#[test]
+	fn test_contains_escapes_wildcards_in_the_pattern() {
+		let sql = media::Entity::find()
+			.filter(apply_string_filter(
+				media::Column::Name,
+				StringLikeFilter::Contains("50%".to_string()),
+			))
+			.select_only()
+			.into_query()
+			.to_string(SqliteQueryBuilder);
+
+		assert_eq!(
+			sql,
+			r#"SELECT  FROM "media" WHERE LOWER("media"."name") LIKE '%50\%%' ESCAPE '\'"#
+		);
+	}
+
+	#[test]
+	fn test_starts_and_ends_with_escape_wildcards() {
+		let starts = media::Entity::find()
+			.filter(apply_string_filter(
+				media::Column::Name,
+				StringLikeFilter::StartsWith("file_".to_string()),
+			))
+			.select_only()
+			.into_query()
+			.to_string(SqliteQueryBuilder);
+		assert_eq!(
+			starts,
+			r#"SELECT  FROM "media" WHERE LOWER("media"."name") LIKE 'file\_%' ESCAPE '\'"#
+		);
+
+		let ends = media::Entity::find()
+			.filter(apply_string_filter(
+				media::Column::Name,
+				StringLikeFilter::EndsWith("_v1".to_string()),
+			))
+			.select_only()
+			.into_query()
+			.to_string(SqliteQueryBuilder);
+		assert_eq!(
+			ends,
+			r#"SELECT  FROM "media" WHERE LOWER("media"."name") LIKE '%\_v1' ESCAPE '\'"#
+		);
+	}
+
+	#[test]
+	fn test_excludes_is_a_substring_negation() {
+		let sql = media::Entity::find()
+			.filter(apply_string_filter(
+				media::Column::Name,
+				StringLikeFilter::Excludes("annual".to_string()),
+			))
+			.select_only()
+			.into_query()
+			.to_string(SqliteQueryBuilder);
+
+		assert_eq!(
+			sql,
+			r#"SELECT  FROM "media" WHERE LOWER("media"."name") NOT LIKE '%annual%' ESCAPE '\'"#
 		);
 	}
 }

--- a/crates/graphql/src/query/author.rs
+++ b/crates/graphql/src/query/author.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 
 use async_graphql::{Context, Object, Result};
-use models::entity::{media, media_metadata, series};
+use models::entity::{media, media_metadata, series, user::AuthUser};
 use sea_orm::{prelude::*, sea_query::Query, QuerySelect};
 
 use crate::{
-	data::CoreContext,
+	data::{AuthContext, CoreContext},
 	object::author::{Author, AuthorSeries},
 	pagination::{
 		OffsetPaginationInfo, PaginatedResponse, Pagination, PaginationValidator,
@@ -30,23 +30,19 @@ fn series_in_library_subquery(library_id: String) -> sea_orm::sea_query::SelectS
 		.to_owned()
 }
 
-/// Fetches all unique author names from the database, optionally scoped to a library.
+/// Fetches all unique author names from the database, optionally scoped to a library,
+/// and scoped to whatever the given user is allowed to see.
+///
 /// Returns a HashMap with lowercase name as key and original casing as value.
 async fn fetch_all_authors(
 	conn: &DatabaseConnection,
 	library_id: Option<String>,
+	auth_user: &AuthUser,
 ) -> Result<HashMap<String, String>> {
-	let mut query = media_metadata::Entity::find()
+	let mut query = media::Entity::find_for_user(auth_user)
 		.select_only()
 		.column(media_metadata::Column::Writers)
 		.distinct()
-		.join_rev(
-			sea_orm::JoinType::InnerJoin,
-			media::Entity::belongs_to(media_metadata::Entity)
-				.from(media::Column::Id)
-				.to(media_metadata::Column::MediaId)
-				.into(),
-		)
 		.filter(media_metadata::Column::Writers.is_not_null());
 
 	if let Some(lib_id) = library_id {
@@ -82,9 +78,10 @@ impl AuthorQuery {
 		#[graphql(desc = "Optional library ID to scope the author search")]
 		library_id: Option<String>,
 	) -> Result<Option<Author>> {
+		let AuthContext { user, .. } = ctx.data::<AuthContext>()?;
 		let conn = ctx.data::<CoreContext>()?.conn.as_ref();
 
-		let authors = fetch_all_authors(conn, library_id.clone()).await?;
+		let authors = fetch_all_authors(conn, library_id.clone(), user).await?;
 		let search_key = name.to_lowercase();
 
 		Ok(authors.get(&search_key).map(|original_name| Author {
@@ -106,9 +103,10 @@ impl AuthorQuery {
 		#[graphql(default, validator(custom = "PaginationValidator"))]
 		pagination: Pagination,
 	) -> Result<PaginatedResponse<Author>> {
+		let AuthContext { user, .. } = ctx.data::<AuthContext>()?;
 		let conn = ctx.data::<CoreContext>()?.conn.as_ref();
 
-		let all_authors = fetch_all_authors(conn, library_id.clone()).await?;
+		let all_authors = fetch_all_authors(conn, library_id.clone(), user).await?;
 
 		let filtered: Vec<String> = if let Some(ref search_term) = search {
 			let search_lower = search_term.to_lowercase();
@@ -178,19 +176,13 @@ impl AuthorQuery {
 		#[graphql(desc = "Optional library ID to scope the series search")]
 		library_id: Option<String>,
 	) -> Result<Option<AuthorSeries>> {
+		let AuthContext { user, .. } = ctx.data::<AuthContext>()?;
 		let conn = ctx.data::<CoreContext>()?.conn.as_ref();
 
-		let mut query = media_metadata::Entity::find()
+		let mut query = media::Entity::find_for_user(user)
 			.select_only()
 			.column(media_metadata::Column::Series)
 			.distinct()
-			.join_rev(
-				sea_orm::JoinType::InnerJoin,
-				media::Entity::belongs_to(media_metadata::Entity)
-					.from(media::Column::Id)
-					.to(media_metadata::Column::MediaId)
-					.into(),
-			)
 			.filter(media_metadata::Column::Series.is_not_null());
 
 		if let Some(ref lib_id) = library_id {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13931,10 +13931,10 @@ expo-auth-session@~56.0.14:
     expo-web-browser "~56.0.5"
     invariant "^2.2.4"
 
-expo-blur@~56.0.3:
-  version "56.0.3"
-  resolved "https://registry.yarnpkg.com/expo-blur/-/expo-blur-56.0.3.tgz#4420700813be7ed47298b9280d83fdfb32d04cdb"
-  integrity sha512-KDDtrpWc2tYlm1WCPaOgBtv+YEGqe5ELheFPIgSNgHt28NQUDcfBcFsA9Us2StDh6osmSD6NbKxOt5bU6PcDbQ==
+expo-blur@~56.0.4:
+  version "56.0.4"
+  resolved "https://registry.yarnpkg.com/expo-blur/-/expo-blur-56.0.4.tgz#7706b6348c7a12fd423651667b2de34a40959471"
+  integrity sha512-/rNpe2NDTmMbSktVJb5z7HoX6apYtq8KVKJNjWOQV7NG01+LvctWzFeMNxWSZVWfIKTndqdqABwqcpYmiCRxxg==
 
 expo-brightness@~56.0.5:
   version "56.0.5"


### PR DESCRIPTION
## Description

This PR is a mix of a few different bug fixes. Originally it only contained items I reviewed from snooping on a few heavily vibe-coded forks, that I figure would never be reported or otherwise flow back to here, but tacked on a few unrelated-to-that mobile app fixes here as well:

- Fix immediate drop of job scheduler
- Fix edge-case string filters with wildcards (e.g., searching for `50%`)
- Scope author queries to user-visible books, not all books
- Add explicit `Cache-Control: no-store` response header for error responses
- Fix style regression for the checkmark in grid items (expo)
   - This code hasn't changed in ~4 months, so I think it was a regression from upgrading expo or nativewind
- Cast wider net for cache invalidation when mutating a book's progression (expo)

If any other small items crop up in the next day or so, I'll add them here and just rebase merge

## Stump Contributor License Agreement

By contributing to Stump, you agree that your contributions will be licensed under the following licenses (where applicable):

- The [expo application](https://github.com/stumpapp/stump/blob/main/apps/expo/LICENSE) is licensed under [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.html)
- All other code in the repository is licensed under [MIT License](https://www.tldrlegal.com/license/mit-license)
