### PR TITLE
:adhesive_bandage: Fix responsive sizing for created API key modal

### DIFF
--- a/packages/browser/src/scenes/settings/app/apiKeys/CreateAPIKeyModal.tsx
+++ b/packages/browser/src/scenes/settings/app/apiKeys/CreateAPIKeyModal.tsx
@@ -122,17 +122,22 @@ export default function CreateAPIKeyModal() {
 							</div>
 
 							<div className="gap-1 flex items-center">
-								<Button size="icon" onClick={() => setHideSecret((prev) => !prev)}>
+								<Button
+									size="icon"
+									className="size-7"
+									onClick={() => setHideSecret((prev) => !prev)}
+									variant="ghost"
+								>
 									<VisibilityIcon className="h-4 w-4 text-muted-foreground" />
 								</Button>
-								<Button size="icon" onClick={() => copy()}>
+								<Button size="icon" className="size-7" onClick={() => copy()} variant="ghost">
 									<CopyIcon className="h-4 w-4 text-muted-foreground" />
 								</Button>
 							</div>
 						</div>
 
 						<div className="p-3 text-sm rounded-lg bg-secondary text-foreground">
-							<span>
+							<span className="font-mono break-all">
 								<code>{hideSecret ? maskedSecret : apiSecret}</code>
 							</span>
 						</div>


### PR DESCRIPTION
## Description

it was clipping the content on smaller viewports, i also made the buttons not ugly


## Screenshots

<details>
<summary>Fixed</summary>
<img width="1233" height="999" alt="Screenshot 2026-08-30 at 12 00 20 PM" src="https://github.com/user-attachments/assets/8fbab53d-9142-4169-8815-a17812f56f80" />

</details>


## Stump Contributor License Agreement

By contributing to Stump, you agree that your contributions will be licensed under the following licenses (where applicable):

- The [expo application](https://github.com/stumpapp/stump/blob/main/apps/expo/LICENSE) is licensed under [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.html)
- All other code in the repository is licensed under [MIT License](https://www.tldrlegal.com/license/mit-license)
