### PR TITLE
:recycle: Improve web and mobile readium interop

### DIFF
--- a/apps/expo/app/stump/[serverId]/books/[bookId]/index.tsx
+++ b/apps/expo/app/stump/[serverId]/books/[bookId]/index.tsx
@@ -180,6 +180,7 @@ export default function Screen() {
 		})
 	}, [downloadBook, book])
 
+	const insets = useSafeAreaInsets()
 	const router = useRouter()
 	const thumbnailRatio = usePreferencesStore((state) => state.thumbnailRatio)
 
@@ -250,8 +251,6 @@ export default function Screen() {
 	const totalPages = book.metadata?.pageCount || book.pages
 	const percentage = getPercentage({ readProgress: progression, totalPages })
 	const readthroughNumber = book.readHistory.length
-
-	const insets = useSafeAreaInsets()
 
 	// Reminder: Whenever this page introduces a new clickable filter field, make sure to
 	// add a corresponding bit in the filter header and prolly metadata overview object

--- a/apps/expo/components/book/overview/ReadingProgressCard.tsx
+++ b/apps/expo/components/book/overview/ReadingProgressCard.tsx
@@ -68,9 +68,6 @@ export function CurrentProgressCard({
 			<Card.StatGroup>
 				<Card.Stat
 					label={t('common.page')}
-					// FIXME: this won't always be accurate for epubs when switching between devices
-					// of different screen sizes. in order to get a more accurate page number, it would
-					// need to be computed on the device itself before render
 					value={page ?? '??'}
 					suffix={totalPages ? ` / ${totalPages}` : undefined}
 				/>

--- a/apps/expo/components/book/overview/ReadingProgressCard.tsx
+++ b/apps/expo/components/book/overview/ReadingProgressCard.tsx
@@ -68,6 +68,9 @@ export function CurrentProgressCard({
 			<Card.StatGroup>
 				<Card.Stat
 					label={t('common.page')}
+					// FIXME: this won't always be accurate for epubs when switching between devices
+					// of different screen sizes. in order to get a more accurate page number, it would
+					// need to be computed on the device itself before render
 					value={page ?? '??'}
 					suffix={totalPages ? ` / ${totalPages}` : undefined}
 				/>

--- a/apps/expo/stores/epub.ts
+++ b/apps/expo/stores/epub.ts
@@ -282,20 +282,34 @@ export const useEpubLocationStore = create<IEpubLocationStore>((set, get) => ({
 	isCurrentLocationBookmarked: () => {
 		const state = get()
 		if (!state.locator) return false
-		return state.bookmarks.some(
-			(b) =>
-				trimFragmentFromHref(b.href) === trimFragmentFromHref(state.locator!.href) &&
-				b.locations?.progression === state.locator!.locations?.progression,
-		)
+		const currentHref = trimFragmentFromHref(state.locator.href)
+		const currentProg = state.locator.locations?.progression ?? null
+		return state.bookmarks.some((b) => {
+			if (trimFragmentFromHref(b.href) !== currentHref) return false
+			const bookmarkProg = b.locations?.progression ?? null
+			if (currentProg != null && bookmarkProg != null) {
+				// i added a small tolerance for precision issues, but honestly this is
+				// fragile as fuck. i'd really like to figure this out properly, but
+				// this should marginally help with some issues i've seen between web vs mobile
+				// and rendering bookmarks >:'(
+				return Math.abs(currentProg - bookmarkProg) < 0.01
+			}
+			return currentProg === bookmarkProg
+		})
 	},
 	getCurrentLocationBookmark: () => {
 		const state = get()
 		if (!state.locator) return undefined
-		return state.bookmarks.find(
-			(b) =>
-				trimFragmentFromHref(b.href) === trimFragmentFromHref(state.locator!.href) &&
-				b.locations?.progression === state.locator!.locations?.progression,
-		)
+		const currentHref = trimFragmentFromHref(state.locator.href)
+		const currentProg = state.locator.locations?.progression ?? null
+		return state.bookmarks.find((b) => {
+			if (trimFragmentFromHref(b.href) !== currentHref) return false
+			const bookmarkProg = b.locations?.progression ?? null
+			if (currentProg != null && bookmarkProg != null) {
+				return Math.abs(currentProg - bookmarkProg) < 0.01
+			}
+			return currentProg === bookmarkProg
+		})
 	},
 
 	annotations: [],

--- a/core/src/filesystem/error.rs
+++ b/core/src/filesystem/error.rs
@@ -1,5 +1,9 @@
 use std::io;
 
+use models::shared::readium::{
+	RWPMPositionBuilderError, RWPMPositionLocationsBuilderError,
+	RWPMPositionsBuilderError,
+};
 use thiserror::Error;
 use unrar::error::UnrarError;
 use zip::result::ZipError;
@@ -65,5 +69,25 @@ impl From<FileError> for CoreError {
 			FileError::UnknownError(err) => CoreError::Unknown(err),
 			_ => CoreError::InternalError(error.to_string()),
 		}
+	}
+}
+
+// lol don't do this long term, accepting for now but fix in my reorganization branch <3
+
+impl From<RWPMPositionLocationsBuilderError> for FileError {
+	fn from(error: RWPMPositionLocationsBuilderError) -> Self {
+		FileError::EpubReadError(error.to_string())
+	}
+}
+
+impl From<RWPMPositionBuilderError> for FileError {
+	fn from(error: RWPMPositionBuilderError) -> Self {
+		FileError::EpubReadError(error.to_string())
+	}
+}
+
+impl From<RWPMPositionsBuilderError> for FileError {
+	fn from(error: RWPMPositionsBuilderError) -> Self {
+		FileError::EpubReadError(error.to_string())
 	}
 }

--- a/core/src/filesystem/media/readium.rs
+++ b/core/src/filesystem/media/readium.rs
@@ -15,6 +15,19 @@ pub struct ReadiumManifestGenerator {
 	base_url: String,
 }
 
+struct SpineItemMetadata {
+	package_path: String,
+	media_type: String,
+	title: Option<String>,
+	position_count: usize,
+}
+
+/// The size of each "page" for positions generation
+/// See the following:
+/// - https://wiki.mobileread.com/wiki/Adobe_Digital_Editions#Page_numbers
+/// - https://github.com/readium/architecture/issues/123
+const PAGE_LENGTH: usize = 1024;
+
 impl ReadiumManifestGenerator {
 	pub fn new(epub_path: impl Into<String>, base_url: impl Into<String>) -> Self {
 		Self {
@@ -43,39 +56,98 @@ impl ReadiumManifestGenerator {
 			.map_err(|error| FileError::EpubReadError(error.to_string()))
 	}
 
+	/// take the spine items and convert them into an itermediate representation
+	/// to support generating positions
+	fn generate_spine_metadata(
+		&self,
+		epub: &mut EpubDoc<BufReader<File>>,
+	) -> Result<Vec<SpineItemMetadata>, FileError> {
+		let resource_metas = epub
+			.spine
+			.clone()
+			.into_iter()
+			.filter(|item| item.linear)
+			.filter_map(|item| {
+				let resource = epub.resources.get(&item.idref)?;
+				let package_path = resource.path.to_string_lossy().to_string();
+				let media_type = resource.mime.clone();
+
+				let title = epub
+					.toc
+					.iter()
+					.find(|nav| {
+						let content = nav.content.to_string_lossy();
+						content.contains(package_path.as_str())
+							|| content.contains(&item.idref)
+					})
+					.map(|nav| nav.label.clone());
+
+				let compressed_size = epub
+					.get_resource_compressed_size(&item.idref)
+					.unwrap_or(PAGE_LENGTH as u64) as usize;
+				let position_count =
+					(compressed_size as f64 / PAGE_LENGTH as f64).ceil() as usize;
+				let position_count = position_count.max(1);
+
+				Some(SpineItemMetadata {
+					package_path,
+					media_type,
+					title,
+					position_count,
+				})
+			})
+			.collect();
+
+		Ok(resource_metas)
+	}
+
 	/// Generate a positions list for the EPUB
 	pub fn generate_positions(&self) -> Result<RWPMPositions, FileError> {
-		let items = self.enumerate_spine_for_positions()?;
-		let positions: Result<Vec<RWPMPosition>, FileError> = items
-			.into_iter()
-			.map(|item| {
+		let mut epub = EpubDoc::new(&self.epub_path)
+			.map_err(|e| FileError::EpubOpenError(e.to_string()))?;
+
+		let spine_items = self.generate_spine_metadata(&mut epub)?;
+		let total_positions: usize = spine_items.iter().map(|r| r.position_count).sum();
+		if total_positions == 0 {
+			return Ok(RWPMPositions::default());
+		}
+
+		let mut positions: Vec<RWPMPosition> = Vec::with_capacity(total_positions);
+		let mut book_position: usize = 1; // 1-based, book-wide
+
+		for meta in spine_items {
+			let href = self.resource_url(&meta.package_path);
+			for i in 0..meta.position_count {
+				let progression = i as f64 / meta.position_count as f64;
+				let total_progression =
+					(book_position - 1) as f64 / total_positions as f64;
+
 				let locations = RWPMPositionLocationsBuilder::default()
-					.position(item.position)
-					.progression(0.0)
-					.total_progression(item.total_progression)
-					.build()
-					.map_err(|error| FileError::EpubReadError(error.to_string()))?;
+					.position(book_position as u32)
+					.progression(progression)
+					.total_progression(total_progression)
+					.build()?;
 
 				let mut builder = RWPMPositionBuilder::default();
 				builder
-					.href(self.resource_url(&item.package_path))
-					.media_type(item.media_type)
+					.href(href.clone())
+					.media_type(meta.media_type.clone())
 					.locations(locations);
-				if let Some(title) = item.title {
-					builder.title(title);
+				if i == 0 {
+					if let Some(ref title) = meta.title {
+						builder.title(title.clone());
+					}
 				}
-				builder
-					.build()
-					.map_err(|error| FileError::EpubReadError(error.to_string()))
-			})
-			.collect();
-		let positions = positions?;
+				positions.push(builder.build()?);
 
-		RWPMPositionsBuilder::default()
+				book_position += 1;
+			}
+		}
+
+		Ok(RWPMPositionsBuilder::default()
 			.total(positions.len() as u32)
 			.positions(positions)
-			.build()
-			.map_err(|error| FileError::EpubReadError(error.to_string()))
+			.build()?)
 	}
 
 	fn extract_metadata(

--- a/crates/graphql/src/loader/reading_session.rs
+++ b/crates/graphql/src/loader/reading_session.rs
@@ -100,6 +100,7 @@ impl Loader<ResumeReadingCursorLoaderKey> for ReadingSessionLoader {
 							elapsed_seconds: total_elapsed,
 							started_at,
 							updated_at: s.updated_at,
+							media_id: key.media_id.clone(),
 						},
 					);
 				},

--- a/crates/graphql/src/object/resume_reading_cursor.rs
+++ b/crates/graphql/src/object/resume_reading_cursor.rs
@@ -1,10 +1,16 @@
-use async_graphql::SimpleObject;
-use models::shared::readium::ReadiumLocator;
-use sea_orm::prelude::*;
+use async_graphql::{ComplexObject, Context, Result, SimpleObject};
+use models::{entity::media, shared::readium::ReadiumLocator};
+use num_traits::ToPrimitive;
+use sea_orm::{prelude::*, QuerySelect};
+use stump_core::filesystem::media::ReadiumManifestGenerator;
+use tokio::task::spawn_blocking;
+
+use crate::data::CoreContext;
 
 /// the current reading position for a book, derived from the latest session
 /// with the highest `readthrough_number`
 #[derive(Debug, Clone, SimpleObject)]
+#[graphql(complex)]
 pub struct ResumeReadingCursor {
 	pub readthrough_number: i32,
 	/// the id of the session this cursor is derived from
@@ -18,4 +24,62 @@ pub struct ResumeReadingCursor {
 	pub started_at: Option<DateTimeWithTimeZone>,
 	// the last time the latest session in the current readthrough was updated
 	pub updated_at: Option<DateTimeWithTimeZone>,
+	#[graphql(skip)]
+	pub media_id: String,
+}
+
+#[ComplexObject]
+impl ResumeReadingCursor {
+	// TODO: im curious if perhaps i should just write positions of ebooks to
+	// db upon ingestion? then if changed/rebuilt regenerate it? that would save
+	// compute, which admittedly i have not measured so have little more than
+	// gut feelings here
+
+	/// A page number computed from the current locator's `total_progression` relative
+	/// to the computed positions list for the book.
+	async fn position_aware_page(&self, ctx: &Context<'_>) -> Result<Option<i32>> {
+		let total_progression = match self
+			.locator
+			.as_ref()
+			.and_then(|l| l.locations.as_ref())
+			.and_then(|loc| loc.total_progression)
+		{
+			Some(decimal) => decimal.to_f64().unwrap_or(0.0),
+			None => return Ok(None),
+		};
+
+		let conn = ctx.data::<CoreContext>()?.conn.as_ref();
+
+		let Some(book) = media::Entity::find_by_id(self.media_id.clone())
+			.select_only()
+			.columns(media::MediaIdentSelect::columns())
+			.filter(media::Column::Extension.like("epub"))
+			.into_model::<media::MediaIdentSelect>()
+			.one(conn)
+			.await?
+		else {
+			// no error because filtered by extension and the book likely exists and is not an epub.
+			// realistically we should never even get here if not epub, since locator should not
+			// be set on non-epubs, but guard against it nonetheless
+			return Ok(None);
+		};
+
+		// the base_url (second param) is only used for href contruction, which we do not care
+		// about here, and so the empty string is fine
+		let generator = ReadiumManifestGenerator::new(&book.path, "");
+		let positions = spawn_blocking(move || generator.generate_positions())
+			.await
+			.map_err(|e| async_graphql::Error::new(e.to_string()))??;
+
+		// finding the last position whose total_progression <= the stored value is
+		// roughly the page number
+		let page = positions
+			.positions
+			.iter()
+			.filter(|p| p.locations.total_progression <= total_progression)
+			.next_back()
+			.map(|p| p.locations.position as i32);
+
+		Ok(page)
+	}
 }

--- a/crates/graphql/src/object/resume_reading_cursor.rs
+++ b/crates/graphql/src/object/resume_reading_cursor.rs
@@ -22,7 +22,7 @@ pub struct ResumeReadingCursor {
 	pub elapsed_seconds: i64,
 	/// when the very first session in the current readthrough started
 	pub started_at: Option<DateTimeWithTimeZone>,
-	// the last time the latest session in the current readthrough was updated
+	/// the last time the latest session in the current readthrough was updated
 	pub updated_at: Option<DateTimeWithTimeZone>,
 	#[graphql(skip)]
 	pub media_id: String,
@@ -64,7 +64,7 @@ impl ResumeReadingCursor {
 			return Ok(None);
 		};
 
-		// the base_url (second param) is only used for href contruction, which we do not care
+		// the base_url is only used for href contruction, which we do not care
 		// about here, and so the empty string is fine
 		let generator = ReadiumManifestGenerator::new(&book.path, "");
 		let positions = spawn_blocking(move || generator.generate_positions())
@@ -76,8 +76,7 @@ impl ResumeReadingCursor {
 		let page = positions
 			.positions
 			.iter()
-			.filter(|p| p.locations.total_progression <= total_progression)
-			.next_back()
+			.rfind(|p| p.locations.total_progression <= total_progression)
 			.map(|p| p.locations.position as i32);
 
 		Ok(page)

--- a/crates/models/src/shared/readium.rs
+++ b/crates/models/src/shared/readium.rs
@@ -108,7 +108,7 @@ pub struct RWPMPositionLocations {
 }
 
 /// A Readium positions list.
-#[derive(Serialize, Builder)]
+#[derive(Serialize, Default, Builder)]
 #[builder(setter(into, strip_option))]
 #[serde(rename_all = "camelCase")]
 pub struct RWPMPositions {

--- a/packages/browser/src/components/readers/epub/annotations/decorations.ts
+++ b/packages/browser/src/components/readers/epub/annotations/decorations.ts
@@ -2,6 +2,7 @@ import { type Decoration, DecorationStyleType } from '@readium/navigator'
 import { Locator, LocatorLocations, LocatorText } from '@readium/shared'
 
 import type { ReaderLocator } from '../context'
+import { hrefsMatch } from '../readium/locator'
 import type { EpubAnnotation } from './types'
 import { DEFAULT_HIGHLIGHT_TINT } from './types'
 
@@ -11,8 +12,9 @@ import { DEFAULT_HIGHLIGHT_TINT } from './types'
 export function annotationToDecoration(
 	annotation: EpubAnnotation,
 	tint: string = DEFAULT_HIGHLIGHT_TINT,
+	positions: Locator[] = [],
 ): Decoration | null {
-	const toolkit = readerLocatorToToolkit(annotation.locator)
+	const toolkit = readerLocatorToToolkit(annotation.locator, positions)
 	if (!toolkit) return null
 
 	return {
@@ -32,16 +34,27 @@ export function annotationToDecoration(
 export function annotationsToDecorations(
 	annotations: EpubAnnotation[],
 	tint: string = DEFAULT_HIGHLIGHT_TINT,
+	positions: Locator[] = [],
 ): Decoration[] {
 	return annotations
-		.map((annotation) => annotationToDecoration(annotation, tint))
+		.map((annotation) => annotationToDecoration(annotation, tint, positions))
 		.filter((d): d is Decoration => d != null)
 }
 
-export function readerLocatorToToolkit(locator: ReaderLocator): Locator | null {
+export function readerLocatorToToolkit(
+	locator: ReaderLocator,
+	positions: Locator[] = [],
+): Locator | null {
 	if (!locator.href) return null
+
+	let href = locator.href
+	if (positions.length > 0) {
+		const match = positions.find((p) => hrefsMatch(p.href, href))
+		if (match) href = match.href
+	}
+
 	return new Locator({
-		href: locator.href,
+		href,
 		type: locator.type || 'application/xhtml+xml',
 		title: locator.title ?? locator.chapterTitle ?? undefined,
 		locations: new LocatorLocations({

--- a/packages/browser/src/components/readers/epub/readium/ReadiumWebReader.tsx
+++ b/packages/browser/src/components/readers/epub/readium/ReadiumWebReader.tsx
@@ -34,6 +34,7 @@ import { EpubContent, type ReaderLocator } from '../context'
 import EpubReaderContainer from '../EpubReaderContainer'
 import {
 	hrefsMatch,
+	packagePathFromHref,
 	resolveInitialLocator,
 	toolkitLocatorToInput,
 	toolkitLocatorToReaderLocator,
@@ -162,9 +163,6 @@ type LoadState =
 	| { status: 'loading' }
 	| { status: 'ready'; opened: OpenedPublication; initialLocator?: Locator }
 	| { status: 'error'; message: string }
-
-const EMPTY_POSITIONS: Locator[] = []
-const EMPTY_DOMAINS: string[] = []
 
 /**
  * Production Readium Web EPUB reader — streams via Stump RWPM.
@@ -453,12 +451,16 @@ export default function ReadiumWebReader({ id, isIncognito }: Props) {
 			const context = extractSelectionContext(containerRef.current, sel.targetFrameSrc)
 
 			const readingOrderHrefs =
-				opened?.publication.manifest.readingOrder?.items.map((link) => link.href) ?? []
+				opened?.publication.manifest.readingOrder?.items.map(
+					(link) => packagePathFromHref(link.href),
+					// ^ links are absolute on web, and relative to package on mobile, so we
+					// normalize onto package-relative
+				) ?? []
 			const chapterTitleFromToc = findChapterTitle(sel.locator?.href ?? '', toc)
 			const locator = enrichSelectionLocator({
 				selectionLocator: sel.locator ?? null,
 				selectedText: sel.text,
-				positions: opened?.positions ?? EMPTY_POSITIONS,
+				positions: opened?.positions ?? [],
 				readingOrderHrefs,
 				chapterTitleFromToc,
 			})
@@ -500,9 +502,9 @@ export default function ReadiumWebReader({ id, isIncognito }: Props) {
 	const { loadState, api } = useReadiumNavigator({
 		containerRef,
 		publication: opened?.publication ?? null,
-		positions: opened?.positions ?? EMPTY_POSITIONS,
+		positions: opened?.positions ?? [],
 		initialLocator,
-		allowedDomains: opened?.allowedDomains ?? EMPTY_DOMAINS,
+		allowedDomains: opened?.allowedDomains ?? [],
 		preferences,
 		onPositionChanged: handlePositionChanged,
 		onTextSelected,
@@ -511,8 +513,11 @@ export default function ReadiumWebReader({ id, isIncognito }: Props) {
 	})
 
 	useEffect(() => {
-		api.applyDecorations(annotationsToDecorations(annotations), ANNOTATION_DECORATION_GROUP)
-	}, [api, annotations])
+		api.applyDecorations(
+			annotationsToDecorations(annotations, undefined, opened?.positions ?? []),
+			ANNOTATION_DECORATION_GROUP,
+		)
+	}, [api, annotations, opened])
 
 	// A navigator position change means the reader moved away from wherever the
 	// selection toolbar was anchored, so drop it rather than show a stale rect.

--- a/packages/browser/src/components/readers/epub/readium/locator.ts
+++ b/packages/browser/src/components/readers/epub/readium/locator.ts
@@ -91,7 +91,7 @@ export function toolkitLocatorToInput(
 	const locations = locator.locations
 	return {
 		chapterTitle: chapterTitle ?? locator.title ?? '',
-		href: locator.href,
+		href: packagePathFromHref(locator.href),
 		title: locator.title,
 		type: locator.type || 'application/xhtml+xml',
 		locations: {


### PR DESCRIPTION
## Description

This PR aims to improve some of the issues reported when moving between web and mobile ebook readers. It definitely doesn't remove all the rough edges, and I have some more testing I'd like to get done, but this should improve things a bit: 

- Store package-relative urls for locator `href`s instead of server urls
   - The web app was storing full urls while mobile was storing relative urls, which caused the locators to not route correctly between platforms (e.g., reading on web, jump to mobile, it kicks you to the start of the book)
   - This should also improve issues with highlights/annotations not "working" between web and mobile platforms
- Refactor the positions generation logic to chunk pages per the RMSDK / Readium standard (a resource has roughly `compressed_size / 1024` positions)
   - This brings page counts into alignment between platforms, but does introduce what I found to be a slightly awkward UX on web footer that would ideally be corrected by showing the page number for each rendered "page" instead of one `X/Y` in the bottom-right
- Add a `position_aware_page` resolver to resume reading cursors, with a note to persist positions as part of ingestion at some point down the road

## Stump Contributor License Agreement

By contributing to Stump, you agree that your contributions will be licensed under the following licenses (where applicable):

- The [expo application](https://github.com/stumpapp/stump/blob/main/apps/expo/LICENSE) is licensed under [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.html)
- All other code in the repository is licensed under [MIT License](https://www.tldrlegal.com/license/mit-license)
