### PR TITLE
:bug: (expo): Fix infinite loop from avatar pull operation

### DIFF
--- a/apps/expo/backgroundTasks/pullServerLogo.ts
+++ b/apps/expo/backgroundTasks/pullServerLogo.ts
@@ -4,7 +4,12 @@ import { DownloadOptions, File } from 'expo-file-system'
 import getProperty from 'lodash/get'
 import { match, P } from 'ts-pattern'
 
-import { cacheDirectory, serverPath } from '~/lib/filesystem'
+import {
+	cacheDirectory,
+	ensureDirectoryExists,
+	serverDirectory,
+	serverPath,
+} from '~/lib/filesystem'
 import { createThumbnail } from '~/lib/widgets/utils'
 import {
 	isKnownServer,
@@ -152,6 +157,7 @@ export async function pullServerAvatar(server: SavedServer, api: Api) {
 	const avatar = await match(avatarData)
 		.with({ logo: P.string }, (s) => s)
 		.with({ uri: P.string }, async (data) => {
+			ensureDirectoryExists(serverDirectory(server.id))
 			const destination = new File(serverPath(server.id, 'avatar.png'))
 			await new File(data.uri).move(destination, { overwrite: true })
 			return (

--- a/apps/expo/lib/filesystem.ts
+++ b/apps/expo/lib/filesystem.ts
@@ -58,7 +58,7 @@ export const toAbsolutePath = (storedPath: string): string => {
 	return urlJoin(docDir, path)
 }
 
-const serverDirectory = (serverID: string) => urlJoin(baseDirectory, serverID)
+export const serverDirectory = (serverID: string) => urlJoin(baseDirectory, serverID)
 
 export const serverPath = (serverID: string, path: string) =>
 	urlJoin(serverDirectory(serverID), path)

--- a/apps/expo/lib/hooks/sync/useSyncServerAvatars.ts
+++ b/apps/expo/lib/hooks/sync/useSyncServerAvatars.ts
@@ -23,45 +23,60 @@ export function useSyncServerAvatars() {
 		[savedServers],
 	)
 
-	useEffect(() => {
-		async function buildSyncableServers() {
-			const fullServers = (await Promise.all(serverIds.map(getFullServer))).filter((s) => s != null)
+	useEffect(
+		() => {
+			async function buildSyncableServers() {
+				const fullServers = (await Promise.all(serverIds.map(getFullServer))).filter(
+					(s) => s != null,
+				)
 
-			// if the server has an avatar set, we won't sync it until you re-enter server. i think this is fine,
-			// most likely folks won't be updating avatars all the time and the extra pings are not overly
-			// necessary imo
-			setAutoSyncableServers(
-				new Set(
-					fullServers
-						.filter(({ avatar, config }) => config?.auth != null && avatar == null)
-						.map(({ id }) => id),
-				),
-			)
-		}
+				// if the server has an avatar set, we won't sync it until you re-enter server. i think this is fine,
+				// most likely folks won't be updating avatars all the time and the extra pings are not overly
+				// necessary imo
+				setAutoSyncableServers(
+					new Set(
+						fullServers
+							.filter(({ avatar, config }) => config?.auth != null && avatar == null)
+							.map(({ id }) => id),
+					),
+				)
+			}
 
-		buildSyncableServers()
-	}, [serverIds, getFullServer])
+			buildSyncableServers()
+		},
+		// eslint-disable-next-line react-compiler/react-compiler
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[serverIds],
+	)
 
 	const lastSyncedSet = useRef(new Set())
 
 	const syncServerLogos = useCallback(
 		async (ids: string[]) => {
-			const instances = await getInstances(ids)
+			const instances = await getInstances(ids, true)
 			const params = []
 			for (const [serverId, instance] of Object.entries(instances)) {
 				const server = serverIdsToServer[serverId]
 				if (server) params.push({ server, api: instance })
 			}
 			await executePullServerLogos(params)
-			lastSyncedSet.current = new Set([...lastSyncedSet.current, ...ids])
 		},
 		[getInstances, serverIdsToServer],
 	)
 
-	useEffect(() => {
-		const unsyncedItems = autoSyncableServers.difference(lastSyncedSet.current)
-		if (unsyncedItems.size) {
-			syncServerLogos(Array.from(unsyncedItems))
-		}
-	}, [autoSyncableServers, syncServerLogos])
+	useEffect(
+		() => {
+			const unsyncedItems = autoSyncableServers.difference(lastSyncedSet.current)
+			if (unsyncedItems.size) {
+				const ids = Array.from(unsyncedItems)
+				// marking as synced before actually syncing because it seems to trigger a re-render
+				// mid-flight which causes the effect to re-fire to infinity
+				lastSyncedSet.current = new Set([...lastSyncedSet.current, ...ids])
+				syncServerLogos(ids)
+			}
+		},
+		// eslint-disable-next-line react-compiler/react-compiler
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[autoSyncableServers],
+	)
 }


### PR DESCRIPTION
## Description

This PR aims to fix an issue with the latest (unreleased) app build which enters an infinite loop when syncing Stump avatars to the app.

I couldn't reliably reproduce the problem locally, so will want to test this a bit more before accepting it as a tentative fix.

## Stump Contributor License Agreement

By contributing to Stump, you agree that your contributions will be licensed under the following licenses (where applicable):

- The [expo application](https://github.com/stumpapp/stump/blob/main/apps/expo/LICENSE) is licensed under [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.html)
- All other code in the repository is licensed under [MIT License](https://www.tldrlegal.com/license/mit-license)
