### PR TITLE
💚 Fix CVE workflow file

### DIFF
--- a/.github/workflows/cve_check.yml
+++ b/.github/workflows/cve_check.yml
@@ -1,6 +1,9 @@
 name: CVE Check
 
 on:
+  push:
+    paths:
+      - .github/workflows/cve_check.yml
   schedule:
     - cron: '0 0 * * 1'
   workflow_dispatch:
@@ -28,11 +31,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # prevent non-zero exit from killing the job
+          set +e
           AUDIT_OUTPUT=$(yarn audit --groups dependencies 2>&1)
           AUDIT_EXIT_CODE=$?
+          set -e
 
           # yarn audit exits 0 when no vulnerabilities are found
-          if [ "$AUDIT_EXIT_CODE" -ne 0 ]; then
+          if [ "$AUDIT_EXIT_CODE" -ne 0 ] && [ "${{ github.event_name }}" != "push" ]; then
             printf '```\n%s\n```\n' "$AUDIT_OUTPUT" > issue-body.txt
             gh issue create \
               --title "[CVE] Vulnerable dependencies detected — $(date -u +%Y-%m-%d)" \

--- a/.github/workflows/cve_check.yml
+++ b/.github/workflows/cve_check.yml
@@ -38,10 +38,14 @@ jobs:
           set -e
 
           # yarn audit exits 0 when no vulnerabilities are found
-          if [ "$AUDIT_EXIT_CODE" -ne 0 ] && [ "${{ github.event_name }}" != "push" ]; then
-            printf '```\n%s\n```\n' "$AUDIT_OUTPUT" > issue-body.txt
-            gh issue create \
-              --title "[CVE] Vulnerable dependencies detected — $(date -u +%Y-%m-%d)" \
-              --body-file issue-body.txt \
-              --label "security"
+          if [ "$AUDIT_EXIT_CODE" -ne 0 ]; then
+            if [ "${{ github.event_name }}" = "push" ]; then
+              echo "$AUDIT_OUTPUT"
+            else
+              printf '```\n%s\n```\n' "$AUDIT_OUTPUT" > issue-body.txt
+              gh issue create \
+                --title "[CVE] Vulnerable dependencies detected — $(date -u +%Y-%m-%d)" \
+                --body-file issue-body.txt \
+                --label "security"
+            fi
           fi


### PR DESCRIPTION

## Description

I noticed the CVE workflow was failing, the exit code of the audit check was killing the job. This should correct it, and now that it is working again I'll address the few vulnerabilities shortly

## Stump Contributor License Agreement

By contributing to Stump, you agree that your contributions will be licensed under the following licenses (where applicable):

- The [expo application](https://github.com/stumpapp/stump/blob/main/apps/expo/LICENSE) is licensed under [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.html)
- All other code in the repository is licensed under [MIT License](https://www.tldrlegal.com/license/mit-license)
