### PR TITLE
:pencil: Update stale documentation links

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -103,7 +103,7 @@ LABEL org.opencontainers.image.title="Stump" \
     org.opencontainers.image.description="A free and open source comics, manga and digital book server with OPDS support" \
     org.opencontainers.image.source="https://github.com/stumpapp/stump" \
     org.opencontainers.image.url="https://stumpapp.dev" \
-    org.opencontainers.image.documentation="https://stumpapp.dev/guides" \
+    org.opencontainers.image.documentation="https://stumpapp.dev/docs" \
     org.opencontainers.image.licenses="MIT" \
     org.opencontainers.image.vendor="stumpapp"
 

--- a/packages/browser/src/scenes/settings/server/general/HelpfulLinks.tsx
+++ b/packages/browser/src/scenes/settings/server/general/HelpfulLinks.tsx
@@ -15,7 +15,7 @@ export default function HelpfulLinks() {
 				label={t('settingsScene.server/general.sections.helpfulLinks.links.documentation')}
 			>
 				<ButtonOrLink
-					href="https://www.stumpapp.dev/guides"
+					href="https://www.stumpapp.dev/docs"
 					target="__blank"
 					rel="noopener noreferrer"
 					size="sm"


### PR DESCRIPTION
## Description

The documentation site was reorganized and lives under `stumpapp.dev/docs` now, but two places in the app still pointed at the old `stumpapp.dev/guides` URLs, which return 404.

- Summary of changes
  - `packages/browser/src/scenes/settings/server/general/HelpfulLinks.tsx`: updated the "Documentation" helpful link from `https://www.stumpapp.dev/guides` to `https://www.stumpapp.dev/docs`
  - `docker/Dockerfile`: updated the `org.opencontainers.image.documentation` OCI label from `https://stumpapp.dev/guides` to `https://stumpapp.dev/docs`
- Reasoning
  - `https://www.stumpapp.dev/guides` returns 404, while `https://www.stumpapp.dev/docs` returns 200. I searched the issue tracker for existing reports and found none, so I went straight to this small fix.
- Additional context
  - scope verified with a quick sweep of `stumpapp.dev` URLs in the codebase; no other stale links remain

How to contribute: https://github.com/stumpapp/stump/blob/main/.github/CONTRIBUTING.md

## Ready?

- [x] I read the [contributing guidelines](https://github.com/stumpapp/stump/blob/main/.github/CONTRIBUTING.md)
- [x] I searched for existing issues or pull requests that may be related to my contribution
- [x] This PR is based into `nightly` and not `main`
- [ ] I added tests and/or documentation for my changes if applicable
- [x] I disclosed any use of LLMs in the creation of this PR (if applicable)

## Stump Contributor License Agreement

- The [expo application](https://github.com/stumpapp/stump/blob/main/apps/expo/LICENSE) is licensed under [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.html)
- All other code in the repository is licensed under [MIT License](https://www.tldrlegal.com/license/mit-license)
