### PR TITLE
feat(i18n): localize image reader settings

### DIFF
--- a/packages/browser/src/components/readers/imageBased/container/DoubleSpreadBehavior.tsx
+++ b/packages/browser/src/components/readers/imageBased/container/DoubleSpreadBehavior.tsx
@@ -1,5 +1,6 @@
 import { DoublePageBehavior, isDoublePageBehavior } from '@stump/client'
 import { Label, NativeSelect } from '@stump/components'
+import { useLocaleContext } from '@stump/i18n'
 import React, { useCallback } from 'react'
 
 type Props = {
@@ -8,6 +9,7 @@ type Props = {
 }
 
 export default function DoubleSpreadBehavior({ behavior, onChange }: Props) {
+	const { t } = useLocaleContext()
 	const handleChange = useCallback(
 		(e: React.ChangeEvent<HTMLSelectElement>) => {
 			if (isDoublePageBehavior(e.target.value)) {
@@ -21,14 +23,25 @@ export default function DoubleSpreadBehavior({ behavior, onChange }: Props) {
 
 	return (
 		<div className="py-1.5">
-			<Label htmlFor="double-spread-behavior">Double Paged</Label>
+			<Label htmlFor="double-spread-behavior">
+				{t('imageReader.settings.doublePageBehavior.label')}
+			</Label>
 			<NativeSelect
 				id="double-spread-behavior"
 				size="sm"
 				options={[
-					{ label: 'Auto', value: 'auto' },
-					{ label: 'Always', value: 'always' },
-					{ label: 'Off', value: 'off' },
+					{
+						label: t('imageReader.settings.doublePageBehavior.options.auto'),
+						value: 'auto',
+					},
+					{
+						label: t('imageReader.settings.doublePageBehavior.options.always'),
+						value: 'always',
+					},
+					{
+						label: t('imageReader.settings.doublePageBehavior.options.off'),
+						value: 'off',
+					},
 				]}
 				value={behavior}
 				onChange={handleChange}

--- a/packages/browser/src/components/readers/imageBased/container/ReaderSettings.tsx
+++ b/packages/browser/src/components/readers/imageBased/container/ReaderSettings.tsx
@@ -1,6 +1,7 @@
 import { BookPreferences, DEFAULT_BOOK_PREFERENCES } from '@stump/client'
 import { Label, RawSwitch } from '@stump/components'
 import { ReadingMode } from '@stump/graphql'
+import { useLocaleContext } from '@stump/i18n'
 import omit from 'lodash/omit'
 import { useCallback, useMemo } from 'react'
 import { useSearchParams } from 'react-router-dom'
@@ -18,6 +19,7 @@ type Props = {
 }
 
 export default function ReaderSettings({ forBook, currentPage }: Props) {
+	const { t } = useLocaleContext()
 	const [search, setSearch] = useSearchParams()
 
 	const store = useReaderStore((state) => state)
@@ -105,7 +107,9 @@ export default function ReaderSettings({ forBook, currentPage }: Props) {
 	return (
 		<div className="gap-4 flex flex-col" key={forBook}>
 			<div>
-				<Label className="text-xs font-medium text-muted-foreground uppercase">Mode</Label>
+				<Label className="text-xs font-medium text-muted-foreground uppercase">
+					{t('imageReader.settings.readerSettings.sections.mode')}
+				</Label>
 
 				<ReadingModeSelect
 					value={activeSettings.readingMode || DEFAULT_BOOK_PREFERENCES.readingMode}
@@ -119,7 +123,9 @@ export default function ReaderSettings({ forBook, currentPage }: Props) {
 			</div>
 
 			<div>
-				<Label className="text-xs font-medium text-muted-foreground uppercase">Image Options</Label>
+				<Label className="text-xs font-medium text-muted-foreground uppercase">
+					{t('imageReader.settings.readerSettings.sections.imageOptions')}
+				</Label>
 
 				<DoubleSpreadBehavior
 					behavior={
@@ -141,10 +147,12 @@ export default function ReaderSettings({ forBook, currentPage }: Props) {
 			</div>
 
 			<div>
-				<Label className="text-xs font-medium text-muted-foreground uppercase">Preferences</Label>
+				<Label className="text-xs font-medium text-muted-foreground uppercase">
+					{t('imageReader.settings.readerSettings.sections.preferences')}
+				</Label>
 				<div className="gap-3 pt-2 flex flex-col">
 					<Label className="px-1 flex items-center justify-between">
-						<span>Separate second page</span>
+						<span>{t('imageReader.settings.readerSettings.preferences.separateSecondPage')}</span>
 						<RawSwitch
 							checked={activeSettings.secondPageSeparate}
 							onCheckedChange={(checked) => onPreferenceChange({ secondPageSeparate: checked })}
@@ -152,7 +160,7 @@ export default function ReaderSettings({ forBook, currentPage }: Props) {
 					</Label>
 
 					<Label className="px-1 flex items-center justify-between">
-						<span>Pan and zoom without Ctrl / Cmd</span>
+						<span>{t('imageReader.settings.readerSettings.preferences.panZoomWithoutCtrl')}</span>
 						<RawSwitch
 							checked={activeSettings.panzoomWithoutCtrl}
 							onCheckedChange={(checked) => onPreferenceChange({ panzoomWithoutCtrl: checked })}
@@ -160,7 +168,7 @@ export default function ReaderSettings({ forBook, currentPage }: Props) {
 					</Label>
 
 					<Label className="px-1 flex items-center justify-between">
-						<span>Tap sides to navigate</span>
+						<span>{t('imageReader.settings.readerSettings.preferences.tapSidesToNavigate')}</span>
 						<RawSwitch
 							checked={activeSettings.tapSidesToNavigate}
 							onCheckedChange={(checked) => onPreferenceChange({ tapSidesToNavigate: checked })}
@@ -168,7 +176,7 @@ export default function ReaderSettings({ forBook, currentPage }: Props) {
 					</Label>
 
 					<Label className="px-1 flex items-center justify-between">
-						<span>Reading timer</span>
+						<span>{t('imageReader.settings.readerSettings.preferences.readingTimer')}</span>
 						<RawSwitch
 							checked={activeSettings.trackElapsedTime}
 							onCheckedChange={(checked) => onPreferenceChange({ trackElapsedTime: checked })}

--- a/packages/browser/src/components/readers/imageBased/container/__tests__/DoubleSpreadBehavior.test.tsx
+++ b/packages/browser/src/components/readers/imageBased/container/__tests__/DoubleSpreadBehavior.test.tsx
@@ -1,0 +1,50 @@
+import { LocaleProvider } from '@stump/i18n'
+import { fireEvent, render, screen, within } from '@testing-library/react'
+
+import DoubleSpreadBehavior from '../DoubleSpreadBehavior'
+
+describe('DoubleSpreadBehavior', () => {
+	const renderSubject = (onChange = vi.fn()) =>
+		render(
+			<LocaleProvider locale="en-US">
+				<DoubleSpreadBehavior behavior="off" onChange={onChange} />
+			</LocaleProvider>,
+		)
+
+	const originalWarn = console.warn
+	beforeAll(() => {
+		console.warn = vi.fn()
+	})
+	afterAll(() => {
+		console.warn = originalWarn
+	})
+
+	it('renders the localized label and options', () => {
+		renderSubject()
+
+		const select = screen.getByRole('combobox', { name: 'Double Paged' })
+		expect(
+			within(select)
+				.getAllByRole('option')
+				.map(({ textContent }) => textContent),
+		).toEqual(['Auto', 'Always', 'Off'])
+	})
+
+	it('updates the double-page behavior', () => {
+		const onChange = vi.fn()
+		renderSubject(onChange)
+
+		fireEvent.change(screen.getByRole('combobox'), { target: { value: 'always' } })
+
+		expect(onChange).toHaveBeenCalledWith('always')
+	})
+
+	it('ignores invalid double-page behavior values', () => {
+		const onChange = vi.fn()
+		renderSubject(onChange)
+
+		fireEvent.change(screen.getByRole('combobox'), { target: { value: 'invalid' } })
+
+		expect(onChange).not.toHaveBeenCalled()
+	})
+})

--- a/packages/browser/src/components/readers/imageBased/container/__tests__/ReaderSettings.test.tsx
+++ b/packages/browser/src/components/readers/imageBased/container/__tests__/ReaderSettings.test.tsx
@@ -1,0 +1,46 @@
+import { LocaleProvider } from '@stump/i18n'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+import ReaderSettings from '../ReaderSettings'
+
+const readerState = vi.hoisted(() => ({
+	bookPreferences: {},
+	setBookPreferences: vi.fn(),
+	setSettings: vi.fn(),
+	settings: {
+		animatedReader: false,
+		doublePageBehavior: 'off',
+		imageScaling: { scaleToFit: 'HEIGHT' },
+		panzoomWithoutCtrl: false,
+		readingDirection: 'LTR',
+		readingMode: 'PAGED',
+		secondPageSeparate: false,
+		tapSidesToNavigate: true,
+		trackElapsedTime: true,
+	},
+}))
+
+vi.mock('@/stores', () => ({
+	useReaderStore: (selector: (state: typeof readerState) => unknown) => selector(readerState),
+}))
+
+describe('ReaderSettings', () => {
+	it('renders localized stable settings copy', () => {
+		render(
+			<MemoryRouter>
+				<LocaleProvider locale="en-US">
+					<ReaderSettings />
+				</LocaleProvider>
+			</MemoryRouter>,
+		)
+
+		expect(screen.getByText('Mode')).toBeInTheDocument()
+		expect(screen.getByText('Image Options')).toBeInTheDocument()
+		expect(screen.getByText('Preferences')).toBeInTheDocument()
+		expect(screen.getByText('Separate second page')).toBeInTheDocument()
+		expect(screen.getByText('Pan and zoom without Ctrl / Cmd')).toBeInTheDocument()
+		expect(screen.getByText('Tap sides to navigate')).toBeInTheDocument()
+		expect(screen.getByText('Reading timer')).toBeInTheDocument()
+	})
+})

--- a/packages/i18n/src/locales/en-US.json
+++ b/packages/i18n/src/locales/en-US.json
@@ -3678,6 +3678,27 @@
 	},
 	"imageReader": {
 		"settings": {
+			"readerSettings": {
+				"sections": {
+					"mode": "Mode",
+					"imageOptions": "Image Options",
+					"preferences": "Preferences"
+				},
+				"preferences": {
+					"separateSecondPage": "Separate second page",
+					"panZoomWithoutCtrl": "Pan and zoom without Ctrl / Cmd",
+					"tapSidesToNavigate": "Tap sides to navigate",
+					"readingTimer": "Reading timer"
+				}
+			},
+			"doublePageBehavior": {
+				"label": "Double Paged",
+				"options": {
+					"auto": "Auto",
+					"always": "Always",
+					"off": "Off"
+				}
+			},
 			"imageScaling": {
 				"label": "Image scaling",
 				"options": {


### PR DESCRIPTION
## Description

This replaces #1381, which was closed when its fork branch was renamed.

This is a focused follow-up to #1318 and #1349 that localizes the remaining stable settings copy in the browser image reader.

- Localize the section headings and stable preference labels rendered by `ReaderSettings`.
- Localize the double-page behavior label and options rendered by `DoubleSpreadBehavior`.
- Extend the existing `imageReader.settings` namespace with component-oriented source keys.
- Add regression coverage for the localized settings copy and double-page behavior selection.
- Add English source strings only so translated locale files continue to be managed through Weblate.

The experimental animated-reader label remains out of scope because its settings UX is explicitly marked as unsettled. This PR does not change reader behavior, stored preference values, mobile/Expo code, EPUB controls, or other localization surfaces.

LLM tooling assisted with this contribution. I reviewed the resulting changes and validated them locally before submission.

## Validation

- Browser test suite: 40 files and 251 tests passed.
- Browser and i18n type checks passed.
- Browser ESLint completed with 0 errors; the existing 17 unrelated warnings remain outside the changed files.
- Prettier checks passed for all changed files.
- `en-US.json` parses successfully.
- `git diff --check` passed.

## Screenshots

Not included. The change is limited to replacing existing visible copy with locale lookups while preserving the rendered English text and behavior.

## Ready?

- [x] I read the [contributing guidelines](https://github.com/stumpapp/stump/blob/main/.github/CONTRIBUTING.md)
- [x] I searched for existing issues or pull requests that may be related to my contribution
- [x] This PR is based into `nightly` and not `main`
- [x] I added tests and/or documentation for my changes if applicable
- [x] I disclosed any use of LLMs in the creation of this PR (if applicable)

## Stump Contributor License Agreement

By contributing to Stump, I agree that these changes will be licensed under the applicable repository licenses.
