### PR TITLE
🩹 Fix smart list `NOT` filter and series `ageRating` filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3509,6 +3509,7 @@ dependencies = [
  "strum 0.27.2",
  "stump_core",
  "tempfile",
+ "tests",
  "tokio",
  "tower-sessions",
  "tracing",

--- a/crates/graphql/Cargo.toml
+++ b/crates/graphql/Cargo.toml
@@ -34,6 +34,7 @@ serde_with.workspace = true
 slugify.workspace = true
 strum.workspace = true
 stump_core = { path = "../../core" }
+tests = { path = "../tests" }
 tokio.workspace = true
 tower-sessions.workspace = true
 tracing.workspace = true

--- a/crates/graphql/src/filter/library.rs
+++ b/crates/graphql/src/filter/library.rs
@@ -8,7 +8,7 @@ use super::{apply_string_filter, IntoFilter, StringLikeFilter};
 // TODO: Support filter by tags (requires join logic)
 
 #[skip_serializing_none]
-#[derive(InputObject, Clone, Debug, Serialize, Deserialize)]
+#[derive(InputObject, Clone, Debug, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct LibraryFilterInput {
 	#[graphql(default)]

--- a/crates/graphql/src/query/smart_lists_builder.rs
+++ b/crates/graphql/src/query/smart_lists_builder.rs
@@ -163,7 +163,7 @@ pub fn build_filters(
 		let mut condition = match filter_group.joiner {
 			SmartListGroupJoiner::And => Condition::all(),
 			SmartListGroupJoiner::Or => Condition::any(),
-			// semantically this is meant to be "non in group are true" and therefore
+			// semantically this is meant to be "none in group are true" and therefore
 			// uses `any` instead of `all`, otherwise it is a simple negate
 			SmartListGroupJoiner::Not => Condition::any().not(),
 		};

--- a/crates/graphql/src/query/smart_lists_builder.rs
+++ b/crates/graphql/src/query/smart_lists_builder.rs
@@ -163,7 +163,9 @@ pub fn build_filters(
 		let mut condition = match filter_group.joiner {
 			SmartListGroupJoiner::And => Condition::all(),
 			SmartListGroupJoiner::Or => Condition::any(),
-			SmartListGroupJoiner::Not => Condition::all().not(),
+			// semantically this is meant to be "non in group are true" and therefore
+			// uses `any` instead of `all`, otherwise it is a simple negate
+			SmartListGroupJoiner::Not => Condition::any().not(),
 		};
 		for filter in &filter_group.groups {
 			condition = match filter {
@@ -258,6 +260,9 @@ fn add_sessions_join(
 
 	query
 }
+
+// TODO(tests): i hate these sql string tests, thanks to the newer fake_data test crate i think
+// we should just instead actually kick off queries against real data and assert a few fundamentals
 
 #[cfg(test)]
 mod tests {

--- a/crates/graphql/src/query/smart_lists_builder.rs
+++ b/crates/graphql/src/query/smart_lists_builder.rs
@@ -269,10 +269,12 @@ mod tests {
 	use super::*;
 	use crate::{
 		filter::{
-			library::LibraryFilterInput, media::MediaFilterInput, StringLikeFilter,
+			library::LibraryFilterInput, media::MediaFilterInput, NumericFilter,
+			StringLikeFilter,
 		},
 		tests::common::get_default_user,
 	};
+	use ::tests::{db::test_database, fake_data};
 	use pretty_assertions::assert_eq;
 	use sea_orm::{
 		sea_query::{Query, SqliteQueryBuilder},
@@ -283,6 +285,90 @@ mod tests {
 		Query::select()
 			.cond_where(condition.clone())
 			.to_string(SqliteQueryBuilder)
+	}
+
+	#[tokio::test]
+	async fn test_media_group_filter_not_is_none_are_true() {
+		let db = test_database().await;
+		let auth_user = fake_data::User::default().auth_user(&db).await;
+
+		let filters: Vec<SmartListFilterGroupInput> = vec![SmartListFilterGroupInput {
+			joiner: SmartListGroupJoiner::Not,
+			groups: vec![
+				SmartListFilterInput::Media(MediaFilterInput {
+					name: Some(StringLikeFilter::Eq("stinky book".to_string())),
+					..Default::default()
+				}),
+				SmartListFilterInput::Media(MediaFilterInput {
+					name: Some(StringLikeFilter::Eq("another stinky book".to_string())),
+					..Default::default()
+				}),
+				SmartListFilterInput::Media(MediaFilterInput {
+					size: Some(NumericFilter::Eq(100)),
+					..Default::default()
+				}),
+			],
+		}];
+
+		let series = fake_data::Series::default().insert(&db).await;
+
+		let stinky_book = fake_data::Media {
+			name: Some("stinky book".to_string()),
+			series_id: series.id.clone(),
+			..Default::default()
+		}
+		.insert(&db)
+		.await;
+
+		let another_stinky_book = fake_data::Media {
+			name: Some("another stinky book".to_string()),
+			series_id: series.id.clone(),
+			..Default::default()
+		}
+		.insert(&db)
+		.await;
+
+		let okay_name_but_stinky_size = fake_data::Media {
+			name: Some("okay name but stinky size".to_string()),
+			size: Some(100),
+			series_id: series.id.clone(),
+			..Default::default()
+		}
+		.insert(&db)
+		.await;
+
+		let totally_okay_will_return_book = fake_data::Media {
+			name: Some("totally okay will return book".to_string()),
+			series_id: series.id.clone(),
+			..Default::default()
+		}
+		.insert(&db)
+		.await;
+
+		let should_exclude_ids = vec![
+			stinky_book.id,
+			another_stinky_book.id,
+			okay_name_but_stinky_size.id,
+		];
+
+		let query = build_books_query(
+			&auth_user,
+			smart_list::SmartListJoiner::And,
+			&filters,
+			None,
+		);
+
+		let results = query
+			.into_model::<media::ModelWithMetadata>()
+			.all(&db)
+			.await
+			.expect("should exec query");
+
+		assert_eq!(results.len(), 1);
+		assert!(!results
+			.iter()
+			.any(|book| should_exclude_ids.contains(&book.media.id)));
+		assert_eq!(results[0].media.id, totally_okay_will_return_book.id);
 	}
 
 	#[test]
@@ -298,23 +384,8 @@ mod tests {
 		let filters: Vec<SmartListFilterGroupInput> = vec![SmartListFilterGroupInput {
 			joiner: SmartListGroupJoiner::And,
 			groups: vec![SmartListFilterInput::Media(MediaFilterInput {
-				id: None,
 				name: Some(StringLikeFilter::Eq("Test".to_string())),
-				_and: None,
-				created_at: None,
-				extension: None,
-				metadata: None,
-				_not: None,
-				_or: None,
-				pages: None,
-				path: None,
-				reading_status: None,
-				series: None,
-				series_id: None,
-				size: None,
-				status: None,
-				tags: None,
-				updated_at: None,
+				..Default::default()
 			})],
 		}];
 		let condition = build_filters(smart_list::SmartListJoiner::And, &filters);
@@ -328,34 +399,15 @@ mod tests {
 			SmartListFilterGroupInput {
 				joiner: SmartListGroupJoiner::Not,
 				groups: vec![SmartListFilterInput::Media(MediaFilterInput {
-					id: None,
 					name: Some(StringLikeFilter::Eq("Book".to_string())),
-					_and: None,
-					created_at: None,
-					extension: None,
-					metadata: None,
-					_not: None,
-					_or: None,
-					pages: None,
-					path: None,
-					reading_status: None,
-					series: None,
-					series_id: None,
-					size: None,
-					status: None,
-					tags: None,
-					updated_at: None,
+					..Default::default()
 				})],
 			},
 			SmartListFilterGroupInput {
 				joiner: SmartListGroupJoiner::Or,
 				groups: vec![SmartListFilterInput::Library(LibraryFilterInput {
-					id: None,
 					name: Some(StringLikeFilter::Eq("Test".to_string())),
-					path: None,
-					_and: None,
-					_not: None,
-					_or: None,
+					..Default::default()
 				})],
 			},
 		];
@@ -373,34 +425,15 @@ mod tests {
 			SmartListFilterGroupInput {
 				joiner: SmartListGroupJoiner::Or,
 				groups: vec![SmartListFilterInput::Media(MediaFilterInput {
-					id: None,
 					name: Some(StringLikeFilter::Eq("Book".to_string())),
-					_and: None,
-					created_at: None,
-					extension: None,
-					metadata: None,
-					_not: None,
-					_or: None,
-					pages: None,
-					path: None,
-					reading_status: None,
-					series: None,
-					series_id: None,
-					size: None,
-					status: None,
-					tags: None,
-					updated_at: None,
+					..Default::default()
 				})],
 			},
 			SmartListFilterGroupInput {
 				joiner: SmartListGroupJoiner::Or,
 				groups: vec![SmartListFilterInput::Library(LibraryFilterInput {
-					id: None,
 					name: Some(StringLikeFilter::Eq("Test".to_string())),
-					path: None,
-					_and: None,
-					_not: None,
-					_or: None,
+					..Default::default()
 				})],
 			},
 		];

--- a/crates/tests/src/fake_data.rs
+++ b/crates/tests/src/fake_data.rs
@@ -1,9 +1,10 @@
 use chrono::Utc;
+use models::entity::user::{AuthUser, LoginUser};
 use models::entity::{library, library_config, media, reading_session, series, user};
 use models::shared::enums::{FileStatus, ReadingStatus};
 use rand::distr::SampleString;
 use rust_decimal::prelude::FromPrimitive;
-use sea_orm::{prelude::DateTimeWithTimeZone, ActiveModelTrait, ActiveValue, DbConn};
+use sea_orm::{prelude::*, ActiveModelTrait, ActiveValue, DbConn};
 use uuid::Uuid;
 
 // note that None here means "use some default", not necessarily "set the value to None".
@@ -15,6 +16,7 @@ pub struct Media {
 	pub id: Option<String>,
 	pub name: Option<String>,
 	pub extension: Option<String>,
+	pub size: Option<i64>,
 	pub created_at: Option<DateTimeWithTimeZone>,
 	pub modified_at: Option<DateTimeWithTimeZone>,
 	pub deleted_at: Option<DateTimeWithTimeZone>,
@@ -38,8 +40,8 @@ impl Media {
 			series_id: ActiveValue::Set(Some(self.series_id.clone())),
 			id: ActiveValue::Set(id.clone()),
 			name: ActiveValue::Set(name.clone()),
-			size: ActiveValue::Set(1234),
 			extension: sea_orm::Set(extension.clone()),
+			size: self.size.map_or(ActiveValue::Set(1234), ActiveValue::Set),
 			pages: ActiveValue::Set(self.pages.unwrap_or(940)),
 			modified_at: self
 				.modified_at
@@ -92,6 +94,18 @@ impl User {
 		};
 
 		model.insert(db).await.expect("could not insert user")
+	}
+
+	pub async fn auth_user(&self, db: &DbConn) -> AuthUser {
+		let user = self.insert(db).await;
+		AuthUser::from(
+			LoginUser::find_by_id(user.id)
+				.into_model::<LoginUser>()
+				.one(db)
+				.await
+				.expect("should exec query")
+				.expect("should find user"),
+		)
 	}
 }
 

--- a/packages/browser/src/components/filters/form/MediaFilterForm.tsx
+++ b/packages/browser/src/components/filters/form/MediaFilterForm.tsx
@@ -83,7 +83,7 @@ export default function MediaFilterForm() {
 
 	const defaultValue = useMemo(() => {
 		const flattenMetadata = {
-			age_rating: (filters?.metadata as MediaMetadataFilterInput)?.ageRating?.eq ?? null,
+			age_rating: (filters?.metadata as MediaMetadataFilterInput)?.ageRating?.lte ?? null,
 			character: (filters?.metadata as MediaMetadataFilterInput)?.characters?.likeAnyOf ?? [],
 			colorist: (filters?.metadata as MediaMetadataFilterInput)?.colorists?.likeAnyOf ?? [],
 			editor: (filters?.metadata as MediaMetadataFilterInput)?.editors?.likeAnyOf ?? [],

--- a/packages/browser/src/components/filters/form/SeriesFilterForm.tsx
+++ b/packages/browser/src/components/filters/form/SeriesFilterForm.tsx
@@ -42,7 +42,7 @@ export default function SeriesFilterForm() {
 		() =>
 			({
 				metadata: {
-					ageRating: filters?.metadata?.ageRating?.gte ?? null,
+					ageRating: filters?.metadata?.ageRating?.lte ?? null,
 					metaType: filters?.metadata?.metaType?.likeAnyOf ?? [],
 					status: filters?.metadata?.status?.likeAnyOf ?? [],
 				},
@@ -93,7 +93,7 @@ const intoGraphql = (values: SeriesFilterFormSchema) =>
 		metadata: {
 			ageRating: values.metadata?.ageRating
 				? {
-						gte: values.metadata.ageRating,
+						lte: values.metadata.ageRating,
 					}
 				: undefined,
 			metaType: values.metadata?.metaType

--- a/packages/browser/src/components/filters/form/__tests__/AgeRatingFilter.test.tsx
+++ b/packages/browser/src/components/filters/form/__tests__/AgeRatingFilter.test.tsx
@@ -38,7 +38,7 @@ describe('AgeRatingFilter', () => {
 			),
 		).toBeInTheDocument()
 
-		await user.click(screen.getByRole('radio', { name: /Aged N and up/ }))
+		await user.click(screen.getByRole('radio', { name: /Aged N and below/ }))
 		expect(screen.getByTestId('age-rating-value')).toHaveTextContent('8')
 
 		await user.click(screen.getByRole('radio', { name: /Any age/ }))

--- a/packages/i18n/src/locales/en-US.json
+++ b/packages/i18n/src/locales/en-US.json
@@ -869,7 +869,7 @@
 				"description": "No age rating filter will be applied"
 			},
 			"custom": {
-				"label": "Aged N and up",
+				"label": "Aged N and below",
 				"description": {
 					"media": "Only media with an age rating of N or lower will be shown, where N is the number you enter below",
 					"series": "Only series with an age rating of N or lower will be shown, where N is the number you enter below"


### PR DESCRIPTION
Closes #1405
Closes #1406

## Description

- Change the smart list group joiner `NOT` to align with the semantic description (#1405)
- Fix the incorrect operator series `ageRating` filter (#1406)

## Stump Contributor License Agreement

By contributing to Stump, you agree that your contributions will be licensed under the following licenses (where applicable):

- The [expo application](https://github.com/stumpapp/stump/blob/main/apps/expo/LICENSE) is licensed under [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.html)
- All other code in the repository is licensed under [MIT License](https://www.tldrlegal.com/license/mit-license)
