### PR TITLE
:adhesive_bandage: Fix a few different oneshot issues

### DIFF
--- a/core/src/filesystem/scanner/utils/oneshot.rs
+++ b/core/src/filesystem/scanner/utils/oneshot.rs
@@ -7,7 +7,7 @@ use std::{
 
 use futures::StreamExt;
 use models::{
-	entity::{library_config, media, media_metadata, series},
+	entity::{library_config, media, media_metadata, series, series_metadata},
 	shared::enums::FileStatus,
 };
 use sea_orm::{prelude::*, ActiveValue, Set, TransactionTrait};
@@ -59,22 +59,29 @@ fn build_oneshot_blocking<P: AsRef<Path>>(
 	let series = series::ActiveModel {
 		id: Set(id.to_string()),
 		path: Set(path.to_string_lossy().to_string()),
-		name: Set(name),
+		name: Set(name.clone()),
 		library_id: Set(Some(library_id.to_string())),
 		is_oneshot: Set(true),
 		status: Set(FileStatus::Ready),
 		..Default::default()
 	};
 
-	let series = BuiltSeries {
-		series,
-		// TODO: do we need to read media metadata for this?
-		metadata: None,
-	};
-
 	let media = MediaBuilder::new(path, &id.to_string(), library_config, core_config)
 		.build()?
 		.oneshot();
+
+	let metadata = match media.metadata.as_ref().map(|m| m.title.clone()) {
+		// ^ note: as_ref() impl for ActiveValue allegedly can panic if the value is not set,
+		// so just went a little more verbose here with a clone and match
+		Some(Set(Some(title))) => Some(series_metadata::ActiveModel {
+			series_id: Set(id.to_string()),
+			title: Set(Some(title)),
+			..Default::default()
+		}),
+		_ => None,
+	};
+
+	let series = BuiltSeries { series, metadata };
 
 	Ok(BuiltOneshot { series, media })
 }

--- a/packages/browser/src/scenes/createLibrary/LibraryReview.tsx
+++ b/packages/browser/src/scenes/createLibrary/LibraryReview.tsx
@@ -114,14 +114,14 @@ export default function LibraryReview() {
 				<div>
 					<Label>{t(getLabelKey('oneshotsDirectory'))}</Label>
 					<Text variant="muted" size="sm">
-						{state.oneshotsDirectory}
+						{state.oneshotsDirectory || t('common.none')}
 					</Text>
 				</div>
 
 				<div>
 					<Label>{t(getLabelKey('description'))}</Label>
 					<Text variant="muted" size="sm">
-						{state.description || 'None'}
+						{state.description || t('common.none')}
 					</Text>
 				</div>
 

--- a/packages/browser/src/scenes/createLibrary/LibraryReview.tsx
+++ b/packages/browser/src/scenes/createLibrary/LibraryReview.tsx
@@ -112,6 +112,13 @@ export default function LibraryReview() {
 				</div>
 
 				<div>
+					<Label>{t(getLabelKey('oneshotsDirectory'))}</Label>
+					<Text variant="muted" size="sm">
+						{state.oneshotsDirectory}
+					</Text>
+				</div>
+
+				<div>
 					<Label>{t(getLabelKey('description'))}</Label>
 					<Text variant="muted" size="sm">
 						{state.description || 'None'}

--- a/packages/browser/src/scenes/library/tabs/settings/basics/BasicSettingsScene.tsx
+++ b/packages/browser/src/scenes/library/tabs/settings/basics/BasicSettingsScene.tsx
@@ -76,6 +76,7 @@ export default function BasicSettingsScene() {
 				config: {
 					thumbnailConfig: intoThumbnailConfig(values.thumbnailConfig),
 					libraryType: values.libraryType,
+					oneshotsDirectory: values.oneshotsDirectory,
 				},
 				description: values.description,
 				name: values.name,

--- a/packages/browser/src/scenes/library/tabs/settings/basics/BasicSettingsScene.tsx
+++ b/packages/browser/src/scenes/library/tabs/settings/basics/BasicSettingsScene.tsx
@@ -48,15 +48,16 @@ export default function BasicSettingsScene() {
 	})
 
 	const [showDirectoryPicker, setShowDirectoryPicker] = useState(false)
-	const [path, name, description, tags, libraryType] = useWatch({
+	const [path, name, description, tags, libraryType, oneshotsDirectory] = useWatch({
 		control: form.control,
-		name: ['path', 'name', 'description', 'tags', 'libraryType'],
+		name: ['path', 'name', 'description', 'tags', 'libraryType', 'oneshotsDirectory'],
 	})
 
 	const hasChanges = useMemo(() => {
 		const currentTagSet = new Set(tags?.map(({ label }) => label) || [])
 		const libraryTagSet = new Set(library?.tags?.map(({ name }) => name) || [])
 		const differentLibraryType = library?.config?.libraryType !== libraryType
+		const existingOneshotsDirectory = library?.config?.oneshotsDirectory || null
 
 		return (
 			library?.path !== normalizePath(path) ||
@@ -64,9 +65,10 @@ export default function BasicSettingsScene() {
 			library?.description !== description ||
 			[...currentTagSet].some((tag) => !libraryTagSet.has(tag)) ||
 			[...libraryTagSet].some((tag) => !currentTagSet.has(tag)) ||
-			differentLibraryType
+			differentLibraryType ||
+			existingOneshotsDirectory !== oneshotsDirectory
 		)
-	}, [library, path, name, description, tags, libraryType])
+	}, [library, path, name, description, tags, libraryType, oneshotsDirectory])
 
 	const handleSubmit = useCallback(
 		(values: CreateOrUpdateLibrarySchema) => {

--- a/packages/i18n/src/locales/en-US.json
+++ b/packages/i18n/src/locales/en-US.json
@@ -555,6 +555,7 @@
 					"quality": "Quality",
 					"name": "Name",
 					"path": "Path",
+					"oneshotsDirectory": "Oneshots directory",
 					"description": "Description",
 					"tags": "Tags",
 					"pattern": "Pattern",
@@ -602,7 +603,7 @@
 		"tabs": {
 			"books": "Books",
 			"series": "Series",
-			"oneshots": "One-shots",
+			"oneshots": "Oneshots",
 			"files": "Files"
 		}
 	},

--- a/packages/i18n/src/locales/en-US.json
+++ b/packages/i18n/src/locales/en-US.json
@@ -2749,6 +2749,7 @@
 		"notReady": "This feature is not ready",
 		"notUsedYet": "Not used yet",
 		"never": "Never",
+		"none":"None",
 		"scan": "Scan",
 		"somethingWentWrong": "Something went wrong",
 		"back": "Back",


### PR DESCRIPTION
Relates to https://github.com/stumpapp/stump/issues/761

## Description

A few follow-up fixes after testing, reported on Discord:

- Pull `media_metadata.title` for `series_metadata.title` if present
- Add display for oneshots directory to library review step
- Adjust condition that disables update submit button to factor `oneshotsDirectory` changes
- Ensure `oneshotsDirectory` reaches the `updateLibrary` call

Will merge after appropriate testing, probably later this evening

## Stump Contributor License Agreement

By contributing to Stump, you agree that your contributions will be licensed under the following licenses (where applicable):

- The [expo application](https://github.com/stumpapp/stump/blob/main/apps/expo/LICENSE) is licensed under [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.html)
- All other code in the repository is licensed under [MIT License](https://www.tldrlegal.com/license/mit-license)
