### PR TITLE
fix(i18n): localize the error fallback

### DIFF
--- a/packages/browser/src/App.tsx
+++ b/packages/browser/src/App.tsx
@@ -2,6 +2,7 @@ import './styles/index.css'
 import '@stump/components/styles/overrides.css'
 
 import { SDKProvider, StumpClientContextProvider, StumpClientProps } from '@stump/client'
+import { type AllowedLocale, LocaleProvider } from '@stump/i18n'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { useEffect, useState } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
@@ -16,10 +17,15 @@ import { useApplyTheme } from './hooks'
 import { useAppStore, useDebugStore, useUserStore } from './stores'
 
 export default function StumpWebClient(props: StumpClientProps) {
+	const locale = useUserStore((store) => store.userPreferences?.locale)
+	const resolvedLocale = (locale as AllowedLocale) || 'en-US'
+
 	return (
-		<ErrorBoundary FallbackComponent={ErrorFallback}>
-			<RouterContainer {...props} />
-		</ErrorBoundary>
+		<LocaleProvider locale={resolvedLocale}>
+			<ErrorBoundary FallbackComponent={ErrorFallback}>
+				<RouterContainer {...props} />
+			</ErrorBoundary>
+		</LocaleProvider>
 	)
 }
 

--- a/packages/browser/src/AppRouter.tsx
+++ b/packages/browser/src/AppRouter.tsx
@@ -1,5 +1,3 @@
-import { LocaleProvider } from '@stump/i18n'
-import { type AllowedLocale } from '@stump/i18n'
 import { lazy } from 'react'
 import { Route, Routes } from 'react-router-dom'
 
@@ -11,7 +9,7 @@ import { LibraryRouter } from './scenes/library'
 import { SeriesRouter } from './scenes/series'
 import { SettingsRouter } from './scenes/settings'
 import { SmartListRouter } from './scenes/smartList'
-import { useAppStore, useUserStore } from './stores'
+import { useAppStore } from './stores'
 
 const HomeScene = lazy(() => import('./scenes/home'))
 const FourOhFour = lazy(() => import('./scenes/error/FourOhFour.tsx'))
@@ -25,33 +23,29 @@ type AppRouterProps = {
 }
 
 export function AppRouter({ basePath }: AppRouterProps = {}) {
-	const locale = useUserStore((store) => store.userPreferences?.locale)
 	const baseUrl = useAppStore((state) => state.baseUrl)
-	const resolvedLocale = (locale as AllowedLocale) || 'en-US'
 
 	if (!baseUrl) {
 		throw new Error('Base URL is not set')
 	}
 
 	return (
-		<LocaleProvider locale={resolvedLocale}>
-			<RouterProvider basePath={basePath}>
-				<Routes>
-					<Route path="/" element={<AppLayout />}>
-						<Route path="" element={<HomeScene />} />
-						<Route path="libraries/*" element={<LibraryRouter />} />
-						<Route path="series/*" element={<SeriesRouter />} />
-						<Route path="books/*" element={<BookRouter />} />
-						<Route path="clubs/*" element={<BookClubRouter />} />
-						<Route path="/smart-lists/*" element={<SmartListRouter />} />
-						<Route path="settings/*" element={<SettingsRouter />} />
-					</Route>
+		<RouterProvider basePath={basePath}>
+			<Routes>
+				<Route path="/" element={<AppLayout />}>
+					<Route path="" element={<HomeScene />} />
+					<Route path="libraries/*" element={<LibraryRouter />} />
+					<Route path="series/*" element={<SeriesRouter />} />
+					<Route path="books/*" element={<BookRouter />} />
+					<Route path="clubs/*" element={<BookClubRouter />} />
+					<Route path="/smart-lists/*" element={<SmartListRouter />} />
+					<Route path="settings/*" element={<SettingsRouter />} />
+				</Route>
 
-					<Route path="/auth" element={<LoginOrClaimScene />} />
-					<Route path="/server-connection-error" element={<ServerConnectionErrorScene />} />
-					<Route path="*" element={<FourOhFour />} />
-				</Routes>
-			</RouterProvider>
-		</LocaleProvider>
+				<Route path="/auth" element={<LoginOrClaimScene />} />
+				<Route path="/server-connection-error" element={<ServerConnectionErrorScene />} />
+				<Route path="*" element={<FourOhFour />} />
+			</Routes>
+		</RouterProvider>
 	)
 }

--- a/packages/browser/src/__tests__/App.test.tsx
+++ b/packages/browser/src/__tests__/App.test.tsx
@@ -1,0 +1,46 @@
+import type { UserPreferences } from '@stump/graphql'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+import StumpWebClient from '../App'
+import { useUserStore } from '../stores'
+
+jest.mock('../styles/index.css', () => ({}))
+jest.mock('@stump/components/styles/overrides.css', () => ({}))
+
+jest.mock('../AppRouter', () => ({
+	AppRouter: () => {
+		throw new Error('Test error')
+	},
+}))
+
+describe('StumpWebClient', () => {
+	const originalError = console.error
+
+	beforeAll(() => {
+		console.error = jest.fn()
+	})
+
+	afterAll(() => {
+		console.error = originalError
+	})
+
+	afterEach(() => {
+		useUserStore.getState().setUserPreferences(null)
+	})
+
+	it('renders the error fallback with the selected locale', async () => {
+		useUserStore.getState().setUserPreferences({ locale: 'de-DE' } as unknown as UserPreferences)
+
+		render(
+			<MemoryRouter>
+				<StumpWebClient platform="browser" baseUrl="http://localhost:10801" />
+			</MemoryRouter>,
+		)
+
+		expect(
+			await screen.findByRole('heading', { name: 'A critical error occurred' }),
+		).toBeInTheDocument()
+		expect(screen.getByRole('link', { name: 'Fehler melden' })).toBeInTheDocument()
+	})
+})

