### PR TITLE
🌐 Update Hungarian locale to use native name

### DIFF
--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -27,7 +27,7 @@ export const localeNames: Record<AllowedLocale, string> = {
 	'fi-FI': 'Suomi',
 	'fr-FR': 'Français',
 	'he-IL': 'עברית',
-	'hu-HU': 'Hungarian',
+	'hu-HU': 'Magyar',
 	'it-IT': 'Italiano',
 	'ja-JP': '日本語',
 	'ko-KR': '한국어',


### PR DESCRIPTION
## Description

Minor pet-peeve i guess, but besides Hungarian every other language is displayed via their native name. Besides Hungarian. This updates Hungarian to _also_ use its native name.


AFAICT, Weblate uses the country to code for it's "own" thing, so this shouldn't cause any problems. 

## Screenshots

<img width="1868" height="650" alt="image" src="https://github.com/user-attachments/assets/827f0edb-4578-4a93-adf1-48c925f3c32a" />

## Ready?

Please read each item and check the boxes:

- [X] I read the [contributing guidelines](https://github.com/stumpapp/stump/blob/main/.github/CONTRIBUTING.md)
- [X] I searched for existing issues or pull requests that may be related to my contribution
- [X] This PR is based into `nightly` and not `main`
- [X] I added tests and/or documentation for my changes if applicable
- [X] I disclosed any use of LLMs in the creation of this PR (if applicable)

## Stump Contributor License Agreement

By contributing to Stump, you agree that your contributions will be licensed under the following licenses (where applicable):

- The [expo application](https://github.com/stumpapp/stump/blob/main/apps/expo/LICENSE) is licensed under [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.html)
- All other code in the repository is licensed under [MIT License](https://www.tldrlegal.com/license/mit-license)
