### PR TITLE
:memo: Improve discoverability of mobile app price in docs

### DIFF
--- a/docs/content/docs/apps/mobile/faq.mdx
+++ b/docs/content/docs/apps/mobile/faq.mdx
@@ -6,9 +6,9 @@ description: Frequently asked questions about the mobile app
 ## What is the pricing model for the app?
 
 <Callout type="warning">
-	The price has yet to be determined and **subject to change**. I am trying to keep it as affordable
+	The price has yet to be finalized and is **subject to change**. I am trying to keep it as affordable
 	as possible while still being sustainable for continued development. The current price I'm
-	considering is $15 USD, which is comparable to similar apps in the market.
+	considering is $10 USD, which is comparable to similar apps in the market.
 
 That said, I understand that no matter the price there will still be people who are not able to afford it. If you are in that situation, please feel free to reach out to me directly and we can work something out. I will refresh a pool of promo codes every year that I will be setting aside.
 
@@ -25,7 +25,10 @@ There is no official release date for the app at this time. Stump as a whole is 
 I have very loose goals to release the app by 2027, but that entirely depends on where life takes me between now and then.
 
 <Callout title="Beta Stability">
-    Application builds are made against the `nightly` branch and so updates may drift from what versioned releases of the server are compatible with. If you want to best ensure compatibility, you will need to run the `nightly` release channel of the server. Once the app is released on a non-beta track, there will be a more stable experience.
+	Application builds are made against the `nightly` branch and so updates may drift from what
+	versioned releases of the server are compatible with. If you want to best ensure compatibility,
+	you will need to run the `nightly` release channel of the server. Once the app is released on a
+	non-beta track, there will be a more stable experience.
 </Callout>
 
 ## Why React Native?

--- a/docs/content/docs/apps/mobile/index.mdx
+++ b/docs/content/docs/apps/mobile/index.mdx
@@ -2,13 +2,14 @@
 title: Mobile App
 ---
 
+The Stump mobile app is a cross-platform application built using [React Native](https://reactnative.dev/) and [Expo](https://expo.dev/). Unlike the rest of Stump, the mobile app is not free and has a one-time purchase model. For more about pricing information, see the mobile-specific [FAQ](/docs/apps/mobile/faq#what-is-the-pricing-model-for-the-app).
+
 <Callout title="Beta Software">
     The mobile app is currently beta software. It is fairly developed and provides an overall good experience, but there will be some rough edges and missing features here and there. As such, these sections of the documentation are subject to change as the app is developed, and may not always be up-to-date.
 
     Additionally, builds are made against the `nightly` branch and so updates may drift from what versioned releases of the server are compatible with. If you want to best ensure compatibility with a Stump server, you will need to run the `nightly` release channel.
-</Callout>
 
-The Stump mobile app is a cross-platform application built using [React Native](https://reactnative.dev/) and [Expo](https://expo.dev/). 
+</Callout>
 
 ## Core Features
 


### PR DESCRIPTION
## Description

A small change to hopefully improve the discoverability of the mobile app pricing model in the documentation, after feedback on Discord

## Stump Contributor License Agreement

By contributing to Stump, you agree that your contributions will be licensed under the following licenses (where applicable):

- The [expo application](https://github.com/stumpapp/stump/blob/main/apps/expo/LICENSE) is licensed under [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.html)
- All other code in the repository is licensed under [MIT License](https://www.tldrlegal.com/license/mit-license)
