### PR TITLE
:sparkles: Replace history for image-based reading

### DIFF
--- a/packages/browser/src/components/readers/imageBased/ImageBasedReader.tsx
+++ b/packages/browser/src/components/readers/imageBased/ImageBasedReader.tsx
@@ -112,7 +112,7 @@ export default function ImageBasedReader({ media, isIncognito, initialPage, onPr
 				setCurrentPage(newPage)
 			} else {
 				setCurrentPage(newPage)
-				navigate(paths.bookReader(media.id, { isIncognito, page: newPage }))
+				navigate(paths.bookReader(media.id, { isIncognito, page: newPage }), { replace: true })
 			}
 
 			if (!isIncognito) {

--- a/packages/browser/src/components/readers/imageBased/container/ReaderSettings.tsx
+++ b/packages/browser/src/components/readers/imageBased/container/ReaderSettings.tsx
@@ -75,7 +75,7 @@ export default function ReaderSettings({ forBook, currentPage }: Props) {
 				} else {
 					search.delete('page')
 				}
-				setSearch(search)
+				setSearch(search, { replace: true })
 			}
 			setBookPreferences({ readingMode: value })
 		},

--- a/packages/browser/src/components/readers/imageBased/continuous/ContinuousScrollReader.tsx
+++ b/packages/browser/src/components/readers/imageBased/continuous/ContinuousScrollReader.tsx
@@ -89,7 +89,7 @@ export default function ContinuousScrollReader({
 		const hasPageURL = !!search.get('page')
 		if (hasPageURL) {
 			search.delete('page')
-			setSearch(search)
+			setSearch(search, { replace: true })
 		}
 	}, [search, setSearch])
 

--- a/packages/browser/src/scenes/book/reader/BookReaderScene.tsx
+++ b/packages/browser/src/scenes/book/reader/BookReaderScene.tsx
@@ -157,14 +157,15 @@ function BookReaderScene({ book }: Props) {
 				paths.bookReader(book.id, {
 					isEpub: true,
 				}),
+				{ replace: true },
 			)
 		} else if (book.extension.match(PDF_EXTENSION) && !isStreaming) {
-			navigate(paths.bookReader(book.id, { isPdf: true, isStreaming: false }))
+			navigate(paths.bookReader(book.id, { isPdf: true, isStreaming: false }), { replace: true })
 		} else if (book.extension.match(ARCHIVE_EXTENSION) || book.extension.match(PDF_EXTENSION)) {
 			if (!initialPage && readingMode === ReadingMode.Paged && !animatedReader) {
-				navigate(paths.bookReader(book.id, { page: 1 }))
+				navigate(paths.bookReader(book.id, { page: 1 }), { replace: true })
 			} else if (!!initialPage && initialPage > book.pages) {
-				navigate(paths.bookReader(book.id, { page: book.pages }))
+				navigate(paths.bookReader(book.id, { page: book.pages }), { replace: true })
 			}
 		}
 	}, [book, initialPage, readingMode, navigate, isStreaming, animatedReader])


### PR DESCRIPTION

Closes #1378

## Description

**Summary of changes**

Fixed the issue where navigating to a different page inside the reader (image / PDF / CBZ/CBR) — e.g. via the "Go to page" input or switching reading mode — pushed a **new** history entry instead of replacing the current one. As a result, the browser **Back** button stepped through every visited page one-by-one rather than exiting the reader.

The fix makes these internal reader navigations **replace** the current history entry instead of adding to it:

- `packages/browser/src/scenes/book/reader/BookReaderScene.tsx` — the auto-navigation to the reader route (EPUB → reader, PDF → reader, and page-clamp redirects) now uses `{ replace: true }`
- `packages/browser/src/components/readers/imageBased/ImageBasedReader.tsx` — "Go to page" navigation now replaces the current entry
- `packages/browser/src/components/readers/imageBased/container/ReaderSettings.tsx` — changing the reading mode (which rewrites the `?page=` search param) now replaces the current entry
- `packages/browser/src/components/readers/imageBased/continuous/ContinuousScrollReader.tsx` — clearing the `?page=` param when switching to continuous scroll now replaces the current entry

**Reasoning**

Switching pages is a transient in-reader action, not a meaningful "back" destination. By replacing the history entry, the Back button takes you back to where you were *before* opening the reader, which is the expected behavior.

**Additional context**

Affects the web reader only (`packages/browser`). No state/logic changes — purely the navigation mode of existing `navigate()` / `setSearch()` calls.

## Screenshots

*(Non-visual behavioral change — no screenshots. You can verify by opening a multi-page PDF/CBZ, jumping between pages, then pressing the browser Back button; it should leave the reader in one press instead of stepping back through each page.)*


## Ready?

Please read each item and check the boxes:

- [x] I read the [contributing guidelines](https://github.com/stumpapp/stump/blob/main/.github/CONTRIBUTING.md)
- [x] I searched for existing issues or pull requests that may be related to my contribution
- [x] This PR is based into `nightly` and not `main`
- [ ] I added tests and/or documentation for my changes if applicable
- [x] I disclosed any use of LLMs in the creation of this PR (if applicable) — **Yes.** An LLM (assistant) was used to assist in making the code changes in this PR; I reviewed each change before committing.

Which matches how it was actually done? I can finalize the full PR body with the matching wording.

## Stump Contributor License Agreement

By contributing to Stump, you agree that your contributions will be licensed under the following licenses (where applicable):

- The [expo application](https://github.com/stumpapp/stump/blob/main/apps/expo/LICENSE) is licensed under [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.html)
- All other code in the repository is licensed under [MIT License](https://www.tldrlegal.com/license/mit-license)