### PR TITLE
:globe_with_meridians: Add Bosnian locale as option

### DIFF
--- a/packages/i18n/src/config.ts
+++ b/packages/i18n/src/config.ts
@@ -4,6 +4,7 @@ import { initReactI18next } from 'react-i18next'
 import {
 	afZA,
 	arSA,
+	bs,
 	caES,
 	csCZ,
 	daDK,
@@ -37,6 +38,7 @@ import {
 } from './locales'
 
 export const LOCALES = [
+	'bs',
 	'af-ZA',
 	'ar-SA',
 	'ca-ES',
@@ -74,6 +76,9 @@ export const LOCALES = [
 export type AllowedLocale = (typeof LOCALES)[number]
 
 export const resources: Resource = {
+	bs: {
+		bs: bs,
+	},
 	'af-ZA': {
 		'af-ZA': afZA,
 	},

--- a/packages/i18n/src/dateFnsLocale.ts
+++ b/packages/i18n/src/dateFnsLocale.ts
@@ -5,6 +5,7 @@ import type { AllowedLocale } from './config'
 
 // Note: lazy loading as to not bloat initial bundle with all the locales
 const dateFnsLocaleLoaders: Record<AllowedLocale, () => Promise<Locale>> = {
+	bs: () => import('date-fns/locale/bs').then((m) => m.bs),
 	'af-ZA': () => import('date-fns/locale/af').then((m) => m.af),
 	'ar-SA': () => import('date-fns/locale/ar-SA').then((m) => m.arSA),
 	'ca-ES': () => import('date-fns/locale/ca').then((m) => m.ca),
@@ -56,6 +57,7 @@ function findClosestLocale(locale: string): AllowedLocale {
 
 	const languageFallbacks: Record<string, AllowedLocale> = {
 		af: 'af-ZA',
+		bs: 'bs',
 		ar: 'ar-SA',
 		ca: 'ca-ES',
 		cs: 'cs-CZ',
@@ -227,6 +229,7 @@ export function formatNarrowDuration(
 }
 
 const LOCALE_NARROW_UNITS = {
+	bs: { h: ' h', m: ' min', s: ' s' },
 	'af-ZA': { h: ' u.', m: ' min.', s: ' s.' },
 	'ar-SA': { h: ' س', m: ' د', s: ' ث' },
 	'ca-ES': { h: ' h', m: ' min', s: ' s' },

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -12,6 +12,7 @@ export { default as LocaleProvider } from './LocaleProvider'
 export type { AllowedLocale }
 
 export const localeNames: Record<AllowedLocale, string> = {
+	bs: 'Bosanski',
 	'af-ZA': 'Afrikaans',
 	'ar-SA': 'العربية',
 	'ca-ES': 'Català',

--- a/packages/i18n/src/locales/index.ts
+++ b/packages/i18n/src/locales/index.ts
@@ -1,5 +1,6 @@
 export { default as afZA } from './af-ZA.json'
 export { default as arSA } from './ar-SA.json'
+export { default as bs } from './bs.json'
 export { default as caES } from './ca-ES.json'
 export { default as csCZ } from './cs-CZ.json'
 export { default as daDK } from './da-DK.json'


### PR DESCRIPTION
Relates(ish) to https://github.com/stumpapp/stump/issues/1388

## Description

A new language was added via Weblate and this PR makes it actually registered in the app

## Stump Contributor License Agreement

By contributing to Stump, you agree that your contributions will be licensed under the following licenses (where applicable):

- The [expo application](https://github.com/stumpapp/stump/blob/main/apps/expo/LICENSE) is licensed under [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.html)
- All other code in the repository is licensed under [MIT License](https://www.tldrlegal.com/license/mit-license)
