### PR TITLE
🐛 Fix importing files shared via content:// URIs

### DIFF
--- a/apps/expo/app/+native-intent.tsx
+++ b/apps/expo/app/+native-intent.tsx
@@ -1,12 +1,11 @@
 import { NativeIntent } from 'expo-router'
 
-import { IMPORTABLE_EXTENSIONS } from '~/lib/localLibrary'
-
 // See https://docs.expo.dev/router/advanced/native-intent/
 export const redirectSystemPath: NativeIntent['redirectSystemPath'] = ({ path }) => {
-	const lowerPath = path.toLowerCase()
-
-	const isFileImport = IMPORTABLE_EXTENSIONS.some((ext) => lowerPath.includes(`.${ext}`))
+	// content:// and file:// URIs (e.g. from "Open with Stump") rarely contain a
+	// literal extension in the path, so we can't rely on extension matching here.
+	// Actual format validation happens in importLocalFile once the file is resolved.
+	const isFileImport = path.startsWith('content://') || path.startsWith('file://')
 
 	if (isFileImport) {
 		return '/'

--- a/apps/expo/lib/import/importFile.ts
+++ b/apps/expo/lib/import/importFile.ts
@@ -2,11 +2,12 @@ import { File } from 'expo-file-system'
 
 import { DownloadRepository } from '~/db/downloads'
 import { booksDirectory, toAbsolutePath } from '~/lib/filesystem'
+import { getContentUriDisplayName } from '~/modules/contentUriInfo'
 import {
 	generateLocalBookId,
-	getFileExtension,
-	isImportableFile,
+	ImportableExtension,
 	LOCAL_LIBRARY_SERVER_ID,
+	resolveImportableExtension,
 } from '~/lib/localLibrary'
 
 export type ImportResult =
@@ -28,30 +29,34 @@ export async function importLocalFile(
 	originalFilename?: string,
 ): Promise<ImportResult> {
 	try {
-		const filename = originalFilename || extractFilename(externalUri)
+		const sourceFile = new File(externalUri)
+		const fallbackFilename =
+			originalFilename ||
+			(await getContentUriDisplayName(externalUri)) ||
+			extractFilename(externalUri)
 
-		if (!isImportableFile(filename)) {
+		let mimeType: string | undefined
+		try {
+			mimeType = sourceFile.type || undefined
+		} catch {
+			mimeType = undefined
+		}
+
+		const extension = resolveImportableExtension(mimeType, fallbackFilename)
+		if (!extension) {
 			return {
 				success: false,
-				error: `Unsupported file type: ${filename}. Supported formats: EPUB, CBZ, PDF`,
+				error: `Unsupported file type: ${fallbackFilename}${mimeType ? ` (${mimeType})` : ''}. Supported formats: EPUB, CBZ, PDF`,
 			}
 		}
 
 		const bookId = generateLocalBookId()
-		const extension = getFileExtension(filename)
-		if (!extension) {
-			return {
-				success: false,
-				error: `Could not determine file extension for file: ${filename}`,
-			}
-		}
 		const storedFilename = `${bookId}.${extension}`
 
 		const booksDir = booksDirectory(LOCAL_LIBRARY_SERVER_ID)
 
 		const destinationUri = `${booksDir}/${storedFilename}`
 
-		const sourceFile = new File(externalUri)
 		const bytes = await sourceFile.bytes()
 		const destFile = new File(destinationUri)
 		destFile.create({ intermediates: true })
@@ -66,7 +71,7 @@ export async function importLocalFile(
 			uri: toAbsolutePath(destinationUri),
 			serverId: LOCAL_LIBRARY_SERVER_ID,
 			size: fileSize,
-			bookName: extractBookName(filename),
+			bookName: extractBookName(fallbackFilename, extension),
 			// TODO: Metadata? idk, kinda would be like reimplementing stump core which sucks
 			metadata: null,
 		})
@@ -96,10 +101,16 @@ function extractFilename(uri: string): string {
 	return lastSegment || `imported_${Date.now()}.epub`
 }
 
-function extractBookName(filename: string): string {
-	return filename
+function extractBookName(filename: string, extension: ImportableExtension): string {
+	const cleaned = filename
 		.replace(/\.(epub|cbz|pdf|zip)$/i, '')
 		.replace(/[-_]/g, ' ')
 		.replace(/\s+/g, ' ')
 		.trim()
+
+	// content:// URIs with no recoverable display name fall back to an opaque
+	// last path segment (often a bare numeric ID), which makes a poor book title.
+	const isOpaque = !cleaned || /^\d+$/.test(cleaned)
+
+	return isOpaque ? `Imported ${extension.toUpperCase()}` : cleaned
 }

--- a/apps/expo/lib/localLibrary.ts
+++ b/apps/expo/lib/localLibrary.ts
@@ -26,6 +26,52 @@ export const getFileExtension = (filename: string): string | undefined => {
 	return filename.split('.').pop()?.toLowerCase()
 }
 
+/**
+ * Maps the MIME types declared in the Android manifest's ACTION_VIEW intent-filters
+ * to the app's supported import extensions. `application/x-cbz` and
+ * `application/vnd.comicbook+zip` both mean `.cbz`.
+ */
+const MIME_TYPE_TO_EXTENSION: Record<string, ImportableExtension> = {
+	'application/epub+zip': 'epub',
+	'application/pdf': 'pdf',
+	'application/x-cbz': 'cbz',
+	'application/vnd.comicbook+zip': 'cbz',
+}
+
+/**
+ * Resolves an importable extension from a MIME type such as the one returned by
+ * expo-file-system's `File.type` (backed by Android's `ContentResolver#getType`,
+ * which works for `content://` URIs, unlike filename-based extension guessing).
+ * Returns undefined for missing, generic, or unmapped types (e.g.
+ * `application/octet-stream`, `application/zip`) rather than guessing.
+ */
+export const getExtensionFromMimeType = (
+	mimeType: string | null | undefined,
+): ImportableExtension | undefined => {
+	const normalized = mimeType?.split(';')[0]?.trim().toLowerCase()
+	return normalized ? MIME_TYPE_TO_EXTENSION[normalized] : undefined
+}
+
+/**
+ * Resolves the extension to use for an imported file. MIME type is authoritative
+ * when it maps to a supported format, since it's resolved correctly even for
+ * opaque `content://` URIs; filename-derived extension is only a fallback.
+ */
+export const resolveImportableExtension = (
+	mimeType: string | null | undefined,
+	filename: string,
+): ImportableExtension | undefined => {
+	const fromMimeType = getExtensionFromMimeType(mimeType)
+	if (fromMimeType) {
+		return fromMimeType
+	}
+
+	const ext = getFileExtension(filename)
+	return ext && IMPORTABLE_EXTENSIONS.includes(ext as ImportableExtension)
+		? (ext as ImportableExtension)
+		: undefined
+}
+
 export function buildLocalToRemoteProgressInput(
 	local: typeof readProgress.$inferSelect,
 ): MediaProgressInput {

--- a/apps/expo/modules/contentUriInfo/android/build.gradle
+++ b/apps/expo/modules/contentUriInfo/android/build.gradle
@@ -1,0 +1,39 @@
+apply plugin: 'com.android.library'
+
+group = 'expo.modules.contenturiinfo'
+version = '1.0.0'
+
+def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.absolutePath, "ExpoModulesCorePlugin.gradle")
+apply from: expoModulesCorePlugin
+applyKotlinExpoModulesCorePlugin()
+useCoreDependencies()
+useExpoPublishing()
+
+def useManagedAndroidSdkVersions = false
+if (useManagedAndroidSdkVersions) {
+  useDefaultAndroidSdkVersions()
+} else {
+  buildscript {
+    ext.safeExtGet = { prop, fallback ->
+      rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+    }
+  }
+  project.android {
+    compileSdkVersion safeExtGet("compileSdkVersion", 36)
+    defaultConfig {
+      minSdkVersion safeExtGet("minSdkVersion", 24)
+      targetSdkVersion safeExtGet("targetSdkVersion", 36)
+    }
+  }
+}
+
+android {
+  namespace "expo.modules.contenturiinfo"
+  defaultConfig {
+    versionCode 1
+    versionName "1.0.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
+}

--- a/apps/expo/modules/contentUriInfo/android/src/main/AndroidManifest.xml
+++ b/apps/expo/modules/contentUriInfo/android/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest>
+</manifest>

--- a/apps/expo/modules/contentUriInfo/android/src/main/java/expo/modules/contenturiinfo/ContentUriInfoModule.kt
+++ b/apps/expo/modules/contentUriInfo/android/src/main/java/expo/modules/contenturiinfo/ContentUriInfoModule.kt
@@ -1,0 +1,30 @@
+package expo.modules.contenturiinfo
+
+import android.net.Uri
+import android.provider.OpenableColumns
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+
+class ContentUriInfoModule : Module() {
+    override fun definition() = ModuleDefinition {
+        Name("ContentUriInfo")
+
+        AsyncFunction("getDisplayName") { uriString: String ->
+            val contentResolver = appContext.reactContext?.contentResolver
+            if (contentResolver == null) {
+                null
+            } else {
+                runCatching {
+                    contentResolver.query(Uri.parse(uriString), arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)?.use { cursor ->
+                        val index = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                        if (index >= 0 && cursor.moveToFirst()) {
+                            cursor.getString(index)
+                        } else {
+                            null
+                        }
+                    }
+                }.getOrNull()
+            }
+        }
+    }
+}

--- a/apps/expo/modules/contentUriInfo/expo-module.config.json
+++ b/apps/expo/modules/contentUriInfo/expo-module.config.json
@@ -1,0 +1,6 @@
+{
+	"platforms": ["android"],
+	"android": {
+		"modules": ["expo.modules.contenturiinfo.ContentUriInfoModule"]
+	}
+}

--- a/apps/expo/modules/contentUriInfo/index.ts
+++ b/apps/expo/modules/contentUriInfo/index.ts
@@ -1,0 +1,33 @@
+import { requireNativeModule } from 'expo'
+import { Platform } from 'react-native'
+
+interface NativeContentUriInfoModule {
+	/**
+	 * Resolves the OpenableColumns.DISPLAY_NAME for a content:// URI via
+	 * Android's ContentResolver. Returns null if the URI has no resolvable
+	 * display name or the query fails.
+	 */
+	getDisplayName(uri: string): Promise<string | null>
+}
+
+/**
+ * Resolves the real display name for a `content://` URI via Android's
+ * ContentResolver (OpenableColumns.DISPLAY_NAME). This exists because the
+ * URI's path segments are frequently opaque (e.g. a numeric document ID from
+ * Google Drive, Gmail, or the Downloads provider) and carry no relation to
+ * the file's actual name, so naive path-parsing on the URI can't recover it.
+ *
+ * Returns null on iOS, for non-`content://` URIs, or if resolution fails.
+ */
+export async function getContentUriDisplayName(uri: string): Promise<string | null> {
+	if (Platform.OS !== 'android' || !uri.startsWith('content://')) {
+		return null
+	}
+
+	try {
+		const ContentUriInfoModule = requireNativeModule<NativeContentUriInfoModule>('ContentUriInfo')
+		return await ContentUriInfoModule.getDisplayName(uri)
+	} catch {
+		return null
+	}
+}


### PR DESCRIPTION
Closes #1415 

## Description

This adds an expo module to get the content info for a given android content URI. There were three possible options that I can think of with this being the least abrasive (in my personal opinion).

The alternatives i could think of are:
- add a patch to the expo-file-system to expose the content mimetype
- add [react-native-fs](https://www.npmjs.com/package/react-native-fs) as a dependency just to be able to resolve the content mimetype

Open to other ideas, I'm not very experienced with expo / react native so I was mostly going off the LLM and some brief research.

**This code was generated with the use of an LLM.** I have tested the change on a Pixel 6, android 16 and it is working.

## Ready?

Please read each item and check the boxes:

- [x] I read the [contributing guidelines](https://github.com/stumpapp/stump/blob/main/.github/CONTRIBUTING.md)
- [x] I searched for existing issues or pull requests that may be related to my contribution
- [x] This PR is based into `nightly` and not `main`
- [ ] I added tests and/or documentation for my changes if applicable
- [x] I disclosed any use of LLMs in the creation of this PR (if applicable)

## Stump Contributor License Agreement

By contributing to Stump, you agree that your contributions will be licensed under the following licenses (where applicable):

- The [expo application](https://github.com/stumpapp/stump/blob/main/apps/expo/LICENSE) is licensed under [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.html)
- All other code in the repository is licensed under [MIT License](https://www.tldrlegal.com/license/mit-license)
