### PR TITLE
✨ Add sorting by publication year in book table view

### DIFF
--- a/crates/graphql/src/order.rs
+++ b/crates/graphql/src/order.rs
@@ -75,6 +75,7 @@ impl OrderBy<media::Entity, MediaOrderBy> for MediaOrderBy {
 					let field = media_metadata::Column::from_str(
 						&order_by.field.to_string().to_snake_case(),
 					)?;
+					// TODO(order-by): Better null handling (e.g. NULLS LAST or option to exclude unpopulated metadata fields when sorting)
 					query = query.order_by(field, order);
 				},
 			}

--- a/packages/browser/src/components/book/table/columns.tsx
+++ b/packages/browser/src/components/book/table/columns.tsx
@@ -152,6 +152,7 @@ const publishedColumn = columnHelper.accessor(
 			</Text>
 		),
 		enableGlobalFilter: true,
+		// TODO(sorting): Consider better null/empty handling (e.g., placing nulls last or excluding them when sorting)
 		enableSorting: true,
 		header: () => (
 			<Text size="sm" variant="secondary">

--- a/packages/browser/src/components/book/table/columns.tsx
+++ b/packages/browser/src/components/book/table/columns.tsx
@@ -1,6 +1,6 @@
 import { formatBytes } from '@stump/client'
 import { Badge, Link, Text } from '@stump/components'
-import { FragmentType, Media, MediaModelOrdering } from '@stump/graphql'
+import { FragmentType, Media, MediaMetadataModelOrdering, MediaModelOrdering } from '@stump/graphql'
 import { ColumnSort } from '@stump/sdk'
 import { ColumnDef, createColumnHelper } from '@tanstack/react-table'
 import { format, intlFormat } from 'date-fns'
@@ -152,14 +152,13 @@ const publishedColumn = columnHelper.accessor(
 			</Text>
 		),
 		enableGlobalFilter: true,
-		// TODO(relation-ordering): Support order by relation
-		enableSorting: false,
+		enableSorting: true,
 		header: () => (
 			<Text size="sm" variant="secondary">
 				Published
 			</Text>
 		),
-		id: 'published',
+		id: MediaMetadataModelOrdering.Year,
 	},
 )
 

--- a/packages/browser/src/components/filters/form/OrderBySelect.tsx
+++ b/packages/browser/src/components/filters/form/OrderBySelect.tsx
@@ -30,6 +30,7 @@ const options: Record<FilterableEntity, OrderingField[]> = {
 		MediaModelOrdering.ModifiedAt,
 		MediaMetadataModelOrdering.Number,
 		MediaMetadataModelOrdering.Volume,
+		MediaMetadataModelOrdering.Year,
 	],
 	series: [
 		SeriesModelOrdering.Name,

--- a/packages/browser/src/components/filters/useFilterScene.ts
+++ b/packages/browser/src/components/filters/useFilterScene.ts
@@ -274,6 +274,7 @@ export function useFilterScene({
 const MEDIA_METADATA_ORDER_FIELDS: string[] = [
 	MediaMetadataModelOrdering.Number,
 	MediaMetadataModelOrdering.Volume,
+	MediaMetadataModelOrdering.Year,
 ]
 
 export function useMediaURLOrderBy(ordering: Ordering): MediaOrderBy[] {


### PR DESCRIPTION
## Description

Adds publication year sorting to the book table. Useful for people who read for example Gutenberg books (e.g., lots of historical stuff), where the publication date is often the best way to sort. 

Also makes the UI a bit more consistent, since now every column has sorting. (Name, Pages, Added already hooked up to sorting.)

## Screenshots

Looks like this in practice on an sample lib:

https://github.com/user-attachments/assets/9e10d685-560d-49ec-a4c0-95702c23051a



## Ready?

Please read each item and check the boxes:

- [X] I read the [contributing guidelines](https://github.com/stumpapp/stump/blob/main/.github/CONTRIBUTING.md)
- [X] I searched for existing issues or pull requests that may be related to my contribution
- [X] This PR is based into `nightly` and not `main`
- [X] I added tests and/or documentation for my changes if applicable
- [X] I disclosed any use of LLMs in the creation of this PR (if applicable)

## Stump Contributor License Agreement

By contributing to Stump, you agree that your contributions will be licensed under the following licenses (where applicable):

- The [expo application](https://github.com/stumpapp/stump/blob/main/apps/expo/LICENSE) is licensed under [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.html)
- All other code in the repository is licensed under [MIT License](https://www.tldrlegal.com/license/mit-license)
