### PR TITLE
:bug: (expo) Fix local URL auto-switching

### DIFF
--- a/apps/expo/app/opds-legacy/[serverId]/_layout.tsx
+++ b/apps/expo/app/opds-legacy/[serverId]/_layout.tsx
@@ -6,7 +6,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { ServerErrorBoundary } from '~/components/error'
 import { FileExplorerAssetsProvider } from '~/components/fileExplorer'
 import { getOPDSInstance } from '~/lib/sdk/auth'
-import { ActiveServerProvider, useActiveServer } from '~/providers/ActiveServerProvider'
+import {
+	ActiveServerProvider,
+	useActiveServer,
+	useUrlSwitch,
+} from '~/providers/ActiveServerProvider'
 import { OPDSLegacyFeedProvider } from '~/providers/OPDSLegacyFeedProvider'
 import { usePreferencesStore, useSavedServers } from '~/stores'
 import { useCacheStore } from '~/stores/cache'
@@ -49,6 +53,8 @@ function Screen() {
 
 	// eslint-disable-next-line react-hooks/refs
 	const [sdk, setSDK] = useState<Api | null>(() => cachedInstance.current || null)
+
+	useUrlSwitch({ url: effectiveServerUrl, setSDK })
 
 	useEffect(() => {
 		const configureSDK = async () => {

--- a/apps/expo/app/opds/[serverId]/_layout.tsx
+++ b/apps/expo/app/opds/[serverId]/_layout.tsx
@@ -5,7 +5,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import OPDSAuthDialog from '~/components/opds/OPDSAuthDialog'
 import { getOPDSInstance } from '~/lib/sdk/auth'
-import { ActiveServerProvider, useActiveServer } from '~/providers/ActiveServerProvider'
+import {
+	ActiveServerProvider,
+	useActiveServer,
+	useUrlSwitch,
+} from '~/providers/ActiveServerProvider'
 import { OPDSFeedProvider } from '~/providers/OPDSFeedProvider'
 import { usePreferencesStore, useSavedServers } from '~/stores'
 import { useCacheStore } from '~/stores/cache'
@@ -35,7 +39,7 @@ function Screen() {
 	const animationEnabled = usePreferencesStore((state) => !state.reduceAnimations)
 
 	const { getServerConfig } = useSavedServers()
-	const { activeServer } = useActiveServer()
+	const { activeServer, effectiveServerUrl } = useActiveServer()
 
 	const cachedInstance = useRef(useCacheStore((state) => state.sdks[`${activeServer.id}-opds`]))
 	const addInstanceToCache = useCacheStore((state) => state.addSDK)
@@ -45,15 +49,17 @@ function Screen() {
 	const [sdk, setSDK] = useState<Api | null>(() => cachedInstance.current || null)
 	const [pendingAuthDoc, setPendingAuthDoc] = useState<OPDSAuthenticationDocument | null>(null)
 
+	useUrlSwitch({ url: effectiveServerUrl, setSDK })
+
 	useEffect(() => {
 		const configureSDK = async () => {
-			const { id, url, kind } = activeServer
+			const { id, kind } = activeServer
 
 			const config = await getServerConfig(id)
 			const instance = await getOPDSInstance({
 				config,
 				serverKind: kind,
-				url,
+				url: effectiveServerUrl,
 			})
 			setSDK(instance)
 			addInstanceToCache(`${id}-opds`, instance)
@@ -62,7 +68,7 @@ function Screen() {
 		if (!sdk) {
 			configureSDK()
 		}
-	}, [activeServer, sdk, getServerConfig, addInstanceToCache])
+	}, [activeServer, effectiveServerUrl, sdk, getServerConfig, addInstanceToCache])
 
 	const onAuthError = useCallback(
 		(_: string | undefined, data: unknown) => {

--- a/apps/expo/app/stump/[serverId]/_layout.tsx
+++ b/apps/expo/app/stump/[serverId]/_layout.tsx
@@ -70,6 +70,20 @@ function Screen() {
 
 	const isServerAccessible = useRef(true)
 
+	const previousUrl = useRef(effectiveServerUrl)
+
+	useEffect(() => {
+		if (previousUrl.current !== effectiveServerUrl) {
+			console.log('switching url', { previousUrl: previousUrl.current, effectiveServerUrl })
+			setSDK((curr) => {
+				curr?.switchUrl(effectiveServerUrl)
+				return curr
+			})
+		} else {
+			console.log('url did not change', { previousUrl: previousUrl.current, effectiveServerUrl })
+		}
+	}, [effectiveServerUrl])
+
 	useEffect(() => {
 		if (isAutoAuthenticating || !isServerAccessible.current) return
 

--- a/apps/expo/app/stump/[serverId]/_layout.tsx
+++ b/apps/expo/app/stump/[serverId]/_layout.tsx
@@ -16,7 +16,11 @@ import { ServerConnectFailed, ServerErrorBoundary } from '~/components/error'
 import ServerAuthDialog from '~/components/ServerAuthDialog'
 import { FullScreenLoader } from '~/components/ui'
 import { authSDKInstance } from '~/lib/sdk/auth'
-import { ActiveServerProvider, useActiveServer } from '~/providers/ActiveServerProvider'
+import {
+	ActiveServerProvider,
+	useActiveServer,
+	useUrlSwitch,
+} from '~/providers/ActiveServerProvider'
 import { StumpServerProvider } from '~/providers/StumpServerProvider'
 import { usePreferencesStore, useSavedServers } from '~/stores'
 import { useCacheStore } from '~/stores/cache'
@@ -70,19 +74,7 @@ function Screen() {
 
 	const isServerAccessible = useRef(true)
 
-	const previousUrl = useRef(effectiveServerUrl)
-
-	useEffect(() => {
-		if (previousUrl.current !== effectiveServerUrl) {
-			console.log('switching url', { previousUrl: previousUrl.current, effectiveServerUrl })
-			setSDK((curr) => {
-				curr?.switchUrl(effectiveServerUrl)
-				return curr
-			})
-		} else {
-			console.log('url did not change', { previousUrl: previousUrl.current, effectiveServerUrl })
-		}
-	}, [effectiveServerUrl])
+	useUrlSwitch({ url: effectiveServerUrl, setSDK })
 
 	useEffect(() => {
 		if (isAutoAuthenticating || !isServerAccessible.current) return

--- a/apps/expo/providers/ActiveServerProvider.tsx
+++ b/apps/expo/providers/ActiveServerProvider.tsx
@@ -1,4 +1,15 @@
-import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react'
+import { queryClient } from '@stump/client'
+import { Api } from '@stump/sdk'
+import {
+	createContext,
+	Dispatch,
+	SetStateAction,
+	useCallback,
+	useContext,
+	useEffect,
+	useRef,
+	useState,
+} from 'react'
 import { useDebounce } from 'rooks'
 
 import { SavedServer } from '~/stores/savedServer'
@@ -18,12 +29,15 @@ type ActiveServerProviderProps = {
 }
 
 export function ActiveServerProvider({ children, activeServer }: ActiveServerProviderProps) {
-	const { ssid, permissionStatus } = useWifiSsid()
-
-	const [effectiveServerUrl, setEffectiveServerUrl] = useState<string | null>(null)
+	const { ssid, permissionStatus, isLoading } = useWifiSsid()
 
 	const localProfile = activeServer.localProfile
 	const isAutoSwitchEnabled = activeServer.autoSwitchToLocal && localProfile != null
+
+	const [effectiveServerUrl, setEffectiveServerUrl] = useState<string | null>(
+		// if auto-switch is disabled there is no point in waiting for ssid eval
+		isAutoSwitchEnabled ? null : activeServer.url,
+	)
 
 	const evaluateSsidAndSwitchUrl = useCallback(() => {
 		const shouldUseLocal =
@@ -33,21 +47,48 @@ export function ActiveServerProvider({ children, activeServer }: ActiveServerPro
 
 	const debouncedEvaluateSsidAndSwitchUrl = useDebounce(evaluateSsidAndSwitchUrl, 500)
 
+	const hasEvaluatedOnce = useRef(false)
 	const lastSsid = useRef<string | null>(null)
+
 	useEffect(() => {
-		if (permissionStatus !== 'granted') return
-		if (ssid === lastSsid.current) return
+		if (!isAutoSwitchEnabled || isLoading) return
+
+		// if enabled but lacking permission, no point evaluating
+		if (permissionStatus !== 'granted') {
+			setEffectiveServerUrl(activeServer.url)
+			return
+		}
+
+		// no change since last eval = no subsequent eval
+		if (hasEvaluatedOnce.current && ssid === lastSsid.current) return
 
 		lastSsid.current = ssid
-		debouncedEvaluateSsidAndSwitchUrl()
-		// TODO: need localProfile?.url in deps? im sussed by it potentially not handling config change well
-	}, [permissionStatus, ssid, debouncedEvaluateSsidAndSwitchUrl])
+
+		if (!hasEvaluatedOnce.current) {
+			hasEvaluatedOnce.current = true
+			evaluateSsidAndSwitchUrl() // no debounce on first eval, switch asap
+		} else {
+			debouncedEvaluateSsidAndSwitchUrl()
+		}
+	}, [
+		isAutoSwitchEnabled,
+		isLoading,
+		permissionStatus,
+		ssid,
+		evaluateSsidAndSwitchUrl,
+		debouncedEvaluateSsidAndSwitchUrl,
+		activeServer.url,
+	])
+
+	if (effectiveServerUrl === null) {
+		return null
+	}
 
 	return (
 		<ActiveServerContext.Provider
 			value={{
 				activeServer,
-				effectiveServerUrl: effectiveServerUrl ?? activeServer.url,
+				effectiveServerUrl,
 			}}
 		>
 			{children}
@@ -73,3 +114,27 @@ export const useServerUrl = () => {
  * Pretty much just used for features that persist across servers (e.g., downloads)
  */
 export const useActiveServerSafe = () => useContext(ActiveServerContext)
+
+type UseUrlSwitchParams = {
+	url: string
+	setSDK: Dispatch<SetStateAction<Api | null>>
+}
+
+/**
+ * watches `url` for changes after the initial render and, when it changes,
+ * cancels any active react-query requests and calls `sdk.switchUrl` so the
+ * existing instance is re-pointed at the new url
+ */
+export function useUrlSwitch({ url, setSDK }: UseUrlSwitchParams) {
+	const previousUrl = useRef(url)
+
+	useEffect(() => {
+		if (previousUrl.current === url) return
+		previousUrl.current = url
+		queryClient.cancelQueries()
+		setSDK((curr) => {
+			curr?.switchUrl(url)
+			return curr
+		})
+	}, [url, setSDK])
+}

--- a/apps/expo/providers/WifiSsidProvider.tsx
+++ b/apps/expo/providers/WifiSsidProvider.tsx
@@ -18,6 +18,10 @@ export type UseWifiSSIDReturn = {
 	connectedToWifi: boolean
 	permissionStatus: PermissionStatus
 	requestPermission: () => Promise<boolean>
+	/**
+	 * will be `true` during the initial permission check **and** the first ssid fetch, so
+	 * consumers know whether to wait before acting on ssid value
+	 */
 	isLoading: boolean
 }
 
@@ -67,10 +71,15 @@ export function WifiSsidProvider({ children }: Props): React.ReactElement {
 				const { status } = await Location.getForegroundPermissionsAsync()
 				if (cancelled) return
 				setPermissionStatus(status)
+				if (status !== PermissionStatus.GRANTED) {
+					setIsLoading(false)
+				}
 			} catch {
-				if (!cancelled) setPermissionStatus(PermissionStatus.UNDETERMINED)
+				if (!cancelled) {
+					setPermissionStatus(PermissionStatus.UNDETERMINED)
+					setIsLoading(false)
+				}
 			}
-			if (!cancelled) setIsLoading(false)
 		}
 
 		initialize()
@@ -82,9 +91,26 @@ export function WifiSsidProvider({ children }: Props): React.ReactElement {
 	// fetch the ssid immediately, then poll, whenever permission is granted
 	useEffect(() => {
 		if (permissionStatus !== PermissionStatus.GRANTED) return
-		fetchSSID()
+
+		let cancelled = false
+
+		const doInitialFetch = async () => {
+			try {
+				await fetchSSID()
+			} catch (error) {
+				console.error('initial SSID fetch failed:', error)
+			} finally {
+				if (!cancelled) setIsLoading(false)
+			}
+		}
+
+		doInitialFetch()
 		const interval = setInterval(fetchSSID, POLL_INTERVAL_MS)
-		return () => clearInterval(interval)
+
+		return () => {
+			cancelled = true
+			clearInterval(interval)
+		}
 	}, [permissionStatus, fetchSSID])
 
 	const value = useMemo(

--- a/packages/sdk/src/api.ts
+++ b/packages/sdk/src/api.ts
@@ -74,6 +74,14 @@ export class Api {
 	private _shouldFormatURL = true
 
 	/**
+	 * An abort controller for the current axios instance. Aborted (and replaced)
+	 * by `switchUrl` so that any active requests against an old base URL
+	 * are cancelled immediately, otherwise you'll hit network errors (after
+	 * an annoyingly long timeout)
+	 */
+	private _abortController: AbortController = new AbortController()
+
+	/**
 	 * Create a new instance of the API
 	 * @param baseURL The base URL to the Stump server
 	 */
@@ -121,12 +129,23 @@ export class Api {
 			if (this._basicAuth) {
 				config.auth = this._basicAuth
 			}
+			// only manage our own signal if caller has not supplied one
+			if (!config.signal) {
+				config.signal = this._abortController.signal
+			}
 			return config
 		})
 		this.axiosInstance = instance
 	}
 
+	/**
+	 * Switch the base URL for the API instance. Internally this will cancel any active requests and reconstruct
+	 * the axios instance
+	 */
 	switchUrl(url: string) {
+		this._abortController.abort()
+		this._abortController = new AbortController()
+
 		this.baseURL = url
 		const instance = axios.create({
 			baseURL: this.serviceURL,
@@ -136,6 +155,9 @@ export class Api {
 			config.headers = config.headers.concat(await this.getHeaders())
 			if (this._basicAuth) {
 				config.auth = this._basicAuth
+			}
+			if (!config.signal) {
+				config.signal = this._abortController.signal
 			}
 			return config
 		})

--- a/packages/sdk/src/api.ts
+++ b/packages/sdk/src/api.ts
@@ -126,6 +126,22 @@ export class Api {
 		this.axiosInstance = instance
 	}
 
+	switchUrl(url: string) {
+		this.baseURL = url
+		const instance = axios.create({
+			baseURL: this.serviceURL,
+			withCredentials: this.configuration.authMethod === 'session',
+		})
+		instance.interceptors.request.use(async (config) => {
+			config.headers = config.headers.concat(await this.getHeaders())
+			if (this._basicAuth) {
+				config.auth = this._basicAuth
+			}
+			return config
+		})
+		this.axiosInstance = instance
+	}
+
 	get isAuthless(): boolean {
 		return this.config.authMethod === 'none'
 	}


### PR DESCRIPTION
## Description

There were a few items related to the unreleased URL auto-switching features I was able to fix after more extensive testing:

- Fix network timeouts of stale requests after switching URLs, which would annoyingly be thrown ~30-60s after a successful reconnect
   - This should prove beneficial even outside the switching features, e.g. might make sense to abort when leaving a server stack (not implemented here)
- Add dedicated `switchUrl` method to SDK instance to handle the swap, instead of trying to rely on lifecycle to recreate instance (which it did not do)
- Fix lifecycle problems with the evaluation logic in the ssid provider
- Remove debounce from initial evaluation of ssid

## Stump Contributor License Agreement

By contributing to Stump, you agree that your contributions will be licensed under the following licenses (where applicable):

- The [expo application](https://github.com/stumpapp/stump/blob/main/apps/expo/LICENSE) is licensed under [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.html)
- All other code in the repository is licensed under [MIT License](https://www.tldrlegal.com/license/mit-license)
