### PR TITLE
✨ Make three-dot book menu match Download button height

### DIFF
--- a/packages/browser/src/scenes/book/BookActionMenu.tsx
+++ b/packages/browser/src/scenes/book/BookActionMenu.tsx
@@ -288,7 +288,7 @@ export default function BookActionMenu({ book }: Props) {
 					align="end"
 					contentWrapperClassName="w-48"
 					trigger={
-						<Button variant="outline" size="icon" className="h-8 w-8 shrink-0">
+						<Button variant="outline" size="icon" className="shrink-0">
 							<EllipsisVertical className="h-4 w-4" />
 						</Button>
 					}


### PR DESCRIPTION
## Description

Another kind of pet-peeve thing, the two buttons (book-view, download button and three dot button) heights were mismatched. Also the two button width was smaller than the width of bigger continue reading buttons, so that also looked bit "off"

Removed the h-8 w-8 override so the icon button uses the default size-9

I think height/width with this looks better/good.

## Screenshots

Before:
<img width="2728" height="856" alt="image" src="https://github.com/user-attachments/assets/d5a89258-929c-4c2a-a8e4-ce6e240d2867" />


After:

<img width="2622" height="850" alt="image" src="https://github.com/user-attachments/assets/9aec4dd3-a4f8-4276-bd30-7caad92e21d0" />


## Ready?

Please read each item and check the boxes:

- [X] I read the [contributing guidelines](https://github.com/stumpapp/stump/blob/main/.github/CONTRIBUTING.md)
- [X] I searched for existing issues or pull requests that may be related to my contribution
- [X] This PR is based into `nightly` and not `main`
- [X] I added tests and/or documentation for my changes if applicable
- [X] I disclosed any use of LLMs in the creation of this PR (if applicable)

## Stump Contributor License Agreement

By contributing to Stump, you agree that your contributions will be licensed under the following licenses (where applicable):

- The [expo application](https://github.com/stumpapp/stump/blob/main/apps/expo/LICENSE) is licensed under [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.html)
- All other code in the repository is licensed under [MIT License](https://www.tldrlegal.com/license/mit-license)
