### PR TITLE
♻️ Support nested oneshot folders and attempt oneshot conversions

### DIFF
--- a/core/src/filesystem/scanner/library_scan_job.rs
+++ b/core/src/filesystem/scanner/library_scan_job.rs
@@ -29,7 +29,12 @@ use crate::{
 		},
 		metadata::MetadataFetchJobParams,
 		scanner::{
-			utils::{build_and_insert_oneshots, build_ignore_rules},
+			utils::{
+				build_and_insert_oneshots, build_ignore_rules,
+				convert_previous_oneshot_entries_to_series_media,
+				convert_to_oneshot_series, PendingOneshotConversion,
+				SeriesConversionOutput,
+			},
 			walk::{walk_oneshots, WalkedOneshots},
 		},
 	},
@@ -693,6 +698,7 @@ impl JobLifecycle for LibraryScanJob {
 					ignored_files,
 					skipped_files,
 					observed_dir_mtimes,
+					previous_oneshot_entries,
 				} = match walk_result {
 					Ok(walked_series) => walked_series,
 					Err(core_error) => {
@@ -761,6 +767,26 @@ impl JobLifecycle for LibraryScanJob {
                     ));
 				};
 
+				if !previous_oneshot_entries.is_empty() {
+					ctx.report_progress(JobProgress::msg(
+						"Converting oneshots to series media",
+					));
+					let SeriesConversionOutput {
+						updated_media,
+						deleted_series,
+						logs: conversion_logs,
+					} = convert_previous_oneshot_entries_to_series_media(
+						&series_id,
+						previous_oneshot_entries,
+						ctx.conn(),
+					)
+					.await?;
+					output.updated_media += updated_media;
+					output.updated_series += deleted_series;
+					// ^ not _strictly_ update but think it is largely acceptable
+					logs.extend(conversion_logs);
+				}
+
 				subtasks = chain_optional_iter(
 					[],
 					[
@@ -794,9 +820,9 @@ impl JobLifecycle for LibraryScanJob {
 						ignore_rules: build_ignore_rules(&self.config)?,
 						max_depth: None, // not needed
 						options: self.options,
-						dir_mtimes: (*self.dir_mtimes).clone(), // TODO: not needed? harmless to leave in ig
-						series_id: None,                        // not needed
-						oneshots_directory: None,               // not needed
+						dir_mtimes: (*self.dir_mtimes).clone(),
+						series_id: None,          // not needed
+						oneshots_directory: None, // not needed
 					},
 				)
 				.await;
@@ -806,6 +832,7 @@ impl JobLifecycle for LibraryScanJob {
 					seen_files,
 					ignored_files,
 					book_operations,
+					pending_oneshot_conversions,
 				} = match walk_result {
 					Ok(result) => result,
 					Err(core_error) => {
@@ -844,6 +871,33 @@ impl JobLifecycle for LibraryScanJob {
 							library_id: self.id.clone(),
 						},
 					));
+				}
+
+				if !pending_oneshot_conversions.is_empty() {
+					ctx.report_progress(JobProgress::msg(
+						"Converting series to oneshots",
+					));
+					for PendingOneshotConversion {
+						series_id: old_id,
+						media,
+					} in pending_oneshot_conversions
+					{
+						let OneshotOperationOutput {
+							created_series: converted,
+							logs: convert_logs,
+							..
+						} = convert_to_oneshot_series(&old_id, media, &self.id, ctx).await?;
+						output.created_series += converted;
+						logs.extend(convert_logs);
+						if converted > 0 {
+							ctx.emit_event(CoreEvent::CreatedManySeries(
+								event::CreatedManySeries {
+									count: converted,
+									library_id: self.id.clone(),
+								},
+							));
+						}
+					}
 				}
 
 				subtasks = book_operations