--- a/packages/browser/src/components/ErrorFallback.tsx
+++ b/packages/browser/src/components/ErrorFallback.tsx
@@ -1,4 +1,5 @@
 import { Button, ButtonOrLink, useBodyLock } from '@stump/components'
+import { useLocaleContext } from '@stump/i18n'
 import { ExternalLink } from 'lucide-react'
 import { FallbackProps } from 'react-error-boundary'
 import { toast } from 'sonner'
@@ -8,11 +9,12 @@ import { copyTextToClipboard } from '../utils/misc'
 // TODO: take in platform?
 export function ErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
 	useBodyLock()
+	const { t } = useLocaleContext()
 
 	function copyErrorStack() {
 		if (error.stack) {
 			copyTextToClipboard(error.stack).then(() => {
-				toast.success('Copied error details to your clipboard')
+				toast.success(t('errorScene.copiedDetails'))
 			})
 		}
 	}
@@ -24,39 +26,41 @@ export function ErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
 		>
 			<img
 				src="/assets/svg/bomb.svg"
-				alt="Construction illustration"
+				alt={t('errorScene.imageAlt')}
 				className="max-h-64 sm:inline-block mx-auto hidden w-1/2 shrink-0 object-scale-down"
 			/>
 			<div className="max-w-sm sm:max-w-md md:max-w-xl">
 				<div className="text-left">
-					<h1 className="text-4xl font-semibold text-foreground">A critical error occurred</h1>
+					<h1 className="text-4xl font-semibold text-foreground">
+						{t('errorScene.criticalHeading')}
+					</h1>
 					<p className="mt-1.5 text-lg text-foreground">
-						{error.message || 'The error message was empty.'}
+						{error.message || t('errorScene.emptyMessage')}
 					</p>
 				</div>
 				<div className="gap-3 pt-3 flex w-full items-center">
 					<ButtonOrLink
 						onClick={resetErrorBoundary}
-						title="Go back to the homepage"
+						title={t('errorScene.buttons.goHomeTitle')}
 						forceAnchor
 						href="/"
 					>
-						Go Home
+						{t('errorScene.buttons.goHome')}
 					</ButtonOrLink>
 					<ButtonOrLink
-						title="Report this error as a potential bug on GitHub"
+						title={t('errorScene.buttons.reportTitle')}
 						href="https://github.com/stumpapp/stump/issues/new/choose"
 						target="_blank"
 					>
-						Report Bug <ExternalLink className="ml-2 h-4 w-4" />
+						{t('errorScene.buttons.report')} <ExternalLink className="ml-2 h-4 w-4" />
 					</ButtonOrLink>
 					{error.stack && (
 						<Button
-							title="Copy the error details to your clipboard"
+							title={t('errorScene.buttons.copyTitle')}
 							onClick={copyErrorStack}
 							variant="ghost"
 						>
-							Copy Error Details
+							{t('errorScene.buttons.copy')}
 						</Button>
 					)}
 				</div>

--- a/packages/i18n/src/locales/en-US.json
+++ b/packages/i18n/src/locales/en-US.json
@@ -810,11 +810,18 @@
 	},
 	"errorScene": {
 		"heading": "lol, oops",
+		"criticalHeading": "A critical error occurred",
+		"emptyMessage": "The error message was empty.",
+		"copiedDetails": "Copied error details to your clipboard",
+		"imageAlt": "Construction illustration",
 		"message": "An error occurred:",
 		"buttons": {
 			"report": "Report Bug",
 			"copy": "Copy Error Details",
-			"goHome": "Go Home"
+			"goHome": "Go Home",
+			"goHomeTitle": "Go back to the homepage",
+			"reportTitle": "Report this error as a potential bug on GitHub",
+			"copyTitle": "Copy the error details to your clipboard"
 		}
 	},
 	"homeScene": {


### PR DESCRIPTION
## Description

This is the first focused replacement PR extracted from #1318 after the maintainer requested smaller, independently reviewable changes.

## 목적

Make the browser error fallback honor the selected locale, including errors thrown before the application router renders.

## 내용(의도 포함)

- Move LocaleProvider above ErrorBoundary so the fallback remains inside the locale context.
- Replace the hard-coded error fallback copy with existing and newly added errorScene source keys.
- Add only en-US source strings so translations can continue through Crowdin.
- Add a regression test that selects de-DE and verifies translated fallback content is rendered.
- Keep this PR limited to the browser error fallback; it does not include broader web, mobile, book club, or desktop localization work.

## 성공기준

- The selected locale is available when ErrorFallback renders.
- Browser tests: 23 suites and 171 tests passed.
- Browser and i18n type checks passed.
- Browser ESLint completed with 0 errors; the existing 16 unrelated warnings remain.
- Prettier and git diff --check passed.

## Ready?

- [x] I read the contributing guidelines.
- [x] I searched for related issues and pull requests; this work is extracted from #1318.
- [x] This PR targets nightly rather than main.
- [x] I added a regression test for the change.

## Stump Contributor License Agreement

By contributing to Stump, I agree that these changes will be licensed under the applicable repository license.