### PR TITLE
🐛  Fix metadata panel collapsing after Edit -> Save on files with no metadata

### DIFF
--- a/packages/browser/src/components/metadata/metadataEditor/MetadataEditorTable.tsx
+++ b/packages/browser/src/components/metadata/metadataEditor/MetadataEditorTable.tsx
@@ -105,14 +105,15 @@ export default function MetadataEditorTable<Item extends RowData>({
 			}}
 		>
 			<table
-				className="w-fit divide-y divide-border"
+				// Note: stay full-width when JS sizing goes stale (e.g. right after save).
+				className="w-full divide-y divide-border"
 				style={{
-					width: table.getCenterTotalSize(),
+					minWidth: table.getCenterTotalSize(),
 				}}
 				ref={tableRef}
 			>
 				<thead>
-					<tr className="relative flex">
+					<tr className="relative flex w-full">
 						{table.getFlatHeaders().map((header) => (
 							<th
 								key={header.id}
@@ -123,7 +124,11 @@ export default function MetadataEditorTable<Item extends RowData>({
 										...getCommonPinningStyles(header.column),
 									},
 								}}
-								className="min-h-10 relative bg-card/70"
+								className={cn(
+									'min-h-10 relative bg-card/70',
+									// Fill leftover space so the row spans the table when sizes run short.
+									{ grow: header.column.columnDef.meta?.isGrow },
+								)}
 							>
 								{flexRender(header.column.columnDef.header, header.getContext())}
 
@@ -153,10 +158,13 @@ export default function MetadataEditorTable<Item extends RowData>({
 
 				<tbody className="divide-y divide-border">
 					{rows.map((row) => (
-						<tr key={row.id} className="group/row flex w-fit">
+						<tr key={row.id} className="group/row flex w-full">
 							{row.getVisibleCells().map((cell) => (
 								<td
-									className="py-2 pl-1.5 pr-1.5 first:pl-4 last:pl-0 last:pr-0 first:border-r first:border-border"
+									className={cn(
+										'py-2 pl-1.5 pr-1.5 first:pl-4 last:pl-0 last:pr-0 first:border-r first:border-border',
+										{ grow: cell.column.columnDef.meta?.isGrow },
+									)}
 									key={cell.id}
 									style={{
 										width: cell.column.getSize(),
@@ -170,9 +178,9 @@ export default function MetadataEditorTable<Item extends RowData>({
 					))}
 
 					{!rows.length && (
-						<tr>
-							<td colSpan={2}>
-								<div className="h-32 flex items-center justify-center">No Metadata</div>
+						<tr className="flex w-full">
+							<td colSpan={columns.length} className="flex-1">
+								<div className="h-32 flex w-full items-center justify-center">No Metadata</div>
 							</td>
 						</tr>
 					)}

--- a/packages/browser/src/components/metadata/metadataEditor/utils.ts
+++ b/packages/browser/src/components/metadata/metadataEditor/utils.ts
@@ -29,39 +29,41 @@ export function calculateTableSizing<DataType>(
 	let totalAvailableWidth = totalWidth
 	let totalIsGrow = 0
 
+	// Note: key by resolved column id, def ids are undefined for accessor columns.
+	// Keep this pure, mutated sizes are lost when defs are recreated after save.
+	const baseSizes = new Map<string, number | undefined>()
+
 	columns.forEach((header) => {
 		const column = header.column.columnDef
-		if (column.size == null) {
+		let size = column.size
+		if (size == null) {
 			if (!column.meta?.isGrow) {
-				let calculatedSize = 100
 				if (column?.meta?.widthPercentage) {
-					calculatedSize = column.meta.widthPercentage * totalWidth * 0.01
+					size = column.meta.widthPercentage * totalWidth * 0.01
 				} else {
-					calculatedSize = totalWidth / columns.length
+					size = totalWidth / columns.length
 				}
-
-				const size = getSize(calculatedSize, column.maxSize, column.minSize)
-
-				column.size = size
+				size = getSize(size, column.maxSize, column.minSize)
 			}
 		}
 
 		if (column.meta?.isGrow) totalIsGrow += 1
-		else totalAvailableWidth -= getSize(column.size, column.maxSize, column.minSize)
+		else totalAvailableWidth -= getSize(size, column.maxSize, column.minSize)
+
+		baseSizes.set(header.column.id, size)
 	})
 
 	const sizing: Record<string, number> = {}
 
 	columns.forEach((header) => {
 		const column = header.column.columnDef
+		const id = header.column.id
 		if (column.meta?.isGrow) {
-			let calculatedSize = 100
-			calculatedSize = Math.floor(totalAvailableWidth / totalIsGrow)
-			const size = getSize(calculatedSize, column.maxSize, column.minSize)
-			column.size = size
+			const calculatedSize = Math.floor(totalAvailableWidth / totalIsGrow)
+			sizing[id] = getSize(calculatedSize, column.maxSize, column.minSize)
+		} else {
+			sizing[id] = Number(baseSizes.get(id))
 		}
-
-		sizing[`${column.id}`] = Number(column.size)
 	})
 
 	return sizing


### PR DESCRIPTION
## Description

Minor UI issue: When I open a book with no metadata, hit Edit -> Save in the metadata panel, and the whole panel collapses to about a fifth of its width (though, i am guessing this dependent on the devices width). The top row shrinks, the Edit button ends up right next to the label, which is a bit jarring. 

This tends to be a problem in libraries where you want metadata gone, e.g., a magazine/scientific papers/document library where any accidental metadata is just noise. So there I delete it, and I see the bug.

Fixed by keying sizes by the resolved column id and keeping the function pure, plus made the table/rows/empty state full-width in CSS so stale JS sizing can't collapse the panel again.


## Screenshots

Before:


https://github.com/user-attachments/assets/891adcb4-93f2-4ab0-82f5-b093bc6f4e21




After:


https://github.com/user-attachments/assets/9ddd43ae-c91e-4c0c-96f6-5f9ad7eb9d78




## Ready?

Please read each item and check the boxes:

- [X] I read the [contributing guidelines](https://github.com/stumpapp/stump/blob/main/.github/CONTRIBUTING.md)
- [X] I searched for existing issues or pull requests that may be related to my contribution
- [X] This PR is based into `nightly` and not `main`
- [X] I added tests and/or documentation for my changes if applicable
- [X] I disclosed any use of LLMs in the creation of this PR (if applicable)

## Stump Contributor License Agreement

By contributing to Stump, you agree that your contributions will be licensed under the following licenses (where applicable):

- The [expo application](https://github.com/stumpapp/stump/blob/main/apps/expo/LICENSE) is licensed under [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.html)
- All other code in the repository is licensed under [MIT License](https://www.tldrlegal.com/license/mit-license)