--- a/core/src/filesystem/scanner/library_scan_job.rs
+++ b/core/src/filesystem/scanner/library_scan_job.rs
@@ -280,7 +280,6 @@ impl JobLifecycle for LibraryScanJob {
 			.into_iter()
 			.map(LibraryScanTask::WalkOneshotsDirectory)
 			.collect::<Vec<LibraryScanTask>>();
-		// TODO: this shouldj ust be a single path lol right? no nesting?
 
 		let tasks = VecDeque::from(
 			[LibraryScanTask::Init(init_task_input)]

--- a/core/src/filesystem/scanner/utils/mod.rs
+++ b/core/src/filesystem/scanner/utils/mod.rs
@@ -20,7 +20,7 @@ pub(crate) use media::{
 	build_and_insert_media, handle_missing_media, handle_restored_media,
 	visit_and_update_media, MediaBuildOperation, MediaOperationOutput,
 };
-pub(crate) use oneshot::{build_and_insert_oneshots, OneshotOperationOutput};
+pub(crate) use oneshot::*;
 pub(crate) use series::{
 	handle_missing_series, insert_series, safely_build_series, MissingSeriesOutput,
 };

--- a/core/src/filesystem/scanner/utils/oneshot.rs
+++ b/core/src/filesystem/scanner/utils/oneshot.rs
@@ -1,5 +1,5 @@
 use std::{
-	collections::{HashSet, VecDeque},
+	collections::{HashMap, HashSet, VecDeque},
 	path::{Path, PathBuf},
 	sync::Arc,
 	time::Instant,
@@ -7,15 +7,24 @@ use std::{
 
 use futures::StreamExt;
 use models::{
-	entity::{library_config, media, media_metadata, series, series_metadata},
+	entity::{
+		library_config,
+		media::{self, MediaIdentSelect},
+		media_metadata,
+		series::{self, SeriesIdentSelect},
+		series_metadata,
+	},
 	shared::enums::FileStatus,
 };
-use sea_orm::{prelude::*, ActiveValue, Set, TransactionTrait};
+use sea_orm::{
+	prelude::*, sea_query::Expr, ActiveValue, QuerySelect, Set, TransactionTrait,
+};
 use tokio::task::spawn_blocking;
 use uuid::Uuid;
 
 use crate::{
 	config::StumpConfig,
+	database::SQLITE_BIND_LIMIT,
 	error::{CoreError, CoreResult},
 	event::CreatedMedia,
 	filesystem::{
@@ -41,6 +50,27 @@ pub(crate) struct OneshotOperationOutput {
 	pub created_series: u64,
 	pub created_media: u64,
 	pub logs: Vec<JobExecuteLog>,
+}
+
+/// A series that was previously scanned as a regular series whose directory now matches
+/// the configured oneshots directory name (and thus should be converted)
+pub struct PendingOneshotConversion {
+	/// The ID of the series to convert into a oneshot
+	pub series_id: String,
+	/// The books that belong to the series being converted
+	pub media: Vec<media::MediaIdentSelect>,
+	// ^ note this SHOULD be one, however would be way too much work to really
+	// enforce that in a way that is user-friendly and allows someone to
+	// choose which is yoinked and which is dumped
+}
+
+/// A book that is currently registered as a oneshot series in the database that should be
+/// updated to be a normal media item in a non-oneshot series
+pub struct PreviousOneshotEntry {
+	/// The file path of the book (also the path of the old oneshot series)
+	pub book_path: PathBuf,
+	/// The ID of the old oneshot series to delete after reassigning its media
+	pub old_series_id: String,
 }
 
 fn build_oneshot_blocking<P: AsRef<Path>>(
@@ -337,4 +367,274 @@ pub(crate) async fn build_and_insert_oneshots(
 		created_series,
 		logs: ordered_logs,
 	})
+}
+
+/// Given a list of series ids which need to be converted into oneshots, collect
+/// all media rows for each series and return a map of series-to-books
+pub(crate) async fn collect_pending_oneshot_conversions(
+	series_ids: Vec<String>,
+	conn: &DatabaseConnection,
+) -> Result<Vec<PendingOneshotConversion>, CoreError> {
+	if series_ids.is_empty() {
+		return Ok(vec![]);
+	}
+
+	let mut books_by_series =
+		HashMap::<String, Vec<MediaIdentSelect>>::with_capacity(series_ids.len());
+
+	let books = media::Entity::find()
+		.select_only()
+		.columns(media::MediaIdentSelect::columns())
+		.column(media::Column::SeriesId)
+		.filter(media::Column::SeriesId.is_in(series_ids.clone()))
+		.into_model::<media::MediaIdentWithSeriesId>()
+		.all(conn)
+		.await?;
+
+	for book in books {
+		books_by_series
+			.entry(book.series_id)
+			.or_default()
+			// TODO(oneshots): technically this would break the oneshot convention, however
+			// i really am not sure how to otherwise go about it without a serious fucking headache
+			// flow to let the user know X oneshot has Y books and you need to pick which to keep vs delete
+			.push(MediaIdentSelect {
+				id: book.id,
+				path: book.path,
+			});
+	}
+
+	Ok(books_by_series
+		.into_iter()
+		.map(|(series_id, media)| PendingOneshotConversion { series_id, media })
+		.collect())
+}
+
+/// Get a list of entries for converting existing oneshot series into regular media items
+/// under a new series. The caller should ensure to only pass in files which
+/// actually require conversion, this function makes no such check
+pub(crate) async fn collect_previous_oneshot_entries(
+	file_paths: Vec<String>,
+	conn: &DatabaseConnection,
+) -> Result<Vec<PreviousOneshotEntry>, CoreError> {
+	if file_paths.is_empty() {
+		return Ok(vec![]);
+	}
+
+	let mut previous_oneshots = Vec::new();
+
+	for chunks in file_paths.chunks(SQLITE_BIND_LIMIT) {
+		let oneshots_to_convert = series::Entity::find()
+			.select_only()
+			.columns(SeriesIdentSelect::columns())
+			.filter(series::Column::IsOneshot.eq(true))
+			.filter(series::Column::Path.is_in(chunks.to_vec()))
+			.into_model::<SeriesIdentSelect>()
+			.all(conn)
+			.await?
+			.into_iter()
+			.map(|s| PreviousOneshotEntry {
+				book_path: PathBuf::from(&s.path),
+				old_series_id: s.id,
+			})
+			.collect::<Vec<_>>();
+		previous_oneshots.extend(oneshots_to_convert);
+	}
+
+	Ok(previous_oneshots)
+}
+
+/// Converts a normal series into individual oneshot series entries for each book in it.
+/// The old series will be deleted after the conversion.
+pub(crate) async fn convert_to_oneshot_series(
+	old_series_id: &str,
+	media_rows: Vec<media::MediaIdentSelect>,
+	library_id: &str,
+	worker_ctx: &JobContext,
+) -> Result<OneshotOperationOutput, JobError> {
+	let mut output = OneshotOperationOutput::default();
+
+	if media_rows.is_empty() {
+		series::Entity::delete_many()
+			.filter(series::Column::Id.eq(old_series_id))
+			.exec(worker_ctx.conn())
+			.await?;
+		return Ok(output);
+	}
+
+	let total = media_rows.len();
+	tracing::debug!(
+		total,
+		old_series_id,
+		"Converting directory series to oneshots"
+	);
+	worker_ctx
+		.report_progress(JobProgress::msg("Converting series to individual oneshots"));
+
+	let txn = worker_ctx.conn().begin().await?;
+
+	for (idx, media_row) in media_rows.iter().enumerate() {
+		let new_series_id = Uuid::new_v4().to_string();
+		let FileParts {
+			file_stem: name, ..
+		} = PathBuf::from(&media_row.path).file_parts();
+
+		let media_metadata = media_metadata::Entity::find()
+			.filter(media_metadata::Column::MediaId.eq(&media_row.id))
+			.one(&txn)
+			.await?;
+
+		let series_metadata = match media_metadata.and_then(|m| m.title) {
+			Some(title) => Some(series_metadata::ActiveModel {
+				series_id: Set(new_series_id.clone()),
+				title: Set(Some(title)),
+				..Default::default()
+			}),
+			_ => None,
+		};
+
+		let new_series = series::ActiveModel {
+			id: Set(new_series_id.clone()),
+			path: Set(media_row.path.clone()),
+			name: Set(name),
+			library_id: Set(Some(library_id.to_string())),
+			is_oneshot: Set(true),
+			status: Set(FileStatus::Ready),
+			..Default::default()
+		};
+		new_series.insert(&txn).await?;
+
+		if let Some(meta) = series_metadata {
+			if let Err(error) = meta.insert(&txn).await {
+				tracing::error!(?error, "Failed to insert series metadata for oneshot");
+			}
+		}
+
+		media::Entity::update_many()
+			.filter(media::Column::Id.eq(&media_row.id))
+			.col_expr(media::Column::SeriesId, Expr::value(new_series_id))
+			.col_expr(media::Column::IsOneshot, Expr::value(true))
+			.exec(&txn)
+			.await?;
+
+		worker_ctx.report_progress(JobProgress::subtask_position(
+			(idx + 1) as i32,
+			total as i32,
+		));
+	}
+
+	series::Entity::delete_many()
+		.filter(series::Column::Id.eq(old_series_id))
+		.exec(&txn)
+		.await?;
+
+	txn.commit().await?;
+
+	output.created_series = total as u64;
+
+	tracing::debug!(
+		created_series = output.created_series,
+		old_series_id,
+		"Finished converting directory series to oneshots"
+	);
+
+	Ok(output)
+}
+
+/// Output of a series-to-oneshot conversion
+#[derive(Default)]
+pub(crate) struct SeriesConversionOutput {
+	pub updated_media: u64,
+	pub deleted_series: u64,
+	pub logs: Vec<JobExecuteLog>,
+}
+
+/// Converts a oneshot series into regular series and media items. The old oneshot series
+/// will be deleted after the conversion.
+pub(crate) async fn convert_previous_oneshot_entries_to_series_media(
+	new_series_id: &str,
+	entries: Vec<PreviousOneshotEntry>,
+	conn: &DatabaseConnection,
+) -> Result<SeriesConversionOutput, JobError> {
+	let mut output = SeriesConversionOutput::default();
+
+	if entries.is_empty() {
+		return Ok(output);
+	}
+
+	tracing::debug!(
+		count = entries.len(),
+		new_series_id,
+		"Converting oneshots to normal series media"
+	);
+
+	let txn = conn.begin().await?;
+
+	for PreviousOneshotEntry {
+		book_path,
+		old_series_id,
+	} in &entries
+	{
+		let book_path_str = book_path.to_string_lossy().to_string();
+
+		match media::Entity::update_many()
+			.filter(media::Column::Path.eq(&book_path_str))
+			.col_expr(
+				media::Column::SeriesId,
+				Expr::value(new_series_id.to_string()),
+			)
+			.col_expr(media::Column::IsOneshot, Expr::value(false))
+			.exec(&txn)
+			.await
+		{
+			Ok(result) => {
+				output.updated_media += result.rows_affected;
+			},
+			Err(error) => {
+				tracing::error!(
+					?error,
+					?book_path_str,
+					"Failed to update media during oneshot-to-series conversion"
+				);
+				output.logs.push(
+					JobExecuteLog::error(format!(
+						"Failed to reassign media to series: {}",
+						error
+					))
+					.with_ctx(format!("Path: {book_path_str}")),
+				);
+				continue;
+			},
+		}
+
+		if let Err(error) = series::Entity::delete_many()
+			.filter(series::Column::Id.eq(old_series_id))
+			.exec(&txn)
+			.await
+		{
+			tracing::error!(
+				?error,
+				old_series_id,
+				"Failed to delete oneshot series during conversion"
+			);
+			output.logs.push(
+				JobExecuteLog::error(format!(
+					"Failed to delete oneshot series entry: {}",
+					error
+				))
+				.with_ctx(format!("Series ID: {old_series_id}")),
+			);
+		}
+		output.deleted_series += 1;
+	}
+
+	txn.commit().await?;
+
+	tracing::debug!(
+		updated_media = output.updated_media,
+		deleted_series = output.deleted_series,
+		"Finished converting oneshots to series media"
+	);
+
+	Ok(output)
 }

--- a/core/src/filesystem/scanner/walk.rs
+++ b/core/src/filesystem/scanner/walk.rs
@@ -151,32 +151,24 @@ pub async fn walk_library(
 		.await
 		.map_err(|e| CoreError::InternalError(format!("Failed to walk library! {e}")))?;
 
-	let full_oneshots_directory = oneshots_directory
-		.as_deref()
-		.filter(|dir| !dir.is_empty())
-		.map(|dir| PathBuf::from(path).join(dir).to_string_lossy().to_string());
+	let oneshots_dir_name = oneshots_directory.as_deref().filter(|dir| !dir.is_empty());
 
 	// note the ordering here, as it is important. oneshots are identified first so that
 	// we avoid entering the standard walk flows for them
 
 	let (oneshot_entries, regular_entries): (Vec<DirEntry>, Vec<DirEntry>) =
 		valid_entries.into_iter().partition(|entry| {
-			full_oneshots_directory
-				.as_deref()
-				.map(|dir| {
-					entry
-						.path()
-						.to_string_lossy()
-						.to_lowercase()
-						// TODO(oneshots): is contains okay? too tired to think through
-						// edge cases but need to revisit before merge
-						.contains(&dir.to_lowercase())
-				})
-				.unwrap_or(false)
+			let Some(oneshots_dir_name) = oneshots_dir_name else {
+				return false;
+			};
+			let entry_name = entry.path().file_name().map(|name| name.to_string_lossy());
+			entry_name.is_some_and(|name| name.eq_ignore_ascii_case(oneshots_dir_name))
+			// ^ we match the name and not a full path because the oneshots_directory just refers
+			// to the name at any level in the tree. e.g. so `<lib>/_oneshots` and `<lib>/Series A/_oneshots`
+			// would both valid oneshot directories
 		});
 	let oneshot_dirs_to_visit: Vec<PathBuf> =
 		oneshot_entries.into_iter().map(|e| e.into_path()).collect();
-	// TODO(oneshots): filter out based on mtime
 
 	let ignored_directories = ignored_entries.len() as u64;
 	let seen_directories = regular_entries.len() as u64 + ignored_directories;

--- a/core/src/filesystem/scanner/walk.rs
+++ b/core/src/filesystem/scanner/walk.rs
@@ -1,5 +1,5 @@
 use std::{
-	collections::HashMap,
+	collections::{HashMap, HashSet},
 	path::{Path, PathBuf},
 	sync::Arc,
 	time::UNIX_EPOCH,
@@ -20,8 +20,9 @@ use crate::{
 		scanner::{
 			options::BookVisitOperation,
 			utils::{
+				collect_pending_oneshot_conversions, collect_previous_oneshot_entries,
 				file_updated_since_scan, mtime_newer_than_datetime,
-				safely_get_current_mtime,
+				safely_get_current_mtime, PendingOneshotConversion, PreviousOneshotEntry,
 			},
 		},
 		PathUtils,
@@ -311,6 +312,9 @@ pub struct WalkedSeries {
 	/// The *changed* mtimes observed for every directory during the walk. If a value was observed but
 	/// unchanged, it will not be included in this map
 	pub observed_dir_mtimes: HashMap<String, u64>,
+	/// A list of entries which were oneshots but after a config change are no longer considered
+	/// oneshots (i.e., the oneshots_directory changed)
+	pub previous_oneshot_entries: Vec<PreviousOneshotEntry>,
 }
 
 impl WalkedSeries {
@@ -322,6 +326,8 @@ impl WalkedSeries {
 	}
 }
 
+/// Walks a series directory and returns the media that need to be created, visited, or marked as missing.
+/// This walker should **never** process a oneshot series, as those are handled by a separate walker.
 pub async fn walk_series(
 	path: &Path,
 	WalkerCtx {
@@ -475,17 +481,36 @@ pub async fn walk_series(
 		.map(|m| (m.path.clone(), m.clone()))
 		.collect::<HashMap<String, _>>();
 
-	let (media_to_create, remaining_entries): (Vec<PathBuf>, Vec<DirEntry>) =
-		valid_entries.into_iter().partition_map(|entry: DirEntry| {
-			let entry_path = entry.path();
-			let entry_path_str = entry_path.to_string_lossy().to_string();
+	let previous_oneshot_entries = collect_previous_oneshot_entries(
+		valid_entries
+			.iter()
+			.map(|e| e.path().to_string_lossy().to_string())
+			.collect::<Vec<_>>(),
+		db.as_ref(),
+	)
+	.await?;
 
-			if existing_media_map.contains_key(entry_path_str.as_str()) {
-				Either::Right(entry)
-			} else {
-				Either::Left(entry_path.to_path_buf())
-			}
-		});
+	let previous_oneshot_paths = previous_oneshot_entries
+		.iter()
+		.map(|d| d.book_path.to_string_lossy().to_string())
+		.collect::<HashSet<String>>();
+
+	let (media_to_create, remaining_entries): (Vec<PathBuf>, Vec<DirEntry>) =
+		valid_entries
+			.into_iter()
+			.filter(|entry| {
+				!previous_oneshot_paths.contains(entry.path().to_string_lossy().as_ref())
+			})
+			.partition_map(|entry: DirEntry| {
+				let entry_path = entry.path();
+				let entry_path_str = entry_path.to_string_lossy().to_string();
+
+				if existing_media_map.contains_key(entry_path_str.as_str()) {
+					Either::Right(entry)
+				} else {
+					Either::Left(entry_path.to_path_buf())
+				}
+			});
 
 	let book_visit_operations = remaining_entries
 		.into_iter()
@@ -565,6 +590,7 @@ pub async fn walk_series(
 		missing_media,
 		series_is_missing: false,
 		observed_dir_mtimes,
+		previous_oneshot_entries,
 	})
 }
 
@@ -588,9 +614,11 @@ pub struct WalkedOneshots {
 	pub to_create: Vec<PathBuf>,
 	/// The operations to perform on books that need to be visited
 	pub book_operations: Vec<OneshotVisitOperation>,
+	/// Existing normal series which need to be converted to a oneshot. This should only happen
+	/// when the oneshots configuration is added or changed
+	pub pending_oneshot_conversions: Vec<PendingOneshotConversion>,
 }
 
-// dir_mtimes, // TODO: check *before* walking?
 pub async fn walk_oneshots(
 	path: &Path,
 	WalkerCtx {
@@ -631,16 +659,46 @@ pub async fn walk_oneshots(
 	// ^ originally i went the tokio::fs::read_dir route but there is not iterator impl
 	// so that was a hard pass
 
+	let oneshots_dir_str = path.to_string_lossy().to_string();
+
+	let pending_oneshot_conversion_ids = series::Entity::find()
+		.select_only()
+		.column(series::Column::Id)
+		.filter(
+			series::Column::Path
+				.starts_with(&oneshots_dir_str)
+				.and(series::Column::IsOneshot.eq(false)),
+		)
+		.into_tuple::<String>()
+		.all(db.as_ref())
+		.await?;
+	// ^ load the series which exist under the oneshots directory but were not created as oneshots,
+	// we will pass them along to the handler to update them accordingly
+
 	let existing_oneshots = series::Entity::find()
 		.select_only()
-		.columns(SeriesIdentSelect::columns())
-		.filter(series::Column::Path.starts_with(path.to_string_lossy().as_ref()))
+		.columns(vec![series::Column::Id, series::Column::Path])
+		.filter(
+			series::Column::Path
+				.starts_with(&oneshots_dir_str)
+				.and(series::Column::IsOneshot.eq(true)),
+		)
 		.into_model::<SeriesIdentSelect>()
 		.all(db.as_ref())
 		.await?
 		.into_iter()
 		.map(|s| (s.path, s.id))
 		.collect::<HashMap<String, String>>();
+
+	let pending_oneshot_conversions =
+		collect_pending_oneshot_conversions(pending_oneshot_conversion_ids, db.as_ref())
+			.await?;
+
+	let pending_oneshot_media_paths: HashSet<String> = pending_oneshot_conversions
+		.iter()
+		.flat_map(|ls| ls.media.iter().map(|m| m.path.clone()))
+		.collect();
+	// ^ the media at these paths will be flipped to is_oneshot = true and series_id reassigned
 
 	// this is a vec of (series_path,series_id) but will mark both series and
 	// book as missing, since the books are series
@@ -665,8 +723,12 @@ pub async fn walk_oneshots(
 		}
 	}
 
-	let (to_create, remaining_paths): (Vec<PathBuf>, Vec<PathBuf>) =
-		file_paths.into_iter().partition_map(|file_path: PathBuf| {
+	let (to_create, remaining_paths): (Vec<PathBuf>, Vec<PathBuf>) = file_paths
+		.into_iter()
+		// we filter these out because their media records already exist and will just have
+		// their series reassigned via convert_to_oneshot_series
+		.filter(|fp| !pending_oneshot_media_paths.contains(fp.to_string_lossy().as_ref()))
+		.partition_map(|file_path: PathBuf| {
 			let file_path_str = file_path.to_string_lossy().to_string();
 			if existing_oneshots.contains_key(&file_path_str) {
 				Either::Right(file_path)
@@ -741,5 +803,6 @@ pub async fn walk_oneshots(
 		ignored_files: ignored_files.len() as u64,
 		to_create,
 		book_operations,
+		pending_oneshot_conversions,
 	})
 }

--- a/crates/models/src/entity/media.rs
+++ b/crates/models/src/entity/media.rs
@@ -267,6 +267,13 @@ impl From<Model> for MediaIdentSelect {
 }
 
 #[derive(Debug, FromQueryResult)]
+pub struct MediaIdentWithSeriesId {
+	pub id: String,
+	pub path: String,
+	pub series_id: String,
+}
+
+#[derive(Debug, FromQueryResult)]
 pub struct MediaThumbSelect {
 	pub id: String,
 	pub path: String,

--- a/docs/content/docs/guides/fundamentals/oneshots.mdx
+++ b/docs/content/docs/guides/fundamentals/oneshots.mdx
@@ -20,9 +20,9 @@ When creating a library, or when editing an existing one, enablement of one-shot
 This is entirely up to you, Stump supports arbitrary names for flexibility. A few things to keep in mind when choosing a directory name or structure:
 
 - It does not need to be named `_oneshots`, that is just a fairly-common convention
-- It **does** need to be a subdirectory of the library root, not a sibling or parent
-- You must only supply the relative path of the one-shots directory, not the full path
-- Nested books will not be ingested during a scan, so ensure you maintain a flat structure
+- It should be a directory name, not a path to a directory
+- At any level of a library, if a directory exists with the configured name then it will be treated as a oneshots directory
+- Nested books will not be ingested during a scan unless their direct parent is a oneshots directory
 
 ## Example Library Structure
 
@@ -45,14 +45,34 @@ Let's take the following structure of a hypothetical `Indie` library as an examp
             <Folder name="Nested Folder" defaultOpen>
               <File name="This book will be ignored.cbz" />
             </Folder>
+
+            <Folder name="_oneshots" defaultOpen>
+              <File name="This book will not be ignored.cbz" />
+            </Folder>
         </Folder>
     </Folder>
 
 </Files>
 
-In this example, the one-shots directory is named `_oneshots` and is a direct subdirectory of the library root. Only 3 books are present at the top level of the `_oneshots` directory, and they will be recognized as one-shots. The nested folder will be ignored, and any books within it, at any level, will not be recognized as one-shots. The books in the `The Last Day of Rain (Claudia Matosa)` series will also not be recognized as one-shots, since they are not in the `_oneshots` directory, but will be treated as a normal series.
+In this example, the one-shots directory is named `_oneshots` and is a direct subdirectory of the library root. There is also a nested `_oneshots` directory, which will be accounted for.
 
-When configuring my library, I would set the path to `/path/to/my/Indie` as the library root, and `_oneshots` as the one-shots directory. Stump will join those paths together internally during the scanning process as needed to index the one-shots (i.e., `/path/to/my/Indie/_oneshots`).
+Stump will recognize the three books in the top-level `_oneshots` directory as one-shots, will ignore the `Nested Folder` and any books within it, and will also recognize the book in the nested `_oneshots` directory as a one-shot. The books in the `The Last Day of Rain (Claudia Matosa)` series will also not be recognized as one-shots, since they are not in the `_oneshots` directory, but will be treated as a normal series. To visualize this for how Stump will treat the library, it would look something like:
+
+```shell
+/path/to/my/Indie
+├── The Last Day of Rain (Claudia Matosa)
+│   ├── Chapter 1.cbz
+│   ├── Chapter 2.cbz
+│   ├── Chapter 3.cbz
+│   └── Chapter 4.cbz
+└── _oneshots
+    ├── Cry Wolf Girl (Ariel Slamet Ries).pdf
+    ├── Skin Deep (Flo Woolley).pdf
+    ├── The Chromatic Fantasy (H.A.).pdf
+    └── This book will not be ignored.cbz
+```
+
+When configuring this library, I would set the path to `/path/to/my/Indie` as the library root, and `_oneshots` as the one-shots directory. Stump will check any subdirectory of the library root for a directory named `_oneshots`, and will combine all books in those directories into one-shot series.
 
 ## Notable One-Shot Behavior
 
@@ -70,3 +90,19 @@ If you change the one-shots directory for a library that already has one-shots, 
 
 - Stump assumes that by the time you change the directory, the books in the old one-shots directory have been moved to the new one-shots directory. If they have not, a scan of the library will likely result in a non-one-shot series being created for the books in the old one-shots directory
 - Similarly, if you remove the one-shots directory entirely, effectively disabling one-shot handling for that library, any books that were previously recognized as one-shots will be grouped into a new non-one-shot series
+
+### Enabling One-Shots on an Existing Library
+
+<Callout type="warn" title="Best-Effort Migration">
+	If you add or change the oneshots directory configuration on a library that was previously scanned
+	without it, Stump attempts to migrate them as a **best-effort**. It is not guaranteed to work, and
+	may result in duplicate entries.
+</Callout>
+
+If you enable oneshots on an existing library that has books/series which would be recognized as one-shots, Stump will attempt to migrate them. The migration process is as follows:
+
+1. The scanner will recognize existing series and books which match the updated oneshots configuration and track them for migration
+2. Each book in the list of aforementioned series will be updated to be an individual oneshot series
+3. The now-migrated non-oneshot series will be deleted
+
+If you disable oneshots on a library that previously had them enabled, the migration process is exactly inverted. Each one-shot series will have its single book moved into a new non-oneshot series, and the one-shot series will be deleted.


### PR DESCRIPTION
## Description

This PR addresses two points of feedback from Discord:

1. The `oneshots_directory` should be indexed at any level of a library, not just root
2. If you change the configured `oneshots_directory` attempt to convert series/media to/from oneshots (depending on the config change).

I haven't had time to do actual testing, just compilation and basic running. I will aim to really test things hopefully by Sunday

## Stump Contributor License Agreement

By contributing to Stump, you agree that your contributions will be licensed under the following licenses (where applicable):

- The [expo application](https://github.com/stumpapp/stump/blob/main/apps/expo/LICENSE) is licensed under [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.html)
- All other code in the repository is licensed under [MIT License](https://www.tldrlegal.com/license/mit-license)
