### PR TITLE
feat(i18n): localize thumbnail selectors

### DIFF
--- a/packages/browser/src/components/thumbnail/UploadImageModal.tsx
+++ b/packages/browser/src/components/thumbnail/UploadImageModal.tsx
@@ -20,21 +20,30 @@ export default function UploadImageModal({ isOpen, onClose, onUploadImage }: Pro
 	const [selectedFile, setSelectedFile] = useState<File | null>(null)
 	const [filePreview, setFilePreview] = useState<string | null>(null)
 
-	const onDrop = useCallback((acceptedFiles: File[], fileRejections: FileRejection[]) => {
-		if (fileRejections.length > 0) {
-			console.error(fileRejections)
-			const firstError = fileRejections[0]?.errors[0]
-			const isTooLarge = firstError?.code === 'file-too-large'
-			toast.error(isTooLarge ? 'File too large (20MB max)' : firstError?.message || 'Unknown error')
-		} else if (acceptedFiles.length > 1 || !acceptedFiles.length) {
-			toast.error(acceptedFiles.length ? 'Only 1 file allowed' : 'No files provided')
-		} else if (acceptedFiles[0]) {
-			const file = acceptedFiles[0]
+	const onDrop = useCallback(
+		(acceptedFiles: File[], fileRejections: FileRejection[]) => {
+			if (fileRejections.length > 0) {
+				console.error(fileRejections)
+				const firstError = fileRejections[0]?.errors[0]
+				const isTooLarge = firstError?.code === 'file-too-large'
+				toast.error(
+					isTooLarge
+						? t(withLocaleKey('fileTooLarge'))
+						: firstError?.message || t('common.unknownError'),
+				)
+			} else if (acceptedFiles.length > 1 || !acceptedFiles.length) {
+				toast.error(
+					acceptedFiles.length ? t(withLocaleKey('onlyOneFile')) : t(withLocaleKey('noFile')),
+				)
+			} else if (acceptedFiles[0]) {
+				const file = acceptedFiles[0]
 
-			setSelectedFile(file)
-			setFilePreview(URL.createObjectURL(file))
-		}
-	}, [])
+				setSelectedFile(file)
+				setFilePreview(URL.createObjectURL(file))
+			}
+		},
+		[t],
+	)
 
 	const { getRootProps, getInputProps } = useDropzone({
 		accept: {
@@ -51,7 +60,7 @@ export default function UploadImageModal({ isOpen, onClose, onUploadImage }: Pro
 				await onUploadImage(selectedFile)
 			} catch (error) {
 				console.error(error)
-				toast.error('Failed to upload image')
+				toast.error(t('thumbnailSelector.errors.uploadFailed'))
 			}
 		}
 	}
@@ -116,10 +125,10 @@ export default function UploadImageModal({ isOpen, onClose, onUploadImage }: Pro
 
 				<Dialog.Footer>
 					<Button variant="outline" onClick={onClose}>
-						Cancel
+						{t('common.cancel')}
 					</Button>
 					<Button onClick={handleConfirm} disabled={!selectedFile}>
-						Confirm selection
+						{t('thumbnailSelector.actions.confirmSelection')}
 					</Button>
 				</Dialog.Footer>
 			</Dialog.Content>

--- a/packages/browser/src/components/thumbnail/__tests__/UploadImageModal.test.tsx
+++ b/packages/browser/src/components/thumbnail/__tests__/UploadImageModal.test.tsx
@@ -1,0 +1,51 @@
+import '@/__mocks__/resizeObserver'
+
+import { LocaleProvider } from '@stump/i18n'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { toast } from 'sonner'
+
+import UploadImageModal from '../UploadImageModal'
+
+vi.mock('sonner', () => ({
+	toast: { error: vi.fn() },
+}))
+
+describe('UploadImageModal', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('shows the localized error when a dropped image exceeds the maximum size', async () => {
+		render(
+			<LocaleProvider locale="en-US">
+				<UploadImageModal isOpen onClose={vi.fn()} onUploadImage={vi.fn()} />
+			</LocaleProvider>,
+		)
+
+		const dropTarget = screen.getByText('Drop image here or click to select').parentElement
+		if (!dropTarget) {
+			throw new Error('Drop target not found')
+		}
+
+		const oversizedFile = new File([new Uint8Array(20 * 1024 * 1024 + 1)], 'oversized.png', {
+			type: 'image/png',
+		})
+
+		fireEvent.drop(dropTarget, {
+			dataTransfer: {
+				files: [oversizedFile],
+				items: [
+					{
+						kind: 'file',
+						type: 'image/png',
+						getAsFile: () => oversizedFile,
+					},
+				],
+				types: ['Files'],
+			},
+		})
+
+		await waitFor(() => expect(toast.error).toHaveBeenCalledWith('File too large'))
+		expect(toast.error).not.toHaveBeenCalledWith(expect.stringContaining('20MB max'))
+	})
+})

--- a/packages/browser/src/scenes/book/settings/BookThumbnailSelector.tsx
+++ b/packages/browser/src/scenes/book/settings/BookThumbnailSelector.tsx
@@ -6,6 +6,7 @@ import {
 	graphql,
 	useFragment,
 } from '@stump/graphql'
+import { useLocaleContext } from '@stump/i18n'
 import { useCallback, useState } from 'react'
 import { toast } from 'sonner'
 
@@ -59,6 +60,7 @@ type Props = {
 
 export default function BookThumbnailSelector({ fragment }: Props) {
 	const book = useFragment(BookThumbnailSelectorFragment, fragment)
+	const { t } = useLocaleContext()
 
 	const [isOpen, setIsOpen] = useState(false)
 	const [page, setPage] = useState<number>()
@@ -109,10 +111,10 @@ export default function BookThumbnailSelector({ fragment }: Props) {
 				setIsOpen(false)
 			} catch (error) {
 				console.error(error)
-				toast.error('Failed to upload image')
+				toast.error(t('thumbnailSelector.errors.uploadFailed'))
 			}
 		},
-		[book.id, uploadThumbnail],
+		[book.id, t, uploadThumbnail],
 	)
 
 	const handleConfirm = useCallback(async () => {
@@ -123,9 +125,9 @@ export default function BookThumbnailSelector({ fragment }: Props) {
 			setIsOpen(false)
 		} catch (error) {
 			console.error(error)
-			toast.error('Failed to update thumbnail')
+			toast.error(t('thumbnailSelector.errors.updateFailed'))
 		}
-	}, [patchThumbnail, page, book.id])
+	}, [patchThumbnail, page, book.id, t])
 
 	return (
 		<div className="relative">
@@ -147,9 +149,9 @@ export default function BookThumbnailSelector({ fragment }: Props) {
 				</Dialog.Trigger>
 				<Dialog.Content size="xl">
 					<Dialog.Header>
-						<Dialog.Title>Select a thumbnail</Dialog.Title>
+						<Dialog.Title>{t('thumbnailSelector.title')}</Dialog.Title>
 						<Dialog.Description>
-							Choose a page from this book to use as the new thumbnail
+							{t('thumbnailSelector.descriptions.chooseBookPage')}
 						</Dialog.Description>
 						<Dialog.Close onClick={() => setIsOpen(false)} />
 					</Dialog.Header>
@@ -163,14 +165,14 @@ export default function BookThumbnailSelector({ fragment }: Props) {
 
 					<Dialog.Footer>
 						<Button variant="outline" onClick={handleCancel}>
-							Cancel
+							{t('common.cancel')}
 						</Button>
 						<Button
 							onClick={handleConfirm}
 							disabled={!page}
 							isLoading={isPatchingThumbnail || isUploadingThumbnail}
 						>
-							Confirm selection
+							{t('thumbnailSelector.actions.confirmSelection')}
 						</Button>
 					</Dialog.Footer>
 				</Dialog.Content>

--- a/packages/browser/src/scenes/series/tabs/settings/SeriesThumbnailSelector.tsx
+++ b/packages/browser/src/scenes/series/tabs/settings/SeriesThumbnailSelector.tsx
@@ -6,6 +6,7 @@ import {
 	SeriesThumbnailSelectorUpdateMutation,
 	useFragment,
 } from '@stump/graphql'
+import { useLocaleContext } from '@stump/i18n'
 import { Suspense, useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
 
@@ -62,6 +63,7 @@ type Props = {
 
 export default function SeriesThumbnailSelector({ fragment }: Props) {
 	const series = useFragment(SeriesThumbnailSelectorFragment, fragment)
+	const { t } = useLocaleContext()
 
 	const { sdk } = useSDK()
 	const [selectedBook, setSelectedBook] = useState<SelectedBook>()
@@ -114,10 +116,10 @@ export default function SeriesThumbnailSelector({ fragment }: Props) {
 				setIsOpen(false)
 			} catch (error) {
 				console.error(error)
-				toast.error('Failed to upload image')
+				toast.error(t('thumbnailSelector.errors.uploadFailed'))
 			}
 		},
-		[series.id, uploadThumbnail],
+		[series.id, t, uploadThumbnail],
 	)
 
 	const handleConfirm = useCallback(async () => {
@@ -128,9 +130,9 @@ export default function SeriesThumbnailSelector({ fragment }: Props) {
 			setIsOpen(false)
 		} catch (error) {
 			console.error(error)
-			toast.error('Failed to update thumbnail')
+			toast.error(t('thumbnailSelector.errors.updateFailed'))
 		}
-	}, [patchThumbnail, page, selectedBook, series.id])
+	}, [patchThumbnail, page, selectedBook, series.id, t])
 
 	const renderContent = () => {
 		if (selectedBook) {
@@ -176,11 +178,11 @@ export default function SeriesThumbnailSelector({ fragment }: Props) {
 				</Dialog.Trigger>
 				<Dialog.Content size="xl">
 					<Dialog.Header>
-						<Dialog.Title>Select a thumbnail</Dialog.Title>
+						<Dialog.Title>{t('thumbnailSelector.title')}</Dialog.Title>
 						<Dialog.Description>
 							{selectedBook
-								? 'Choose a page from this book to use as the new thumbnail'
-								: 'Select a book from the series'}
+								? t('thumbnailSelector.descriptions.chooseBookPage')
+								: t('thumbnailSelector.descriptions.chooseSeriesBook')}
 
 							{selectedBook && (
 								<span
@@ -190,7 +192,7 @@ export default function SeriesThumbnailSelector({ fragment }: Props) {
 										setPage(undefined)
 									}}
 								>
-									Go back
+									{t('common.goBack')}
 								</span>
 							)}
 						</Dialog.Description>
@@ -201,14 +203,14 @@ export default function SeriesThumbnailSelector({ fragment }: Props) {
 
 					<Dialog.Footer>
 						<Button variant="outline" onClick={handleCancel}>
-							Cancel
+							{t('common.cancel')}
 						</Button>
 						<Button
 							onClick={handleConfirm}
 							disabled={!selectedBook || !page}
 							isLoading={isPatchingThumbnail || isUploadingThumbnail}
 						>
-							Confirm selection
+							{t('thumbnailSelector.actions.confirmSelection')}
 						</Button>
 					</Dialog.Footer>
 				</Dialog.Content>

--- a/packages/browser/src/scenes/series/tabs/settings/__tests__/SeriesThumbnailSelector.test.tsx
+++ b/packages/browser/src/scenes/series/tabs/settings/__tests__/SeriesThumbnailSelector.test.tsx
@@ -1,0 +1,69 @@
+import '@/__mocks__/pointerCapture'
+import '@/__mocks__/resizeObserver'
+
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import SeriesThumbnailSelector from '../SeriesThumbnailSelector'
+
+vi.mock('@stump/client', () => ({
+	useGraphQLMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useSDK: () => ({
+		sdk: {
+			axios: { get: vi.fn() },
+			media: { bookPageURL: vi.fn() },
+		},
+	}),
+}))
+
+vi.mock('@stump/graphql', async () => {
+	const actual = await vi.importActual<typeof import('@stump/graphql')>('@stump/graphql')
+
+	return {
+		...actual,
+		useFragment: (_fragment: unknown, fragment: unknown) => fragment,
+	}
+})
+
+vi.mock('@stump/i18n', () => ({
+	useLocaleContext: () => ({ t: (key: string) => `translated:${key}` }),
+}))
+
+vi.mock('@/components/entity', () => ({
+	EntityCard: () => <div />,
+}))
+
+vi.mock('@/components/thumbnail/EditThumbnailDropdown', () => ({
+	default: ({ onChooseSelector }: { onChooseSelector: () => void }) => (
+		<button onClick={onChooseSelector}>Choose thumbnail</button>
+	),
+}))
+
+vi.mock('../../../../book/settings/BookPageGrid', () => ({
+	default: () => <div />,
+}))
+
+vi.mock('../SeriesBookGrid', () => ({
+	default: () => <div />,
+}))
+
+describe('SeriesThumbnailSelector', () => {
+	it('renders localized selector content after opening the dialog', () => {
+		render(
+			<SeriesThumbnailSelector
+				fragment={
+					{ id: 'series-1', thumbnail: { url: 'https://example.com/thumbnail.jpg' } } as any
+				}
+			/>,
+		)
+
+		fireEvent.click(screen.getByRole('button', { name: 'Choose thumbnail' }))
+
+		expect(screen.getByText('translated:thumbnailSelector.title')).toBeInTheDocument()
+		expect(
+			screen.getByText('translated:thumbnailSelector.descriptions.chooseSeriesBook'),
+		).toBeInTheDocument()
+		expect(
+			screen.getByRole('button', { name: 'translated:thumbnailSelector.actions.confirmSelection' }),
+		).toBeInTheDocument()
+	})
+})

--- a/packages/i18n/src/locales/en-US.json
+++ b/packages/i18n/src/locales/en-US.json
@@ -2670,7 +2670,24 @@
 		"uploadImage": {
 			"emptyState": "A preview of your image will appear here",
 			"prompt": "Drop image here or click to select",
-			"remove": "Remove image"
+			"remove": "Remove image",
+			"fileTooLarge": "File too large",
+			"onlyOneFile": "Only one file is allowed",
+			"noFile": "No file was provided"
+		}
+	},
+	"thumbnailSelector": {
+		"title": "Select a thumbnail",
+		"descriptions": {
+			"chooseBookPage": "Choose a page from this book to use as the new thumbnail",
+			"chooseSeriesBook": "Select a book from the series"
+		},
+		"actions": {
+			"confirmSelection": "Confirm selection"
+		},
+		"errors": {
+			"uploadFailed": "Failed to upload image",
+			"updateFailed": "Failed to update thumbnail"
 		}
 	},
 	"common": {


### PR DESCRIPTION
## 목적
Localize the shared thumbnail upload flow and the book and series thumbnail selectors as a focused follow-up to closed PR #1318.

## 내용(의도 포함)
- Add focused `thumbnailSelector` source keys while keeping existing common and dropdown keys where they are semantically appropriate.
- Localize upload validation, selector descriptions, actions, and mutation failure messages.
- Remove the mutable `20MB max` value from translatable copy without changing the actual 20 MiB upload limit.
- Add regression tests for the oversized-file path and locale-context usage in the series selector.
- Keep library thumbnail management, translated locale files, mobile, desktop, book club, and `StumpRouter` changes out of scope.

This follows the namespace and review-scope feedback from closed PR #1318 in a smaller, independently reviewable change. English source strings can be translated through Weblate after merge.

## 성공기준
- Browser tests: 38 files and 246 tests passed.
- Browser and i18n type checks passed.
- Browser lint completed with 0 errors; 17 existing warnings remain outside the changed files.
- `git diff --check` passed.
- Target hard-coded strings no longer remain in the three changed production components.
- Layout, DOM order, state transitions, GraphQL mutations, and upload behavior remain unchanged by source inspection.
- Authenticated manual browser rendering was not performed.