### PR TITLE
feat(i18n): localize image reader header controls

### DIFF
--- a/packages/browser/src/components/readers/imageBased/container/ReaderHeader.tsx
+++ b/packages/browser/src/components/readers/imageBased/container/ReaderHeader.tsx
@@ -1,4 +1,5 @@
 import { Link, Text } from '@stump/components'
+import { useLocaleContext } from '@stump/i18n'
 import { motion } from 'framer-motion'
 import { ArrowLeft, Fullscreen, Shrink } from 'lucide-react'
 import { useFullscreen } from 'rooks'
@@ -12,6 +13,7 @@ import SettingsDialog from './SettingsDialog'
 import TimerMenu from './TimerMenu'
 
 export default function ReaderHeader() {
+	const { t } = useLocaleContext()
 	const { book } = useImageBaseReaderContext()
 	const {
 		settings: { showToolBar },
@@ -37,7 +39,7 @@ export default function ReaderHeader() {
 				<div className="space-x-4 flex items-center">
 					<Link
 						className="flex items-center text-foreground hover:text-foreground/80"
-						title="Go to media overview"
+						title={t('imageReader.header.goToMediaOverview')}
 						to={paths.bookOverview(id)}
 					>
 						<ArrowLeft size={'1.25rem'} />

--- a/packages/browser/src/components/readers/imageBased/container/SettingsDialog.tsx
+++ b/packages/browser/src/components/readers/imageBased/container/SettingsDialog.tsx
@@ -1,4 +1,5 @@
 import { Dialog, Tabs } from '@stump/components'
+import { useLocaleContext } from '@stump/i18n'
 import { Settings2 } from 'lucide-react'
 import { useState } from 'react'
 
@@ -7,6 +8,7 @@ import ControlButton from './ControlButton'
 import ReaderSettings from './ReaderSettings'
 
 export default function SettingsDialog() {
+	const { t } = useLocaleContext()
 	const { book, currentPage } = useImageBaseReaderContext()
 
 	const [modality, setModality] = useState<'book' | 'global'>('book')
@@ -26,8 +28,10 @@ export default function SettingsDialog() {
 					onValueChange={(value) => setModality(value as 'book' | 'global')}
 				>
 					<Tabs.List>
-						<Tabs.Trigger value="book">Book</Tabs.Trigger>
-						<Tabs.Trigger value="global">Global</Tabs.Trigger>
+						<Tabs.Trigger value="book">{t('imageReader.settingsDialog.scopes.book')}</Tabs.Trigger>
+						<Tabs.Trigger value="global">
+							{t('imageReader.settingsDialog.scopes.global')}
+						</Tabs.Trigger>
 					</Tabs.List>
 				</Tabs>
 

--- a/packages/browser/src/components/readers/imageBased/container/TimerMenu.tsx
+++ b/packages/browser/src/components/readers/imageBased/container/TimerMenu.tsx
@@ -1,4 +1,5 @@
 import { Dropdown } from '@stump/components'
+import { useLocaleContext } from '@stump/i18n'
 import { Clock } from 'lucide-react'
 
 import { useBookPreferences } from '@/scenes/book/reader/useBookPreferences'
@@ -7,6 +8,7 @@ import { useImageBaseReaderContext } from '../context'
 import ControlButton from './ControlButton'
 
 export default function TimerMenu() {
+	const { t } = useLocaleContext()
 	const { book, timer } = useImageBaseReaderContext()
 	const {
 		bookPreferences: { trackElapsedTime },
@@ -23,10 +25,10 @@ export default function TimerMenu() {
 
 			<Dropdown.Content align="end" onCloseAutoFocus={(e) => e.preventDefault()}>
 				<Dropdown.Item onClick={() => setBookPreferences({ trackElapsedTime: !trackElapsedTime })}>
-					{trackElapsedTime ? 'Stop Timer' : 'Start Timer'}
+					{trackElapsedTime ? t('imageReader.timerMenu.stop') : t('imageReader.timerMenu.start')}
 				</Dropdown.Item>
 
-				<Dropdown.Item onClick={timer.reset}>Reset Timer</Dropdown.Item>
+				<Dropdown.Item onClick={timer.reset}>{t('imageReader.timerMenu.reset')}</Dropdown.Item>
 			</Dropdown.Content>
 		</Dropdown>
 	)

--- a/packages/browser/src/components/readers/imageBased/container/__tests__/ReaderHeader.test.tsx
+++ b/packages/browser/src/components/readers/imageBased/container/__tests__/ReaderHeader.test.tsx
@@ -1,0 +1,70 @@
+import { LocaleProvider } from '@stump/i18n'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { useFullscreen } from 'rooks'
+
+import { usePaths } from '@/paths'
+import { useBookPreferences } from '@/scenes/book/reader/useBookPreferences'
+
+import { useImageBaseReaderContext } from '../../context'
+import ReaderHeader from '../ReaderHeader'
+
+vi.mock('rooks', () => ({
+	useFullscreen: vi.fn(),
+}))
+
+vi.mock('@/paths', () => ({
+	usePaths: vi.fn(),
+}))
+
+vi.mock('@/scenes/book/reader/useBookPreferences', () => ({
+	useBookPreferences: vi.fn(),
+}))
+
+vi.mock('../../context', async () => ({
+	...(await vi.importActual<typeof import('../../context')>('../../context')),
+	useImageBaseReaderContext: vi.fn(),
+}))
+
+vi.mock('../SettingsDialog', () => ({
+	default: () => <div data-testid="settings-dialog" />,
+}))
+
+vi.mock('../TimerMenu', () => ({
+	default: () => <div data-testid="timer-menu" />,
+}))
+
+describe('ReaderHeader', () => {
+	beforeEach(() => {
+		vi.mocked(useFullscreen).mockReturnValue({
+			disableFullscreen: vi.fn(async () => undefined),
+			enableFullscreen: vi.fn(async () => undefined),
+			fullscreenElement: null,
+			isFullscreenAvailable: false,
+			isFullscreenEnabled: false,
+			toggleFullscreen: vi.fn(async () => undefined),
+		})
+		vi.mocked(usePaths).mockReturnValue({
+			bookOverview: (id: string) => `/books/${id}`,
+		} as ReturnType<typeof usePaths>)
+		vi.mocked(useBookPreferences).mockReturnValue({
+			settings: { showToolBar: true },
+		} as ReturnType<typeof useBookPreferences>)
+		vi.mocked(useImageBaseReaderContext).mockReturnValue({
+			book: { id: 'book-id', resolvedName: 'Sample Book' },
+		} as ReturnType<typeof useImageBaseReaderContext>)
+	})
+
+	it('links back to the media overview with localized copy', () => {
+		render(
+			<MemoryRouter>
+				<LocaleProvider locale="en-US">
+					<ReaderHeader />
+				</LocaleProvider>
+			</MemoryRouter>,
+		)
+
+		expect(screen.getByTitle('Go to media overview')).toHaveAttribute('href', '/books/book-id')
+		expect(screen.getByText('Sample Book')).toBeInTheDocument()
+	})
+})

--- a/packages/browser/src/components/readers/imageBased/container/__tests__/SettingsDialog.test.tsx
+++ b/packages/browser/src/components/readers/imageBased/container/__tests__/SettingsDialog.test.tsx
@@ -1,0 +1,52 @@
+import { LocaleProvider } from '@stump/i18n'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { useImageBaseReaderContext } from '../../context'
+import SettingsDialog from '../SettingsDialog'
+
+vi.mock('../../context', async () => ({
+	...(await vi.importActual<typeof import('../../context')>('../../context')),
+	useImageBaseReaderContext: vi.fn(),
+}))
+
+vi.mock('../ReaderSettings', () => ({
+	default: ({ forBook, currentPage }: { forBook?: string; currentPage?: number }) => (
+		<div
+			data-testid="reader-settings"
+			data-for-book={forBook ?? ''}
+			data-current-page={currentPage ?? ''}
+		/>
+	),
+}))
+
+describe('SettingsDialog', () => {
+	beforeEach(() => {
+		vi.mocked(useImageBaseReaderContext).mockReturnValue({
+			book: { id: 'book-id' },
+			currentPage: 7,
+		} as ReturnType<typeof useImageBaseReaderContext>)
+	})
+
+	it('switches between localized book and global settings scopes', async () => {
+		const user = userEvent.setup()
+		render(
+			<LocaleProvider locale="en-US">
+				<SettingsDialog />
+			</LocaleProvider>,
+		)
+
+		await user.click(screen.getByRole('button'))
+
+		const readerSettings = await screen.findByTestId('reader-settings')
+		expect(screen.getByRole('tab', { name: 'Book' })).toHaveAttribute('data-state', 'active')
+		expect(readerSettings).toHaveAttribute('data-for-book', 'book-id')
+		expect(readerSettings).toHaveAttribute('data-current-page', '7')
+
+		await user.click(screen.getByRole('tab', { name: 'Global' }))
+
+		expect(screen.getByRole('tab', { name: 'Global' })).toHaveAttribute('data-state', 'active')
+		expect(readerSettings).toHaveAttribute('data-for-book', '')
+		expect(readerSettings).toHaveAttribute('data-current-page', '')
+	})
+})

--- a/packages/browser/src/components/readers/imageBased/container/__tests__/TimerMenu.test.tsx
+++ b/packages/browser/src/components/readers/imageBased/container/__tests__/TimerMenu.test.tsx
@@ -1,0 +1,100 @@
+import { ReadingDirection, ReadingImageScaleFit, ReadingMode } from '@stump/graphql'
+import { LocaleProvider } from '@stump/i18n'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { useBookPreferences } from '@/scenes/book/reader/useBookPreferences'
+
+import { IImageBaseReaderContext, useImageBaseReaderContext } from '../../context'
+import TimerMenu from '../TimerMenu'
+
+vi.mock('@/scenes/book/reader/useBookPreferences', () => ({
+	useBookPreferences: vi.fn(),
+}))
+
+vi.mock('../../context', async () => ({
+	...(await vi.importActual<typeof import('../../context')>('../../context')),
+	useImageBaseReaderContext: vi.fn(),
+}))
+
+const resetTimer = vi.fn()
+const setBookPreferences = vi.fn()
+const setSettings = vi.fn()
+
+const createReaderContext = (): IImageBaseReaderContext => ({
+	book: { id: 'book-id' } as IImageBaseReaderContext['book'],
+	currentPage: 1,
+	getPageUrl: vi.fn(),
+	imageSizes: {},
+	pageSets: [],
+	setCurrentPage: vi.fn(),
+	setPageSize: vi.fn(),
+	timer: {
+		getCurrentTime: vi.fn(() => 0),
+		pause: vi.fn(),
+		reset: resetTimer,
+		resume: vi.fn(),
+	},
+	toggleToolbar: vi.fn(),
+})
+
+const mockPreferences = (trackElapsedTime: boolean) => {
+	const bookPreferences = {
+		brightness: 1,
+		imageScaling: { scaleToFit: ReadingImageScaleFit.Height },
+		readingDirection: ReadingDirection.Ltr,
+		readingMode: ReadingMode.Paged,
+		secondPageSeparate: false,
+		tapSidesToNavigate: true,
+		trackElapsedTime,
+	}
+
+	vi.mocked(useBookPreferences).mockReturnValue({
+		bookPreferences,
+		setBookPreferences,
+		setSettings,
+		settings: {
+			...bookPreferences,
+			preload: { ahead: 5, behind: 3 },
+			showToolBar: false,
+		},
+	})
+}
+
+describe('TimerMenu', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		vi.mocked(useImageBaseReaderContext).mockReturnValue(createReaderContext())
+	})
+
+	it('starts and resets the reader timer', async () => {
+		const user = userEvent.setup()
+		mockPreferences(false)
+		render(
+			<LocaleProvider locale="en-US">
+				<TimerMenu />
+			</LocaleProvider>,
+		)
+
+		await user.click(screen.getByRole('button'))
+		await user.click(await screen.findByText('Start Timer'))
+		expect(setBookPreferences).toHaveBeenCalledWith({ trackElapsedTime: true })
+
+		await user.click(screen.getByRole('button'))
+		await user.click(await screen.findByText('Reset Timer'))
+		expect(resetTimer).toHaveBeenCalledOnce()
+	})
+
+	it('shows the stop action when the timer is active', async () => {
+		const user = userEvent.setup()
+		mockPreferences(true)
+		render(
+			<LocaleProvider locale="en-US">
+				<TimerMenu />
+			</LocaleProvider>,
+		)
+
+		await user.click(screen.getByRole('button'))
+		expect(await screen.findByText('Stop Timer')).toBeInTheDocument()
+	})
+})

--- a/packages/i18n/src/locales/en-US.json
+++ b/packages/i18n/src/locales/en-US.json
@@ -3677,6 +3677,20 @@
 		}
 	},
 	"imageReader": {
+		"header": {
+			"goToMediaOverview": "Go to media overview"
+		},
+		"settingsDialog": {
+			"scopes": {
+				"book": "Book",
+				"global": "Global"
+			}
+		},
+		"timerMenu": {
+			"start": "Start Timer",
+			"stop": "Stop Timer",
+			"reset": "Reset Timer"
+		},
 		"settings": {
 			"imageScaling": {
 				"label": "Image scaling",


### PR DESCRIPTION
## Description

This is a focused follow-up to #1318 and #1349 that localizes the remaining user-facing copy in three browser image-reader header controls. It follows the same incremental approach as #1381 but is independently based on the latest `nightly` branch.

- Localize the media-overview link title rendered by `ReaderHeader`.
- Localize the book and global scope tabs rendered by `SettingsDialog`.
- Localize the start, stop, and reset actions rendered by `TimerMenu`.
- Add component-oriented English source keys under the existing `imageReader` namespace.
- Add functional regression coverage for overview navigation, settings-scope switching, and timer actions.
- Add English source strings only so translated locale files continue to be managed through Weblate.

This PR preserves the existing rendered English copy, reader behavior, stored preference values, and component structure. It does not change mobile/Expo code, EPUB controls, translated locale files, or the settings covered by #1381.

LLM tooling assisted with this contribution. I reviewed the resulting changes and validated them locally before submission.

## Validation

- Focused image-reader header tests: 3 files and 4 tests passed.
- Browser test suite: 41 files and 251 tests passed.
- Browser and i18n type checks passed.
- Browser ESLint completed with 0 errors; the existing 17 unrelated warnings remain outside the changed files.
- Prettier checks passed for all changed files.
- `en-US.json` parses successfully.
- `git diff --check` passed.

## Screenshots

Not included. The change is limited to replacing existing visible copy with locale lookups while preserving the rendered English text and behavior.

## Ready?

- [x] I read the [contributing guidelines](https://github.com/stumpapp/stump/blob/main/.github/CONTRIBUTING.md)
- [x] I searched for existing issues or pull requests that may be related to my contribution
- [x] This PR is based into `nightly` and not `main`
- [x] I added tests and/or documentation for my changes if applicable
- [x] I disclosed any use of LLMs in the creation of this PR (if applicable)

## Stump Contributor License Agreement

By contributing to Stump, I agree that these changes will be licensed under the applicable repository licenses.
