### PR TITLE
 🐛 Fix stale thumbnail caching

### DIFF
--- a/core/src/filesystem/image/thumbnail/generate.rs
+++ b/core/src/filesystem/image/thumbnail/generate.rs
@@ -1,5 +1,6 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
+use chrono::Utc;
 use futures::{stream::FuturesUnordered, StreamExt};
 use models::{
 	entity::{library, media, series},
@@ -9,8 +10,8 @@ use models::{
 	},
 };
 use sea_orm::{
-	prelude::*, sea_query::Query, EntityTrait, Order, QueryFilter, QueryOrder,
-	QuerySelect,
+	prelude::*, sea_query::Query, ConnectionTrait, EntityTrait, Order, QueryFilter,
+	QueryOrder, QuerySelect,
 };
 use tokio::{fs, sync::oneshot, task::spawn_blocking};
 
@@ -39,7 +40,7 @@ pub enum ThumbnailGenerateError {
 	ProcessorError(#[from] ProcessorError),
 	#[error("Did not receive thumbnail generation result")]
 	ResultNeverReceived,
-	#[error("Failed to update media entity")]
+	#[error("Failed to update thumbnail entity")]
 	UpdateFailed,
 	#[error("A candidate source for thumbnail generation could not be found")]
 	NothingToGenerate,
@@ -59,7 +60,87 @@ pub struct GenerateThumbnailOptions {
 	pub image_options: ImageProcessorOptions,
 	pub core_config: StumpConfig,
 	pub force_regen: bool,
-	pub filename: Option<String>,
+	pub is_custom: bool,
+	pub target: ThumbnailTarget,
+}
+
+#[derive(Debug, Clone)]
+pub enum ThumbnailTarget {
+	Media,
+	Series(String),
+	Library(String),
+}
+
+fn is_generated_thumbnail(path: &Path) -> bool {
+	path.file_stem()
+		.and_then(|stem| stem.to_str())
+		.is_some_and(|stem| stem.ends_with(".generated"))
+}
+
+pub async fn bump_media_thumbnail_fallbacks<C>(
+	conn: &C,
+	series_id: Option<&str>,
+) -> Result<(), DbErr>
+where
+	C: ConnectionTrait,
+{
+	let Some(series_id) = series_id else {
+		return Ok(());
+	};
+	let updated_at = Some(DateTimeWithTimeZone::from(Utc::now()));
+
+	series::Entity::update_many()
+		.filter(series::Column::Id.eq(series_id))
+		.col_expr(series::Column::UpdatedAt, Expr::value(updated_at.clone()))
+		.exec(conn)
+		.await?;
+
+	library::Entity::update_many()
+		.filter(
+			library::Column::Id.in_subquery(
+				Query::select()
+					.column(series::Column::LibraryId)
+					.from(series::Entity)
+					.and_where(series::Column::Id.eq(series_id))
+					.to_owned(),
+			),
+		)
+		.col_expr(library::Column::UpdatedAt, Expr::value(updated_at))
+		.exec(conn)
+		.await?;
+
+	Ok(())
+}
+
+pub async fn bump_series_thumbnail_fallbacks<C>(
+	conn: &C,
+	series_ids: &[String],
+) -> Result<(), DbErr>
+where
+	C: ConnectionTrait,
+{
+	if series_ids.is_empty() {
+		return Ok(());
+	}
+
+	library::Entity::update_many()
+		.filter(
+			library::Column::Id.in_subquery(
+				Query::select()
+					.column(series::Column::LibraryId)
+					.from(series::Entity)
+					.and_where(series::Column::Id.is_in(series_ids.iter().cloned()))
+					.to_owned(),
+			),
+		)
+		.col_expr(
+			library::Column::UpdatedAt,
+			Expr::value(Some(DateTimeWithTimeZone::from(Utc::now()))),
+		)
+		.exec(conn)
+		.await?;
+
+	Ok(())
 }
 
 /// A type alias for whether a thumbnail was generated or not during the generation process. This is
@@ -106,28 +187,40 @@ pub async fn generate_book_thumbnail(
 		image_options,
 		core_config,
 		force_regen,
-		filename,
+		is_custom,
+		target,
 	}: GenerateThumbnailOptions,
 ) -> Result<GenerateOutput, ThumbnailGenerateError> {
 	let book_path = book.path.clone();
-	let file_name = filename.unwrap_or_else(|| book.id.clone());
-
-	let file_path = if let Some(stored_path) = &book.thumbnail_path {
-		PathBuf::from(stored_path.clone())
+	let entity_id = match &target {
+		ThumbnailTarget::Media => book.id.clone(),
+		ThumbnailTarget::Series(id) | ThumbnailTarget::Library(id) => id.clone(),
+	};
+	let file_name = if is_custom {
+		entity_id
 	} else {
-		core_config.get_thumbnails_dir().join(format!(
+		format!("{entity_id}.generated")
+	};
+
+	let file_path = match (&target, &book.thumbnail_path) {
+		(ThumbnailTarget::Media, Some(stored_path)) => PathBuf::from(stored_path),
+		_ => core_config.get_thumbnails_dir().join(format!(
 			"{}.{}",
 			file_name,
 			image_options.format.extension()
-		))
+		)),
 	};
+	let preserve_existing = !force_regen
+		|| matches!(&target, ThumbnailTarget::Media)
+			&& !is_custom
+			&& !is_generated_thumbnail(&file_path);
 
 	if let Err(e) = fs::metadata(&file_path).await {
 		// A `NotFound` error is expected here, but anything else is unexpected
 		if e.kind() != std::io::ErrorKind::NotFound {
 			tracing::error!(error = ?e, "IO error while checking for file existence?");
 		}
-	} else if !force_regen {
+	} else if preserve_existing {
 		match fs::read(&file_path).await {
 			Ok(thumbnail) => return Ok((thumbnail, PathBuf::from(&file_path), false)),
 			Err(e) => {
@@ -188,26 +281,74 @@ pub async fn generate_book_thumbnail(
 			},
 		};
 
-	let update_result = media::Entity::update_many()
-		.filter(media::Column::Id.eq(book.id.clone()))
-		.col_expr(
-			media::Column::ThumbnailPath,
-			Expr::value(Some(thumbnail_path.to_string_lossy().to_string())),
-		)
-		.col_expr(
-			media::Column::ThumbnailMeta,
-			Expr::value(thumbnail_metadata),
-		)
-		.exec(conn)
-		.await;
-
-	match update_result {
-		Ok(_) => Ok((thumbnail, thumbnail_path, did_generate)),
-		Err(e) => {
-			tracing::error!(error = ?e, "Failed to update media entity with thumbnail info");
-			Err(ThumbnailGenerateError::UpdateFailed)
+	let thumbnail_path_value = thumbnail_path.to_string_lossy().to_string();
+	let updated_at = Some(DateTimeWithTimeZone::from(Utc::now()));
+	let update_result = match &target {
+		ThumbnailTarget::Media => {
+			media::Entity::update_many()
+				.filter(media::Column::Id.eq(&book.id))
+				.col_expr(
+					media::Column::ThumbnailPath,
+					Expr::value(Some(thumbnail_path_value)),
+				)
+				.col_expr(
+					media::Column::ThumbnailMeta,
+					Expr::value(thumbnail_metadata),
+				)
+				.col_expr(media::Column::UpdatedAt, Expr::value(updated_at))
+				.exec(conn)
+				.await
 		},
+		ThumbnailTarget::Series(id) => {
+			series::Entity::update_many()
+				.filter(series::Column::Id.eq(id))
+				.col_expr(
+					series::Column::ThumbnailPath,
+					Expr::value(Some(thumbnail_path_value)),
+				)
+				.col_expr(
+					series::Column::ThumbnailMeta,
+					Expr::value(thumbnail_metadata),
+				)
+				.col_expr(series::Column::UpdatedAt, Expr::value(updated_at))
+				.exec(conn)
+				.await
+		},
+		ThumbnailTarget::Library(id) => {
+			library::Entity::update_many()
+				.filter(library::Column::Id.eq(id))
+				.col_expr(
+					library::Column::ThumbnailPath,
+					Expr::value(Some(thumbnail_path_value)),
+				)
+				.col_expr(
+					library::Column::ThumbnailMeta,
+					Expr::value(thumbnail_metadata),
+				)
+				.col_expr(library::Column::UpdatedAt, Expr::value(updated_at))
+				.exec(conn)
+				.await
+		},
+	};
+
+	if let Err(error) = update_result {
+		tracing::error!(?error, "Failed to update entity with thumbnail info");
+		return Err(ThumbnailGenerateError::UpdateFailed);
 	}
+
+	if is_custom {
+		match &target {
+			ThumbnailTarget::Media => {
+				bump_media_thumbnail_fallbacks(conn, Some(&book.series_id)).await?
+			},
+			ThumbnailTarget::Series(id) => {
+				bump_series_thumbnail_fallbacks(conn, std::slice::from_ref(id)).await?
+			},
+			ThumbnailTarget::Library(_) => {},
+		}
+	}
+
+	Ok((thumbnail, thumbnail_path, did_generate))
 }
 
 /// Copy a book's thumbnail to a target entity (series or library) and update the database.
@@ -260,7 +401,7 @@ where
 	let dest_path = ctx
 		.config()
 		.get_thumbnails_dir()
-		.join(format!("{}.{}", entity_id, ext));
+		.join(format!("{}.generated.{}", entity_id, ext));
 
 	fs::copy(&source_path, &dest_path).await?;
 	tracing::debug!(
@@ -297,25 +438,30 @@ async fn generate_series_thumbnail(
 	ctx: &JobContext,
 	options: GenerateThumbnailOptions,
 ) -> Result<GenerateOutput, ThumbnailGenerateError> {
-	if let (false, Some(thumbnail_path)) = (options.force_regen, &series.thumbnail_path) {
-		match fs::metadata(thumbnail_path).await {
-			Ok(_) => {
-				tracing::debug!(
-					series_id = %series.id,
-					?thumbnail_path,
-					"Thumbnail already exists, skipping generation"
-				);
-				let thumbnail_data = fs::read(thumbnail_path).await?;
-				return Ok((thumbnail_data, PathBuf::from(thumbnail_path), false));
-			},
-			Err(error) => {
-				tracing::debug!(
-					?error,
-					series_id = %series.id,
-					?thumbnail_path,
-					"Thumbnail path exists in DB but file may be missing, regenerating"
-				);
-			},
+	if let Some(thumbnail_path) = &series.thumbnail_path {
+		let preserve_existing =
+			!options.force_regen || !is_generated_thumbnail(Path::new(thumbnail_path));
+
+		if preserve_existing {
+			match fs::metadata(thumbnail_path).await {
+				Ok(_) => {
+					tracing::debug!(
+						series_id = %series.id,
+						?thumbnail_path,
+						"Thumbnail already exists, skipping generation"
+					);
+					let thumbnail_data = fs::read(thumbnail_path).await?;
+					return Ok((thumbnail_data, PathBuf::from(thumbnail_path), false));
+				},
+				Err(error) => {
+					tracing::debug!(
+						?error,
+						series_id = %series.id,
+						?thumbnail_path,
+						"Thumbnail path exists in DB but file may be missing, regenerating"
+					);
+				},
+			}
 		}
 	}
 
@@ -349,6 +495,10 @@ async fn generate_series_thumbnail(
 					series::Column::ThumbnailMeta,
 					Expr::value(thumbnail_metadata),
 				)
+				.col_expr(
+					series::Column::UpdatedAt,
+					Expr::value(Some(DateTimeWithTimeZone::from(Utc::now()))),
+				)
 		},
 	)
 	.await
@@ -360,26 +510,30 @@ async fn generate_library_thumbnail(
 	ctx: &JobContext,
 	options: GenerateThumbnailOptions,
 ) -> Result<GenerateOutput, ThumbnailGenerateError> {
-	if let (false, Some(thumbnail_path)) = (options.force_regen, &library.thumbnail_path)
-	{
-		match fs::metadata(thumbnail_path).await {
-			Ok(_) => {
-				tracing::debug!(
-					library_id = %library.id,
-					?thumbnail_path,
-					"Thumbnail already exists, skipping generation"
-				);
-				let thumbnail_data = fs::read(thumbnail_path).await?;
-				return Ok((thumbnail_data, PathBuf::from(thumbnail_path), false));
-			},
-			Err(error) => {
-				tracing::debug!(
-					?error,
-					library_id = %library.id,
-					?thumbnail_path,
-					"Thumbnail path exists in DB but file may be missing, regenerating"
-				);
-			},
+	if let Some(thumbnail_path) = &library.thumbnail_path {
+		let preserve_existing =
+			!options.force_regen || !is_generated_thumbnail(Path::new(thumbnail_path));
+
+		if preserve_existing {
+			match fs::metadata(thumbnail_path).await {
+				Ok(_) => {
+					tracing::debug!(
+						library_id = %library.id,
+						?thumbnail_path,
+						"Thumbnail already exists, skipping generation"
+					);
+					let thumbnail_data = fs::read(thumbnail_path).await?;
+					return Ok((thumbnail_data, PathBuf::from(thumbnail_path), false));
+				},
+				Err(error) => {
+					tracing::debug!(
+						?error,
+						library_id = %library.id,
+						?thumbnail_path,
+						"Thumbnail path exists in DB but file may be missing, regenerating"
+					);
+				},
+			}
 		}
 	}
 
@@ -414,6 +568,10 @@ async fn generate_library_thumbnail(
 				.col_expr(
 					library::Column::ThumbnailMeta,
 					Expr::value(thumbnail_metadata),
+				)
+				.col_expr(
+					library::Column::UpdatedAt,
+					Expr::value(Some(DateTimeWithTimeZone::from(Utc::now()))),
 				)
 		},
 	)

--- a/core/src/filesystem/image/thumbnail/generation_job.rs
+++ b/core/src/filesystem/image/thumbnail/generation_job.rs
@@ -10,7 +10,8 @@ use sea_orm::{prelude::*, QuerySelect, QueryTrait};
 use crate::{
 	database::{chunk_vec_into, SQLITE_BIND_LIMIT},
 	filesystem::image::thumbnail::generate::{
-		safely_generate_batch, GenerateImageSource, GenerateThumbnailOptions,
+		bump_series_thumbnail_fallbacks, safely_generate_batch, GenerateImageSource,
+		GenerateThumbnailOptions, ThumbnailTarget,
 	},
 	job::{
 		error::JobError, JobContext, JobLifecycle, JobOutputExt, JobProgress,
@@ -307,7 +308,8 @@ impl JobLifecycle for ThumbnailGenerationJob {
 						image_options: self.options.clone(),
 						core_config: ctx.config().clone(),
 						force_regen: self.params.force_regenerate,
-						filename: None, // Each book will use its ID as the filename
+						is_custom: false,
+						target: ThumbnailTarget::Media,
 					},
 					|position| {
 						ctx.report_progress(JobProgress::subtask_position(
@@ -321,6 +323,7 @@ impl JobLifecycle for ThumbnailGenerationJob {
 				logs.extend(sub_logs);
 			},
 			ThumbnailGenerationTask::Series(series_ids) => {
+				let fallback_series_ids = series_ids.clone();
 				let series = series::Entity::find()
 					.select_only()
 					.columns(series::SeriesThumbSelect::columns())
@@ -348,7 +351,8 @@ impl JobLifecycle for ThumbnailGenerationJob {
 						image_options: self.options.clone(),
 						core_config: ctx.config().clone(),
 						force_regen: self.params.force_regenerate,
-						filename: None, // Each series will use its ID as the filename
+						is_custom: false,
+						target: ThumbnailTarget::Media,
 					},
 					|position| {
 						ctx.report_progress(JobProgress::subtask_position(
@@ -358,6 +362,11 @@ impl JobLifecycle for ThumbnailGenerationJob {
 					},
 				)
 				.await;
+				if sub_output.generated_thumbnails > 0 {
+					bump_series_thumbnail_fallbacks(ctx.conn(), &fallback_series_ids)
+						.await
+						.map_err(|e| JobError::TaskFailed(e.to_string()))?;
+				}
 				output.update(sub_output);
 				logs.extend(sub_logs);
 			},
@@ -389,7 +398,8 @@ impl JobLifecycle for ThumbnailGenerationJob {
 						image_options: self.options.clone(),
 						core_config: ctx.config().clone(),
 						force_regen: self.params.force_regenerate,
-						filename: None, // Each library will use its ID as the filename
+						is_custom: false,
+						target: ThumbnailTarget::Media,
 					},
 					|position| {
 						ctx.report_progress(JobProgress::subtask_position(

--- a/core/src/filesystem/image/thumbnail/mod.rs
+++ b/core/src/filesystem/image/thumbnail/mod.rs
@@ -5,7 +5,9 @@ mod placeholder_job;
 mod utils;
 
 pub use generate::{
+	bump_media_thumbnail_fallbacks, bump_series_thumbnail_fallbacks,
 	generate_book_thumbnail, GenerateThumbnailOptions, ThumbnailGenerateError,
+	ThumbnailTarget,
 };
 pub use generation_job::{
 	ThumbnailGenerationJob, ThumbnailGenerationJobParams, ThumbnailGenerationJobScope,

--- a/core/src/filesystem/scanner/library_scan_job.rs
+++ b/core/src/filesystem/scanner/library_scan_job.rs
@@ -24,8 +24,8 @@ use crate::{
 	event::{self, CreatedOrUpdatedManyMedia},
 	filesystem::{
 		image::{
-			PlaceholderGenerationJobConfig, PlaceholderGenerationJobScope,
-			ThumbnailGenerationJobParams,
+			bump_media_thumbnail_fallbacks, PlaceholderGenerationJobConfig,
+			PlaceholderGenerationJobScope, ThumbnailGenerationJobParams,
 		},
 		metadata::MetadataFetchJobParams,
 		scanner::utils::safely_insert_series,
@@ -39,6 +39,7 @@ use crate::{
 };
 
 use super::{
+	options::BookVisitOperation,
 	series_scan_job::SeriesScanTask,
 	utils::{
 		handle_missing_media, handle_missing_series, handle_restored_media,
@@ -100,6 +101,24 @@ impl LibraryScanJob {
 			pending_dir_mtimes: Arc::new(Mutex::new(vec![])),
 			series_id_by_path: Arc::new(Mutex::new(HashMap::new())),
 		}
+	}
+
+	async fn bump_thumbnail_fallbacks(
+		&self,
+		ctx: &JobContext,
+		series_id: &str,
+		changed_media: u64,
+	) -> Result<(), JobError> {
+		if changed_media > 0
+			&& self
+				.config
+				.as_ref()
+				.is_some_and(|config| config.thumbnail_config.is_none())
+		{
+			bump_media_thumbnail_fallbacks(ctx.conn(), Some(series_id)).await?;
+		}
+
+		Ok(())
 	}
 }
 
@@ -311,7 +330,10 @@ impl JobLifecycle for LibraryScanJob {
 				tracing::trace!("Thumbnail generation job should be enqueued");
 				let params = ThumbnailGenerationJobParams::books_in_library(
 					self.id.clone(),
-					false,
+					matches!(
+						self.options.book_operation(),
+						Some(BookVisitOperation::Rebuild)
+					),
 				);
 				if let Err(e) = ctx
 					.enqueue(StumpJob::thumbnail_generation(options, params))
@@ -803,6 +825,8 @@ impl JobLifecycle for LibraryScanJob {
 						logs: new_logs,
 						..
 					} = handle_restored_media(ctx, &series_id, ids).await;
+					self.bump_thumbnail_fallbacks(ctx, &series_id, updated_media)
+						.await?;
 
 					ctx.emit_event(CoreEvent::CreatedOrUpdatedManyMedia(
 						CreatedOrUpdatedManyMedia {
@@ -829,6 +853,8 @@ impl JobLifecycle for LibraryScanJob {
 						logs: new_logs,
 						..
 					} = handle_missing_media(ctx, &series_id, paths).await;
+					self.bump_thumbnail_fallbacks(ctx, &series_id, updated_media)
+						.await?;
 
 					ctx.emit_event(CoreEvent::CreatedOrUpdatedManyMedia(
 						CreatedOrUpdatedManyMedia {
@@ -867,6 +893,8 @@ impl JobLifecycle for LibraryScanJob {
 						paths,
 					)
 					.await?;
+					self.bump_thumbnail_fallbacks(ctx, &series_id, created_media)
+						.await?;
 
 					ctx.emit_event(CoreEvent::CreatedOrUpdatedManyMedia(
 						CreatedOrUpdatedManyMedia {
@@ -904,6 +932,8 @@ impl JobLifecycle for LibraryScanJob {
 						params,
 					)
 					.await?;
+					self.bump_thumbnail_fallbacks(ctx, &series_id, updated_media)
+						.await?;
 
 					ctx.emit_event(CoreEvent::CreatedOrUpdatedManyMedia(
 						event::CreatedOrUpdatedManyMedia {

--- a/core/src/filesystem/scanner/series_scan_job.rs
+++ b/core/src/filesystem/scanner/series_scan_job.rs
@@ -14,8 +14,8 @@ use serde::{Deserialize, Serialize};
 use crate::{
 	event,
 	filesystem::image::{
-		PlaceholderGenerationJobConfig, PlaceholderGenerationJobScope,
-		ThumbnailGenerationJobParams,
+		bump_media_thumbnail_fallbacks, PlaceholderGenerationJobConfig,
+		PlaceholderGenerationJobScope, ThumbnailGenerationJobParams,
 	},
 	job::{
 		error::JobError, stump_job::StumpJob, CoreJobOutput, JobContext, JobLifecycle,
@@ -216,11 +216,6 @@ impl JobLifecycle for SeriesScanJob {
 		ctx: &JobContext,
 		output: &Self::Output,
 	) -> Result<(), JobError> {
-		ctx.emit_event(CoreEvent::JobOutput(event::JobOutput {
-			id: ctx.job_id.clone(),
-			output: CoreJobOutput::SeriesScan(output.clone()),
-		}));
-
 		let did_create = output.created_media > 0;
 		let did_update = output.updated_media > 0;
 
@@ -228,6 +223,14 @@ impl JobLifecycle for SeriesScanJob {
 			.config
 			.as_ref()
 			.and_then(|o| o.thumbnail_config.clone());
+		if image_options.is_none() && (did_create || did_update) {
+			bump_media_thumbnail_fallbacks(ctx.conn(), Some(&self.id)).await?;
+		}
+
+		ctx.emit_event(CoreEvent::JobOutput(event::JobOutput {
+			id: ctx.job_id.clone(),
+			output: CoreJobOutput::SeriesScan(output.clone()),
+		}));
 
 		match image_options {
 			Some(options) if did_create || did_update => {

--- a/crates/graphql/src/mutation/library.rs
+++ b/crates/graphql/src/mutation/library.rs
@@ -13,14 +13,14 @@ use models::{
 };
 use sea_orm::{
 	prelude::*,
-	sea_query::{OnConflict, Query},
+	sea_query::{Expr, OnConflict, Query},
 	Condition, IntoActiveModel, QuerySelect, Set, TransactionTrait,
 };
 use stump_core::filesystem::{
 	image::{
 		generate_book_thumbnail, remove_thumbnails, GenerateThumbnailOptions,
 		ImageProcessorOptionsExt, PlaceholderGenerationJobConfig,
-		PlaceholderGenerationJobScope, ThumbnailGenerationJobParams,
+		PlaceholderGenerationJobScope, ThumbnailGenerationJobParams, ThumbnailTarget,
 	},
 	media::analysis::{AnalysisJobConfig, MediaAnalysisJobScope},
 	metadata::{MetadataFetchJobParams, MetadataFetchScope},
@@ -523,7 +523,7 @@ impl LibraryMutation {
 		let core = ctx.data::<CoreContext>()?;
 		let AuthContext { user, .. } = ctx.data::<AuthContext>()?;
 
-		let (library, config) = library::Entity::find_for_user(user)
+		let (_library, config) = library::Entity::find_for_user(user)
 			.filter(library::Column::Id.eq(id.to_string()))
 			.find_also_related(library_config::Entity)
 			.one(core.conn.as_ref())
@@ -555,11 +555,18 @@ impl LibraryMutation {
 				image_options,
 				core_config: core.config.as_ref().clone(),
 				force_regen: true,
-				filename: Some(id.to_string()),
+				is_custom: true,
+				target: ThumbnailTarget::Library(id.to_string()),
 			},
 		)
 		.await?;
 		tracing::debug!(path = ?path_buf, "Generated library thumbnail");
+
+		let library = library::Entity::find_for_user(user)
+			.filter(library::Column::Id.eq(id.to_string()))
+			.one(core.conn.as_ref())
+			.await?
+			.ok_or("Library not found")?;
 
 		Ok(library.into())
 	}
@@ -790,9 +797,10 @@ impl LibraryMutation {
 			.one(core.conn.as_ref())
 			.await?
 			.ok_or("Library not found")?;
+		let library_id = library.id;
 
-		let series = series::Entity::find_for_user(user)
-			.filter(series::Column::LibraryId.eq(library.id.clone()))
+		let series = series::Entity::find()
+			.filter(series::Column::LibraryId.eq(library_id.clone()))
 			.select_only()
 			.columns(series::SeriesIdentSelect::columns())
 			.into_model::<series::SeriesIdentSelect>()
@@ -801,8 +809,13 @@ impl LibraryMutation {
 
 		let books = media::Entity::find()
 			.filter(
-				media::Column::SeriesId
-					.is_in(series.iter().map(|s| s.id.clone()).collect::<Vec<_>>()),
+				media::Column::SeriesId.in_subquery(
+					Query::select()
+						.column(series::Column::Id)
+						.from(series::Entity)
+						.and_where(series::Column::LibraryId.eq(library_id.clone()))
+						.to_owned(),
+				),
 			)
 			.select_only()
 			.columns(media::MediaIdentSelect::columns())
@@ -811,7 +824,7 @@ impl LibraryMutation {
 			.await?;
 
 		let ids = chain(
-			[library.id],
+			[library_id.clone()],
 			series
 				.iter()
 				.map(|s| s.id.clone())
@@ -824,6 +837,52 @@ impl LibraryMutation {
 			tracing::error!(?error, "Failed to remove library thumbnails");
 			return Err(error.into());
 		}
+
+		let updated_at = Some(DateTimeWithTimeZone::from(Utc::now()));
+		let txn = core.conn.as_ref().begin().await?;
+
+		library::Entity::update_many()
+			.filter(library::Column::Id.eq(library_id.clone()))
+			.col_expr(library::Column::ThumbnailPath, Expr::value(None::<String>))
+			.col_expr(
+				library::Column::ThumbnailMeta,
+				Expr::value(None::<models::shared::image::ImageMetadata>),
+			)
+			.col_expr(library::Column::UpdatedAt, Expr::value(updated_at.clone()))
+			.exec(&txn)
+			.await?;
+
+		series::Entity::update_many()
+			.filter(series::Column::LibraryId.eq(library_id.clone()))
+			.col_expr(series::Column::ThumbnailPath, Expr::value(None::<String>))
+			.col_expr(
+				series::Column::ThumbnailMeta,
+				Expr::value(None::<models::shared::image::ImageMetadata>),
+			)
+			.col_expr(series::Column::UpdatedAt, Expr::value(updated_at.clone()))
+			.exec(&txn)
+			.await?;
+
+		media::Entity::update_many()
+			.filter(
+				media::Column::SeriesId.in_subquery(
+					Query::select()
+						.column(series::Column::Id)
+						.from(series::Entity)
+						.and_where(series::Column::LibraryId.eq(library_id))
+						.to_owned(),
+				),
+			)
+			.col_expr(media::Column::ThumbnailPath, Expr::value(None::<String>))
+			.col_expr(
+				media::Column::ThumbnailMeta,
+				Expr::value(None::<models::shared::image::ImageMetadata>),
+			)
+			.col_expr(media::Column::UpdatedAt, Expr::value(updated_at))
+			.exec(&txn)
+			.await?;
+
+		txn.commit().await?;
 
 		Ok(true)
 	}

--- a/crates/graphql/src/mutation/media.rs
+++ b/crates/graphql/src/mutation/media.rs
@@ -11,7 +11,7 @@ use sea_orm::{
 };
 use stump_core::{
 	filesystem::{
-		image::{generate_book_thumbnail, GenerateThumbnailOptions},
+		image::{generate_book_thumbnail, GenerateThumbnailOptions, ThumbnailTarget},
 		media::analysis::{AnalysisJobConfig, MediaAnalysisJobScope},
 	},
 	job::stump_job::StumpJob,
@@ -214,11 +214,18 @@ impl MediaMutation {
 				image_options,
 				core_config: core.config.as_ref().clone(),
 				force_regen: true,
-				filename: Some(id.to_string()),
+				is_custom: true,
+				target: ThumbnailTarget::Media,
 			},
 		)
 		.await?;
 		tracing::debug!(path = ?path_buf, "Generated book thumbnail");
+
+		let book = media::ModelWithMetadata::find_by_id_for_user(id.to_string(), user)
+			.into_model::<media::ModelWithMetadata>()
+			.one(core.conn.as_ref())
+			.await?
+			.ok_or("Book not found")?;
 
 		Ok(book.into())
 	}

--- a/crates/graphql/src/mutation/series.rs
+++ b/crates/graphql/src/mutation/series.rs
@@ -10,7 +10,7 @@ use sea_orm::{
 	ActiveValue::Set,
 };
 use stump_core::filesystem::{
-	image::{generate_book_thumbnail, GenerateThumbnailOptions},
+	image::{generate_book_thumbnail, GenerateThumbnailOptions, ThumbnailTarget},
 	media::analysis::{AnalysisJobConfig, MediaAnalysisJobScope},
 };
 use stump_core::job::stump_job::StumpJob;
@@ -163,11 +163,18 @@ impl SeriesMutation {
 				image_options,
 				core_config: core.config.as_ref().clone(),
 				force_regen: true,
-				filename: Some(id.to_string()),
+				is_custom: true,
+				target: ThumbnailTarget::Series(id.to_string()),
 			},
 		)
 		.await?;
 		tracing::debug!(path = ?path_buf, "Generated series thumbnail");
+
+		let series = series::ModelWithMetadata::find_by_id_for_user(id.to_string(), user)
+			.into_model::<series::ModelWithMetadata>()
+			.one(core.conn.as_ref())
+			.await?
+			.ok_or("Series not found")?;
 
 		Ok(series.into())
 	}

--- a/crates/graphql/src/mutation/upload.rs
+++ b/crates/graphql/src/mutation/upload.rs
@@ -11,11 +11,11 @@ use models::{
 	entity::{library, library_config, media, series},
 	shared::enums::UserPermission,
 };
-use sea_orm::{prelude::*, sea_query::Query};
+use sea_orm::{prelude::*, sea_query::Query, IntoActiveModel, Set};
 use stump_core::filesystem::{
 	image::{
-		place_thumbnail, remove_thumbnails, PlaceholderGenerationJobConfig,
-		PlaceholderGenerationJobScope,
+		bump_media_thumbnail_fallbacks, bump_series_thumbnail_fallbacks, place_thumbnail,
+		remove_thumbnails, PlaceholderGenerationJobConfig, PlaceholderGenerationJobScope,
 	},
 	ContentType,
 };
@@ -222,14 +222,9 @@ impl UploadMutation {
 
 		tracing::debug!(?path_buf, "Placed library thumbnail");
 
-		library::Entity::update_many()
-			.col_expr(
-				library::Column::ThumbnailPath,
-				Expr::value(Some(path_buf.to_string_lossy().to_string())),
-			)
-			.filter(library::Column::Id.eq(library.id.clone()))
-			.exec(core.conn.as_ref())
-			.await?;
+		let mut active = library.into_active_model();
+		active.thumbnail_path = Set(Some(path_buf.to_string_lossy().to_string()));
+		let library = active.update(core.conn.as_ref()).await?;
 
 		let config = config.ok_or("Library config not found")?;
 
@@ -277,9 +272,8 @@ impl UploadMutation {
 	) -> Result<Series> {
 		let AuthContext { user, .. } = ctx.data()?;
 		let core = ctx.data::<CoreContext>()?;
-		let _conn = core.conn.as_ref();
 
-		let series = series::ModelWithMetadata::find_for_user(user)
+		let mut series = series::ModelWithMetadata::find_for_user(user)
 			.filter(series::Column::Id.eq(id.to_string()))
 			.into_model::<series::ModelWithMetadata>()
 			.one(core.conn.as_ref())
@@ -322,14 +316,14 @@ impl UploadMutation {
 
 		tracing::debug!(?path_buf, "Placed series thumbnail");
 
-		series::Entity::update_many()
-			.col_expr(
-				series::Column::ThumbnailPath,
-				Expr::value(Some(path_buf.to_string_lossy().to_string())),
-			)
-			.filter(series::Column::Id.eq(series.series.id.clone()))
-			.exec(core.conn.as_ref())
-			.await?;
+		let mut active = series.series.clone().into_active_model();
+		active.thumbnail_path = Set(Some(path_buf.to_string_lossy().to_string()));
+		series.series = active.update(core.conn.as_ref()).await?;
+		bump_series_thumbnail_fallbacks(
+			core.conn.as_ref(),
+			std::slice::from_ref(&series.series.id),
+		)
+		.await?;
 
 		let config = library_config::Entity::find()
 			.filter(
@@ -385,7 +379,7 @@ impl UploadMutation {
 		let AuthContext { user, .. } = ctx.data()?;
 		let core = ctx.data::<CoreContext>()?;
 
-		let book = media::ModelWithMetadata::find_for_user(user)
+		let mut book = media::ModelWithMetadata::find_for_user(user)
 			.filter(media::Column::Id.eq(id.to_string()))
 			.into_model::<media::ModelWithMetadata>()
 			.one(core.conn.as_ref())
@@ -432,14 +426,14 @@ impl UploadMutation {
 
 		tracing::debug!(?path_buf, "Placed book thumbnail");
 
-		media::Entity::update_many()
-			.col_expr(
-				media::Column::ThumbnailPath,
-				Expr::value(Some(path_buf.to_string_lossy().to_string())),
-			)
-			.filter(media::Column::Id.eq(book.media.id.clone()))
-			.exec(core.conn.as_ref())
-			.await?;
+		let mut active = book.media.clone().into_active_model();
+		active.thumbnail_path = Set(Some(path_buf.to_string_lossy().to_string()));
+		book.media = active.update(core.conn.as_ref()).await?;
+		bump_media_thumbnail_fallbacks(
+			core.conn.as_ref(),
+			book.media.series_id.as_deref(),
+		)
+		.await?;
 
 		let config = library_config::Entity::find()
 			.filter(
@@ -504,7 +498,7 @@ impl UploadMutation {
 		let AuthContext { user, .. } = ctx.data()?;
 		let core = ctx.data::<CoreContext>()?;
 
-		let series = series::ModelWithMetadata::find_for_user(user)
+		let mut series = series::ModelWithMetadata::find_for_user(user)
 			.filter(series::Column::Id.eq(id.to_string()))
 			.into_model::<series::ModelWithMetadata>()
 			.one(core.conn.as_ref())
@@ -533,14 +527,14 @@ impl UploadMutation {
 
 		tracing::debug!(?path_buf, "Placed series thumbnail from base64");
 
-		series::Entity::update_many()
-			.col_expr(
-				series::Column::ThumbnailPath,
-				Expr::value(Some(path_buf.to_string_lossy().to_string())),
-			)
-			.filter(series::Column::Id.eq(series.series.id.clone()))
-			.exec(core.conn.as_ref())
-			.await?;
+		let mut active = series.series.clone().into_active_model();
+		active.thumbnail_path = Set(Some(path_buf.to_string_lossy().to_string()));
+		series.series = active.update(core.conn.as_ref()).await?;
+		bump_series_thumbnail_fallbacks(
+			core.conn.as_ref(),
+			std::slice::from_ref(&series.series.id),
+		)
+		.await?;
 
 		let config = library_config::Entity::find()
 			.filter(
@@ -599,7 +593,7 @@ impl UploadMutation {
 		let AuthContext { user, .. } = ctx.data()?;
 		let core = ctx.data::<CoreContext>()?;
 
-		let book = media::ModelWithMetadata::find_for_user(user)
+		let mut book = media::ModelWithMetadata::find_for_user(user)
 			.filter(media::Column::Id.eq(id.to_string()))
 			.into_model::<media::ModelWithMetadata>()
 			.one(core.conn.as_ref())
@@ -627,14 +621,14 @@ impl UploadMutation {
 
 		tracing::debug!(?path_buf, "Placed book thumbnail from base64");
 
-		media::Entity::update_many()
-			.col_expr(
-				media::Column::ThumbnailPath,
-				Expr::value(Some(path_buf.to_string_lossy().to_string())),
-			)
-			.filter(media::Column::Id.eq(book.media.id.clone()))
-			.exec(core.conn.as_ref())
-			.await?;
+		let mut active = book.media.clone().into_active_model();
+		active.thumbnail_path = Set(Some(path_buf.to_string_lossy().to_string()));
+		book.media = active.update(core.conn.as_ref()).await?;
+		bump_media_thumbnail_fallbacks(
+			core.conn.as_ref(),
+			book.media.series_id.as_deref(),
+		)
+		.await?;
 
 		let config = library_config::Entity::find()
 			.filter(

--- a/crates/graphql/src/object/library.rs
+++ b/crates/graphql/src/object/library.rs
@@ -383,6 +383,7 @@ impl Library {
 	/// qualified URL to the image.
 	async fn thumbnail(&self, ctx: &Context<'_>) -> Result<ImageRef> {
 		let service = ctx.data::<ServiceContext>()?;
+		let last_modified = self.model.updated_at;
 
 		let dimensions = self
 			.model
@@ -392,12 +393,14 @@ impl Library {
 			.map(|dim| (dim.width, dim.height));
 
 		Ok(ImageRef {
-			url: service
-				.format_url(format!("/api/v2/library/{}/thumbnail", self.model.id)),
+			url: service.cache_friendly_url(
+				format!("/api/v2/library/{}/thumbnail", self.model.id),
+				&last_modified,
+			),
 			height: dimensions.map(|(_, height)| height),
 			width: dimensions.map(|(width, _)| width),
 			metadata: self.model.thumbnail_meta.clone(),
-			..Default::default()
+			last_modified,
 		})
 	}
 }

--- a/crates/graphql/src/object/media.rs
+++ b/crates/graphql/src/object/media.rs
@@ -187,6 +187,7 @@ impl Media {
 	async fn thumbnail(&self, ctx: &Context<'_>) -> Result<ImageRef> {
 		let service = ctx.data::<ServiceContext>()?;
 		let loader = ctx.data::<DataLoader<MediaAnalysisLoader>>()?;
+		let last_modified = self.model.updated_at;
 
 		let dimensions = match self
 			.model
@@ -206,11 +207,14 @@ impl Media {
 		};
 
 		Ok(ImageRef {
-			url: service.format_url(format!("/api/v2/media/{}/thumbnail", self.model.id)),
+			url: service.cache_friendly_url(
+				format!("/api/v2/media/{}/thumbnail", self.model.id),
+				&last_modified,
+			),
 			height: dimensions.as_ref().map(|dim| dim.1),
 			width: dimensions.as_ref().map(|dim| dim.0),
 			metadata: self.model.thumbnail_meta.clone(),
-			..Default::default()
+			last_modified,
 		})
 	}
 

--- a/crates/graphql/src/object/series.rs
+++ b/crates/graphql/src/object/series.rs
@@ -314,6 +314,7 @@ impl Series {
 	/// qualified URL to the image.
 	async fn thumbnail(&self, ctx: &Context<'_>) -> Result<ImageRef> {
 		let service = ctx.data::<ServiceContext>()?;
+		let last_modified = self.model.updated_at;
 
 		let dimensions = self
 			.model
@@ -323,12 +324,14 @@ impl Series {
 			.map(|dim| (dim.width, dim.height));
 
 		Ok(ImageRef {
-			url: service
-				.format_url(format!("/api/v2/series/{}/thumbnail", self.model.id)),
+			url: service.cache_friendly_url(
+				format!("/api/v2/series/{}/thumbnail", self.model.id),
+				&last_modified,
+			),
 			height: dimensions.as_ref().map(|dim| dim.1),
 			width: dimensions.as_ref().map(|dim| dim.0),
 			metadata: self.model.thumbnail_meta.clone(),
-			..Default::default()
+			last_modified,
 		})
 	}
 

--- a/packages/browser/src/components/book/table/CoverImageCell.tsx
+++ b/packages/browser/src/components/book/table/CoverImageCell.tsx
@@ -1,4 +1,3 @@
-import { useSDK } from '@stump/client'
 import { Book } from 'lucide-react'
 import { useState } from 'react'
 
@@ -6,12 +5,11 @@ import { EntityImage } from '@/components/entity'
 import { usePreferences } from '@/hooks/usePreferences'
 
 type Props = {
-	id: string
+	url: string
 	title?: string
 }
 
-export default function CoverImageCell({ id, title }: Props) {
-	const { sdk } = useSDK()
+export default function CoverImageCell({ url, title }: Props) {
 	const {
 		preferences: { thumbnailRatio },
 	} = usePreferences()
@@ -20,7 +18,7 @@ export default function CoverImageCell({ id, title }: Props) {
 	const loadImage = () => {
 		const image = new Image()
 		return new Promise((resolve, reject) => {
-			image.src = sdk.media.thumbnailURL(id)
+			image.src = url
 			image.onload = () => resolve(image)
 			image.onerror = (e) => {
 				console.error('Image failed to load:', e)
@@ -57,7 +55,7 @@ export default function CoverImageCell({ id, title }: Props) {
 				title={title}
 				className="h-14 w-auto rounded-md object-cover p-px"
 				style={{ aspectRatio: thumbnailRatio }}
-				src={sdk.media.thumbnailURL(id)}
+				src={url}
 				onError={() => setShowFallback(true)}
 			/>
 		</div>

--- a/packages/browser/src/components/book/table/columns.tsx
+++ b/packages/browser/src/components/book/table/columns.tsx
@@ -40,7 +40,9 @@ function MetadataBadgeListCell({ values }: { values?: string[] | null }) {
 }
 
 const coverColumn = columnHelper.display({
-	cell: ({ row: { original: book } }) => <CoverImageCell id={book.id} title={book.resolvedName} />,
+	cell: ({ row: { original: book } }) => (
+		<CoverImageCell url={book.thumbnail.url} title={book.resolvedName} />
+	),
 	enableGlobalFilter: true,
 	header: () => null,
 	id: 'cover',

--- a/packages/browser/src/components/entity/AuthImage.tsx
+++ b/packages/browser/src/components/entity/AuthImage.tsx
@@ -5,10 +5,16 @@ type Props = {
 	token?: string
 } & React.ImgHTMLAttributes<HTMLImageElement>
 
+type LoadedImage = {
+	src: string
+	token: string
+	url: string
+}
+
 export const AuthImage = forwardRef<HTMLImageElement, Props>(({ token, src, ...props }, ref) => {
 	const { sdk } = useSDK()
 
-	const [imageURL, setImageURL] = useState<string | null>(null)
+	const [loadedImage, setLoadedImage] = useState<LoadedImage | null>(null)
 
 	const doFetch = useCallback(
 		async (url: string) => {
@@ -21,32 +27,48 @@ export const AuthImage = forwardRef<HTMLImageElement, Props>(({ token, src, ...p
 		[sdk.axios],
 	)
 	const fetchImage = useCallback(
-		async (url: string) => {
-			const data = await queryClient.fetchQuery({
+		(url: string) =>
+			queryClient.fetchQuery({
 				queryKey: ['AuthImage.fetchImage', url],
-				staleTime: 1000 * 60 * 60 * 24 * 5, // 5 days
-				queryFn: async () => doFetch(url),
-			})
-
-			const imageURL = URL.createObjectURL(data)
-			setImageURL(imageURL)
-		},
+				staleTime: 1000 * 60 * 60 * 24 * 5,
+				queryFn: () => doFetch(url),
+			}),
 		[doFetch],
 	)
 
 	useEffect(() => {
-		if (token && src && !imageURL) {
+		let active = true
+
+		if (token && src) {
 			fetchImage(src)
+				.then((data) => {
+					if (active) {
+						setLoadedImage({ src, token, url: URL.createObjectURL(data) })
+					}
+				})
+				.catch((error) => {
+					if (active) {
+						setLoadedImage({ src, token, url: src })
+						console.error('Failed to load authenticated image:', error)
+					}
+				})
 		}
-	}, [token, src, fetchImage, imageURL])
+
+		return () => {
+			active = false
+		}
+	}, [token, src, fetchImage])
 
 	useEffect(() => {
 		return () => {
-			if (imageURL) {
-				URL.revokeObjectURL(imageURL)
+			if (loadedImage?.url.startsWith('blob:')) {
+				URL.revokeObjectURL(loadedImage.url)
 			}
 		}
-	}, [imageURL])
+	}, [loadedImage])
+
+	const imageURL =
+		loadedImage && loadedImage.src === src && loadedImage.token === token ? loadedImage.url : null
 
 	if (!imageURL) {
 		return null

--- a/packages/browser/src/components/explorer/FileThumbnail.tsx
+++ b/packages/browser/src/components/explorer/FileThumbnail.tsx
@@ -3,12 +3,12 @@ import {
 	EBOOK_EXTENSION,
 	PDF_EXTENSION,
 	queryClient,
-	useSDK,
+	useGraphQL,
 } from '@stump/client'
 import { cn } from '@stump/components'
 import { graphql, MediaAtPathQuery } from '@stump/graphql'
 import { Api } from '@stump/sdk'
-import { useEffect, useRef, useState } from 'react'
+import { useState } from 'react'
 
 import { usePreferences } from '@/hooks/usePreferences'
 import { useTheme } from '@/hooks/useTheme'
@@ -39,23 +39,20 @@ function getIconSrc(path: string, isDirectory: boolean, isDark: boolean): string
 }
 
 export default function FileThumbnail({ path, isDirectory, thumbSize, containerClassName }: Props) {
-	const { sdk } = useSDK()
 	const {
 		preferences: { thumbnailRatio },
 	} = usePreferences()
 	const { isDarkVariant } = useTheme()
 
-	const [showFallback, setShowFallback] = useState(false)
-	const [book, setBook] = useState<MediaAtPath>(null)
-
-	const didFetchRef = useRef(false)
-
-	useEffect(() => {
-		if (!book && !didFetchRef.current && !isDirectory) {
-			didFetchRef.current = true
-			getBook(path, sdk).then(setBook)
-		}
-	}, [book, path, isDirectory, sdk])
+	const [failedThumbnailUrl, setFailedThumbnailUrl] = useState<string>()
+	const { data } = useGraphQL(
+		query,
+		['getMediaByPath', path],
+		{ path },
+		{ enabled: !isDirectory, staleTime: 1000 * 60 * 15 },
+	)
+	const book = data?.mediaByPath
+	const showFallback = !!book && failedThumbnailUrl === book.thumbnail.url
 
 	const iconSrc = getIconSrc(path, isDirectory, isDarkVariant)
 
@@ -65,7 +62,7 @@ export default function FileThumbnail({ path, isDirectory, thumbSize, containerC
 				<div
 					className={cn('relative flex shrink-0 items-center justify-center', containerClassName)}
 					style={{ width: thumbSize, height: thumbSize, minWidth: thumbSize, minHeight: thumbSize }}
-					onClick={showFallback ? () => setShowFallback(false) : undefined}
+					onClick={showFallback ? () => setFailedThumbnailUrl(undefined) : undefined}
 				>
 					<img
 						src={iconSrc}
@@ -83,8 +80,8 @@ export default function FileThumbnail({ path, isDirectory, thumbSize, containerC
 			>
 				<EntityImage
 					className="max-h-full max-w-full rounded-sm object-contain"
-					src={sdk.media.thumbnailURL(book.id)}
-					onError={() => setShowFallback(true)}
+					src={book.thumbnail.url}
+					onError={() => setFailedThumbnailUrl(book.thumbnail.url)}
 				/>
 			</div>
 		)
@@ -104,8 +101,8 @@ export default function FileThumbnail({ path, isDirectory, thumbSize, containerC
 		<EntityImage
 			className={cn('h-full w-auto rounded-sm object-cover', containerClassName)}
 			style={{ aspectRatio: thumbnailRatio }}
-			src={sdk.media.thumbnailURL(book.id)}
-			onError={() => setShowFallback(true)}
+			src={book.thumbnail.url}
+			onError={() => setFailedThumbnailUrl(book.thumbnail.url)}
 		/>
 	)
 }
@@ -123,18 +120,12 @@ const query = graphql(`
 `)
 
 export type MediaAtPath = MediaAtPathQuery['mediaByPath']
-/**
- * A function that attempts to fetch the book associated with the file, if any exists.
- * The queryClient is used in order to properly cache the result.
- */
+
 export const getBook = async (path: string, sdk: Api) => {
 	try {
 		const response = await queryClient.fetchQuery({
 			queryKey: ['getMediaByPath', path],
-			queryFn: async () => {
-				return sdk.execute(query, { path })
-			},
-			// 15 minutes
+			queryFn: () => sdk.execute(query, { path }),
 			staleTime: 1000 * 60 * 15,
 		})
 		return response.mediaByPath ?? null

--- a/packages/browser/src/components/series/SeriesCard.tsx
+++ b/packages/browser/src/components/series/SeriesCard.tsx
@@ -1,4 +1,3 @@
-import { useSDK } from '@stump/client'
 import { Text } from '@stump/components'
 import { FileStatus } from '@stump/graphql'
 import { useCallback } from 'react'
@@ -16,6 +15,7 @@ export interface SeriesCardData {
 	mediaCount: number
 	percentageCompleted: number
 	status: FileStatus
+	thumbnail: { url: string }
 }
 
 export type SeriesCardProps = {
@@ -25,8 +25,6 @@ export type SeriesCardProps = {
 }
 
 export default function SeriesCard({ data, fullWidth, variant = 'default' }: SeriesCardProps) {
-	const { sdk } = useSDK()
-
 	const isCoverOnly = variant === 'cover'
 
 	const prefetchSeries = usePrefetchSeries()
@@ -81,7 +79,7 @@ export default function SeriesCard({ data, fullWidth, variant = 'default' }: Ser
 		<EntityCard
 			title={data.resolvedName}
 			href={paths.seriesOverview(data.id)}
-			imageUrl={sdk.series.thumbnailURL(data.id)}
+			imageUrl={data.thumbnail.url}
 			progress={getProgress()}
 			subtitle={getSubtitle()}
 			onMouseEnter={prefetch}

--- a/packages/browser/src/components/series/table/CoverImageCell.tsx
+++ b/packages/browser/src/components/series/table/CoverImageCell.tsx
@@ -1,4 +1,3 @@
-import { useSDK } from '@stump/client'
 import { Book } from 'lucide-react'
 import { useState } from 'react'
 
@@ -6,18 +5,14 @@ import { EntityImage } from '@/components/entity'
 import { usePreferences } from '@/hooks/usePreferences'
 
 type Props = {
-	/**
-	 * The ID of the series
-	 */
-	id: string
+	url: string
 	/**
 	 * The title for the image
 	 */
 	title?: string
 }
 
-export default function CoverImageCell({ id, title }: Props) {
-	const { sdk } = useSDK()
+export default function CoverImageCell({ url, title }: Props) {
 	const {
 		preferences: { thumbnailRatio },
 	} = usePreferences()
@@ -26,7 +21,7 @@ export default function CoverImageCell({ id, title }: Props) {
 	const loadImage = () => {
 		const image = new Image()
 		return new Promise((resolve, reject) => {
-			image.src = sdk.series.thumbnailURL(id)
+			image.src = url
 			image.onload = () => resolve(image)
 			image.onerror = (e) => {
 				console.error('Image failed to load:', e)
@@ -62,7 +57,7 @@ export default function CoverImageCell({ id, title }: Props) {
 			title={title}
 			className="h-14 w-auto rounded-sm object-cover"
 			style={{ aspectRatio: thumbnailRatio }}
-			src={sdk.series.thumbnailURL(id)}
+			src={url}
 			onError={() => setShowFallback(true)}
 		/>
 	)

--- a/packages/browser/src/components/series/table/columns.tsx
+++ b/packages/browser/src/components/series/table/columns.tsx
@@ -13,9 +13,9 @@ const columnHelper = createColumnHelper<SeriesCardData>()
 const coverColumn = columnHelper.display({
 	cell: ({
 		row: {
-			original: { id, resolvedName },
+			original: { resolvedName, thumbnail },
 		},
-	}) => <CoverImageCell id={id} title={resolvedName} />,
+	}) => <CoverImageCell url={thumbnail.url} title={resolvedName} />,
 	enableGlobalFilter: true,
 	header: () => (
 		<Text size="sm" variant="secondary">

--- a/packages/browser/src/hooks/useCoreEvent.ts
+++ b/packages/browser/src/hooks/useCoreEvent.ts
@@ -7,6 +7,8 @@ import { toast } from 'sonner'
 import { match, P } from 'ts-pattern'
 import { useShallow } from 'zustand/react/shallow'
 
+import { invalidateThumbnailQueries } from '@/utils/query'
+
 const subscription = graphql(`
 	subscription UseCoreEvent {
 		readEvents {
@@ -173,6 +175,11 @@ const handleJobOutput = async (
 	{ output }: Extract<UseCoreEventSubscription['readEvents'], { __typename: 'JobOutput' }>,
 	{ client, sdk }: Omit<EventHandlerParams, 'store' | 'liveRefetch'>,
 ) => {
+	if (output.__typename === 'ThumbnailGenerationOutput') {
+		await invalidateThumbnailQueries(client)
+		return
+	}
+
 	const affectedBooks = match(output)
 		.with(
 			{ __typename: P.union('LibraryScanOutput', 'SeriesScanOutput') },
@@ -187,16 +194,21 @@ const handleJobOutput = async (
 		)
 		.with({ __typename: 'SeriesScanOutput' }, () => affectedBooks)
 		.otherwise(() => 0)
-
 	const keys = [
 		sdk.cacheKeys.scanHistory,
 		sdk.cacheKeys.getStats,
 		'missingEntities', // TODO: Put behind key?
-		...(affectedBooks > 0 ? [sdk.cacheKeys.recentlyAddedMedia, sdk.cacheKeys.media] : []),
-		...(affectedSeries > 0 ? [sdk.cacheKeys.recentlyAddedSeries, sdk.cacheKeys.series] : []),
+		...(affectedBooks > 0 ? [sdk.cacheKeys.media] : []),
+		...(affectedSeries > 0 ? [sdk.cacheKeys.series] : []),
 	] as string[]
 
-	await client.invalidateQueries({
-		predicate: ({ queryKey: [rootKey] }) => typeof rootKey === 'string' && keys.includes(rootKey),
-	})
+	const invalidations = [
+		client.invalidateQueries({
+			predicate: ({ queryKey: [rootKey] }) => typeof rootKey === 'string' && keys.includes(rootKey),
+		}),
+	]
+	if (affectedBooks > 0 || affectedSeries > 0) {
+		invalidations.push(invalidateThumbnailQueries(client))
+	}
+	await Promise.all(invalidations)
 }

--- a/packages/browser/src/scenes/book/settings/BookThumbnailSelector.tsx
+++ b/packages/browser/src/scenes/book/settings/BookThumbnailSelector.tsx
@@ -1,17 +1,14 @@
 import { useGraphQLMutation, useGraphQLUploadMutation, useSDK } from '@stump/client'
-import { Button, Dialog, PickSelect } from '@stump/components'
-import {
-	BookThumbnailSelectorUpdateMutation,
-	FragmentType,
-	graphql,
-	useFragment,
-} from '@stump/graphql'
+import { Button, Dialog } from '@stump/components'
+import { FragmentType, graphql, useFragment } from '@stump/graphql'
 import { useLocaleContext } from '@stump/i18n'
+import { useQueryClient } from '@tanstack/react-query'
 import { useCallback, useState } from 'react'
 import { toast } from 'sonner'
 
 import { EntityCard } from '@/components/entity'
 import EditThumbnailDropdown from '@/components/thumbnail/EditThumbnailDropdown'
+import { invalidateThumbnailQueries } from '@/utils/query'
 
 import BookPageGrid from './BookPageGrid'
 
@@ -52,8 +49,6 @@ const uploadMutation = graphql(`
 	}
 `)
 
-type OnSuccessData = PickSelect<BookThumbnailSelectorUpdateMutation, 'updateMediaThumbnail'>
-
 type Props = {
 	fragment: FragmentType<typeof BookThumbnailSelectorFragment>
 }
@@ -66,29 +61,18 @@ export default function BookThumbnailSelector({ fragment }: Props) {
 	const [page, setPage] = useState<number>()
 
 	const { sdk } = useSDK()
+	const queryClient = useQueryClient()
 
-	const onSuccess = useCallback(
-		({ thumbnail }: OnSuccessData) =>
-			sdk.axios.get(thumbnail.url, {
-				headers: {
-					'Cache-Control': 'no-cache',
-					Pragma: 'no-cache',
-					Expires: '0',
-				},
-			}),
-		[sdk],
-	)
+	const onSuccess = useCallback(() => invalidateThumbnailQueries(queryClient), [queryClient])
 
 	const { mutateAsync: patchThumbnail, isPending: isPatchingThumbnail } = useGraphQLMutation(
 		updateMutation,
-		{
-			onSuccess: (data) => onSuccess(data.updateMediaThumbnail),
-		},
+		{ onSuccess },
 	)
 
 	const { mutateAsync: uploadThumbnail, isPending: isUploadingThumbnail } =
 		useGraphQLUploadMutation(uploadMutation, {
-			onSuccess: (data) => onSuccess(data.uploadMediaThumbnail),
+			onSuccess,
 		})
 
 	const handleOpenChange = (nowOpen: boolean) => {
@@ -108,6 +92,7 @@ export default function BookThumbnailSelector({ fragment }: Props) {
 		async (file: File) => {
 			try {
 				await uploadThumbnail({ id: book.id, file })
+				setPage(undefined)
 				setIsOpen(false)
 			} catch (error) {
 				console.error(error)
@@ -122,6 +107,7 @@ export default function BookThumbnailSelector({ fragment }: Props) {
 
 		try {
 			await patchThumbnail({ id: book.id, input: { page } })
+			setPage(undefined)
 			setIsOpen(false)
 		} catch (error) {
 			console.error(error)

--- a/packages/browser/src/scenes/library/tabs/settings/options/thumbnails/DeleteLibraryThumbnails.tsx
+++ b/packages/browser/src/scenes/library/tabs/settings/options/thumbnails/DeleteLibraryThumbnails.tsx
@@ -9,9 +9,12 @@ import {
 	Text,
 } from '@stump/components'
 import { graphql } from '@stump/graphql'
+import { useQueryClient } from '@tanstack/react-query'
 import { AlertTriangle } from 'lucide-react'
 import { useCallback, useState } from 'react'
 import { toast } from 'sonner'
+
+import { invalidateThumbnailQueries } from '@/utils/query'
 
 import { useLibraryManagement } from '../../context'
 
@@ -22,6 +25,7 @@ const mutation = graphql(`
 `)
 
 export default function DeleteLibraryThumbnails() {
+	const queryClient = useQueryClient()
 	const {
 		library: { id },
 	} = useLibraryManagement()
@@ -35,6 +39,7 @@ export default function DeleteLibraryThumbnails() {
 	const handleDeleteThumbnails = useCallback(async () => {
 		try {
 			await deleteThumbnails({ id })
+			await invalidateThumbnailQueries(queryClient)
 			toast.success('Library thumbnails deleted')
 		} catch (error) {
 			console.error(error)
@@ -45,7 +50,7 @@ export default function DeleteLibraryThumbnails() {
 				toast.error(fallbackMessage)
 			}
 		}
-	}, [id, deleteThumbnails])
+	}, [id, deleteThumbnails, queryClient])
 
 	return (
 		<>

--- a/packages/browser/src/scenes/library/tabs/settings/options/thumbnails/LibraryThumbnailSelector.tsx
+++ b/packages/browser/src/scenes/library/tabs/settings/options/thumbnails/LibraryThumbnailSelector.tsx
@@ -1,6 +1,7 @@
-import { useGraphQLMutation, useSDK } from '@stump/client'
-import { Button, Dialog, Label, PickSelect, Text } from '@stump/components'
-import { graphql, LibraryThumbnailSelectorUpdateMutation } from '@stump/graphql'
+import { useGraphQLMutation } from '@stump/client'
+import { Button, Dialog, Label, Text } from '@stump/components'
+import { graphql } from '@stump/graphql'
+import { useQueryClient } from '@tanstack/react-query'
 import { Suspense, useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
 
@@ -8,6 +9,7 @@ import EditThumbnailDropdown from '@/components/thumbnail/EditThumbnailDropdown'
 import BookPageGrid from '@/scenes/book/settings/BookPageGrid'
 import { useLibraryContext } from '@/scenes/library/context'
 import SeriesBookGrid, { SelectedBook } from '@/scenes/series/tabs/settings/SeriesBookGrid'
+import { invalidateThumbnailQueries } from '@/utils/query'
 
 import LibrarySeriesGrid, { SelectedSeries } from '../../LibrarySeriesGrid'
 
@@ -35,10 +37,8 @@ const uploadMutation = graphql(`
 	}
 `)
 
-type OnSuccessData = PickSelect<LibraryThumbnailSelectorUpdateMutation, 'updateLibraryThumbnail'>
-
 export default function LibraryThumbnailSelector() {
-	const { sdk } = useSDK()
+	const queryClient = useQueryClient()
 	const [selectedSeries, setSelectedSeries] = useState<SelectedSeries>()
 	const [selectedBook, setSelectedBook] = useState<SelectedBook>()
 	const [page, setPage] = useState<number>()
@@ -47,30 +47,16 @@ export default function LibraryThumbnailSelector() {
 
 	const { library } = useLibraryContext()
 
-	const onSuccess = useCallback(
-		({ thumbnail }: OnSuccessData) =>
-			sdk.axios.get(thumbnail.url, {
-				headers: {
-					'Cache-Control': 'no-cache',
-					Pragma: 'no-cache',
-					Expires: '0',
-				},
-			}),
-		[sdk],
-	)
+	const onSuccess = useCallback(() => invalidateThumbnailQueries(queryClient), [queryClient])
 
 	const { mutateAsync: patchThumbnail, isPending: isPatchingThumbnail } = useGraphQLMutation(
 		updateMutation,
-		{
-			onSuccess: (data) => onSuccess(data.updateLibraryThumbnail),
-		},
+		{ onSuccess },
 	)
 
 	const { mutateAsync: uploadThumbnail, isPending: isUploadingThumbnail } = useGraphQLMutation(
 		uploadMutation,
-		{
-			onSuccess: (data) => onSuccess(data.uploadLibraryThumbnail),
-		},
+		{ onSuccess },
 	)
 
 	const handleOpenChange = (nowOpen: boolean) => {

--- a/packages/browser/src/scenes/series/tabs/settings/SeriesThumbnailSelector.tsx
+++ b/packages/browser/src/scenes/series/tabs/settings/SeriesThumbnailSelector.tsx
@@ -1,17 +1,14 @@
 import { useGraphQLMutation, useSDK } from '@stump/client'
-import { Button, Dialog, PickSelect } from '@stump/components'
-import {
-	FragmentType,
-	graphql,
-	SeriesThumbnailSelectorUpdateMutation,
-	useFragment,
-} from '@stump/graphql'
+import { Button, Dialog } from '@stump/components'
+import { FragmentType, graphql, useFragment } from '@stump/graphql'
 import { useLocaleContext } from '@stump/i18n'
+import { useQueryClient } from '@tanstack/react-query'
 import { Suspense, useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
 
 import { EntityCard } from '@/components/entity'
 import EditThumbnailDropdown from '@/components/thumbnail/EditThumbnailDropdown'
+import { invalidateThumbnailQueries } from '@/utils/query'
 
 import BookPageGrid from '../../../book/settings/BookPageGrid'
 import SeriesBookGrid, { SelectedBook } from './SeriesBookGrid'
@@ -47,8 +44,6 @@ const uploadMutation = graphql(`
 	}
 `)
 
-type OnSuccessData = PickSelect<SeriesThumbnailSelectorUpdateMutation, 'updateSeriesThumbnail'>
-
 type Props = {
 	fragment: FragmentType<typeof SeriesThumbnailSelectorFragment>
 }
@@ -66,34 +61,21 @@ export default function SeriesThumbnailSelector({ fragment }: Props) {
 	const { t } = useLocaleContext()
 
 	const { sdk } = useSDK()
+	const queryClient = useQueryClient()
 	const [selectedBook, setSelectedBook] = useState<SelectedBook>()
 	const [page, setPage] = useState<number>()
 	const [isOpen, setIsOpen] = useState(false)
 
-	const onSuccess = useCallback(
-		({ thumbnail: { url } }: OnSuccessData) =>
-			sdk.axios.get(url, {
-				headers: {
-					'Cache-Control': 'no-cache',
-					Pragma: 'no-cache',
-					Expires: '0',
-				},
-			}),
-		[sdk],
-	)
+	const onSuccess = useCallback(() => invalidateThumbnailQueries(queryClient), [queryClient])
 
 	const { mutateAsync: patchThumbnail, isPending: isPatchingThumbnail } = useGraphQLMutation(
 		updateMutation,
-		{
-			onSuccess: (data) => onSuccess(data.updateSeriesThumbnail),
-		},
+		{ onSuccess },
 	)
 
 	const { mutateAsync: uploadThumbnail, isPending: isUploadingThumbnail } = useGraphQLMutation(
 		uploadMutation,
-		{
-			onSuccess: (data) => onSuccess(data.uploadSeriesThumbnail),
-		},
+		{ onSuccess },
 	)
 
 	const handleOpenChange = (nowOpen: boolean) => {

--- a/packages/browser/src/scenes/smartList/items/table/CoverImageCell.tsx
+++ b/packages/browser/src/scenes/smartList/items/table/CoverImageCell.tsx
@@ -1,4 +1,3 @@
-import { useSDK } from '@stump/client'
 import { Book } from 'lucide-react'
 import { useState } from 'react'
 
@@ -6,11 +5,10 @@ import { EntityImage } from '@/components/entity'
 import { usePreferences } from '@/hooks/usePreferences'
 
 type Props = {
-	id: string
+	url: string
 	title?: string
 }
-export default function CoverImageCell({ id, title }: Props) {
-	const { sdk } = useSDK()
+export default function CoverImageCell({ url, title }: Props) {
 	const {
 		preferences: { thumbnailRatio },
 	} = usePreferences()
@@ -19,7 +17,7 @@ export default function CoverImageCell({ id, title }: Props) {
 	const loadImage = () => {
 		const image = new Image()
 		return new Promise((resolve, reject) => {
-			image.src = sdk.media.thumbnailURL(id)
+			image.src = url
 			image.onload = () => resolve(image)
 			image.onerror = (e) => {
 				console.error('Image failed to load:', e)
@@ -55,7 +53,7 @@ export default function CoverImageCell({ id, title }: Props) {
 			title={title}
 			className="h-20 w-auto rounded-sm object-cover"
 			style={{ aspectRatio: thumbnailRatio }}
-			src={sdk.media.thumbnailURL(id)}
+			src={url}
 			onError={() => setShowFallback(true)}
 		/>
 	)

--- a/packages/browser/src/scenes/smartList/items/table/mediaColumns.tsx
+++ b/packages/browser/src/scenes/smartList/items/table/mediaColumns.tsx
@@ -12,7 +12,9 @@ import CoverImageCell from './CoverImageCell'
 const columnHelper = createColumnHelper<Media>()
 
 const coverColumn = columnHelper.display({
-	cell: ({ row: { original: book } }) => <CoverImageCell id={book.id} title={book.resolvedName} />,
+	cell: ({ row: { original: book } }) => (
+		<CoverImageCell url={book.thumbnail.url} title={book.resolvedName} />
+	),
 	enableGlobalFilter: true,
 	header: () => (
 		<Text size="sm" variant="muted">

--- a/packages/browser/src/utils/query.ts
+++ b/packages/browser/src/utils/query.ts
@@ -1,0 +1,33 @@
+import type { QueryClient } from '@tanstack/react-query'
+
+const THUMBNAIL_QUERY_KEYS = new Set([
+	'bookClubBooks',
+	'bookClubBySlug',
+	'bookOverlay',
+	'bookOverview',
+	'bookReader',
+	'booksAfterCursor',
+	'booksSearch',
+	'continueReading',
+	'getMediaByPath',
+	'lastVisitedLibrary',
+	'libraryBooks',
+	'libraryById',
+	'librarySeries',
+	'librarySeriesGrid',
+	'mediaById',
+	'onDeck',
+	'readiumWebReader',
+	'recentlyAddedMedia',
+	'recentlyAddedSeries2',
+	'seriesBookGrid',
+	'seriesBooks',
+	'seriesById',
+	'smartListItems',
+])
+
+export const invalidateThumbnailQueries = (client: QueryClient) =>
+	client.invalidateQueries({
+		predicate: ({ queryKey: [rootKey] }) =>
+			typeof rootKey === 'string' && THUMBNAIL_QUERY_KEYS.has(rootKey),
+	})


### PR DESCRIPTION
Closes #913

Related to #546 and #619

Regenerates Stump-generated thumbnails during forced library rebuilds and adds modification timestamps to media, series, and library thumbnail URLs. When a thumbnail changes, the related timestamp changes with it, giving the browser a new URL and bypassing the existing long-lived cache without disabling caching.

Relevant browser queries are refreshed after thumbnail uploads, selections, deletions, scans, and generation jobs. Thumbnail consumers, including tables and the File Explorer, now use the versioned URLs returned by GraphQL instead of rebuilding unversioned URLs locally.

New generated thumbnails include a .generated filename marker so Stump can distinguish them from custom uploads. This allows forced rebuilds to replace generated thumbnails without overwriting user-provided covers. A filename marker was chosen instead of a database migration because the distinction is only needed while managing the files, and existing thumbnails cannot be reliably classified after the fact. Existing unmarked thumbnails are therefore treated as custom or legacy files, while newly generated thumbnails can be safely replaced going forward.

While tracing the full thumbnail flow, this also fixes:

- Library and series thumbnail selections updating the source book instead of the intended entity.
- Thumbnail mutations returning stale entity data after an update.
- Library thumbnail deletion leaving stale paths and metadata in the database.
- Authenticated images displaying an outdated result when their source changes during an active request.
- Failed authenticated image requests leaving the image without a fallback.

Library thumbnail cleanup now clears its database state transactionally. It also uses relational queries instead of passing every series and media ID as a separate SQL parameter, avoiding SQLite bind limits on large libraries.